### PR TITLE
Fixed doc bug in setSocketConfigurator()

### DIFF
--- a/src/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/com/rabbitmq/client/ConnectionFactory.java
@@ -409,7 +409,7 @@ public class ConnectionFactory implements Cloneable {
 
     /**
      * Set the socket configurator. This gets a chance to "configure" a socket
-     * after it has been opened. The default socket configurator disables
+     * before it has been opened. The default socket configurator disables
      * Nagle's algorithm.
      *
      * @param socketConfigurator the configurator to use


### PR DESCRIPTION
Fixed issue #14. FrameHandlerFactory sets the configuration before connecting the socket and not after connecting the socket.
