### PR TITLE
improved json parsing

### DIFF
--- a/test/src/com/rabbitmq/client/test/ClientTests.java
+++ b/test/src/com/rabbitmq/client/test/ClientTests.java
@@ -38,6 +38,7 @@ public class ClientTests extends TestCase {
         suite.addTestSuite(com.rabbitmq.utility.IntAllocatorTests.class);
         suite.addTestSuite(AMQBuilderApiTest.class);
         suite.addTestSuite(AmqpUriTest.class);
+        suite.addTestSuite(JSONReadWriteTest.class);
         return suite;
     }
 }

--- a/test/src/com/rabbitmq/client/test/JSONReadWriteTest.java
+++ b/test/src/com/rabbitmq/client/test/JSONReadWriteTest.java
@@ -1,0 +1,119 @@
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is VMware, Inc.
+//  Copyright (c) 2007-2013 VMware, Inc.  All rights reserved.
+//
+
+
+package com.rabbitmq.client.test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import com.rabbitmq.tools.json.JSONWriter;
+import com.rabbitmq.tools.json.JSONReader;
+
+import junit.framework.TestCase;
+
+public class JSONReadWriteTest extends TestCase {
+
+    public void testReadWriteSimple() throws Exception {
+
+    	Object myRet;
+    	String myJson;
+
+    	// simple string
+    	myRet = new JSONReader().read(myJson = new JSONWriter().write("blah"));
+    	assertEquals("blah", myRet);
+
+    	// simple int
+    	myRet = new JSONReader().read(myJson = new JSONWriter().write(1));
+    	assertEquals(1, myRet);
+
+    	// string with double quotes
+    	myRet = new JSONReader().read(myJson = new JSONWriter().write("t1-blah\"blah"));
+    	assertEquals("t1-blah\"blah", myRet);
+    	// string with single quotes
+    	myRet = new JSONReader().read(myJson = new JSONWriter().write("t2-blah'blah"));
+    	assertEquals("t2-blah'blah", myRet);
+    	// string with two double quotes
+    	myRet = new JSONReader().read(myJson = new JSONWriter().write("t3-blah\"n\"blah"));
+    	assertEquals("t3-blah\"n\"blah", myRet);
+    	// string with two single quotes
+    	myRet = new JSONReader().read(myJson = new JSONWriter().write("t4-blah'n'blah"));
+    	assertEquals("t4-blah'n'blah", myRet);
+    	// string with a single and a double quote
+    	myRet = new JSONReader().read(myJson = new JSONWriter().write("t4-blah'n\"blah"));
+    	assertEquals("t4-blah'n\"blah", myRet);
+
+    	// UTF-8 character
+    	myRet = new JSONReader().read(myJson = new JSONWriter().write("smile \u9786"));
+    	// System.out.println("JSON: "+myJson);
+    	// System.out.println("JSON: "+myRet);
+    	assertEquals("smile \u9786", myRet);
+
+    	// null byte
+    	myRet = new JSONReader().read(myJson = new JSONWriter().write("smile \u0000"));
+    	// System.out.println("JSON: "+myJson);
+    	// System.out.println("JSON: "+myRet);
+    	assertEquals("smile \u0000", myRet);
+
+    }
+
+    public void testMoreComplicated() throws Exception {
+
+    	String v, s;
+    	Object t;
+
+    	s = "[\"foo\",{\"bar\":[\"baz\",null,1.0,2]}]";
+    	v = new JSONWriter().write(new JSONReader().read(s));
+    	assertEquals(s, v);
+
+    	s = "[\"foo\",{\"bar\":[\"b\\\"az\",null,1.0,2]}]";
+    	t = new JSONReader().read(s);
+    	v = new JSONWriter().write(t);
+    	assertEquals(s, v);
+
+    	s = "[\"foo\",{\"bar\":[\"b'az\",null,1.0,2]}]";
+    	v = new JSONWriter().write(new JSONReader().read(s));
+    	assertEquals(s, v);
+
+    	s = "[\"foo\",{\"bar\":[\"b'a'z\",null,1.0,2]}]";
+    	v = new JSONWriter().write(new JSONReader().read(s));
+    	assertEquals(s, v);
+
+    	s = "[\"foo\",{\"bar\":[\"b\\\"a\\\"z\",null,1.0,2]}]";
+    	v = new JSONWriter().write(new JSONReader().read(s));
+    	assertEquals(s, v);
+
+    }
+
+    public void testBadJSON() throws Exception {
+
+    	try {
+    		new JSONReader().read("[\"foo\",{\"bar\":[\"b\"az\",null,1.0,2]}]");
+    		fail("Should not have parsed");
+    	}
+    	catch (IllegalStateException e) {}
+
+    	try {
+	    	new JSONReader().read("[\"foo\",{\"bar\":[\"b\"a\"z\",null,1.0,2]}]");
+    		fail("Should not have parsed");
+    	}
+    	catch (IllegalStateException e) {}
+
+    }
+
+}


### PR DESCRIPTION
To follow up on this issue:
https://github.com/rabbitmq/rabbitmq-java-client/issues/4

I did some adjustments on the JSON parser as follows:
- it now remembers if a string was quoted with single or double quotes and deals with both scenarios properly
- some cases of bad json were going into an infinite loop, it now throws an exception
- unneeded backslashes (something like \$ for example) now return the literal character instead of throwing it away
- test cases created for the above and just for json functionality in general

Please merge this in so makes it into your next release.
