### PR TITLE
Make Channel and Connection implement AutoCloseable for use in try-with-...

### DIFF
--- a/src/com/rabbitmq/client/Channel.java
+++ b/src/com/rabbitmq/client/Channel.java
@@ -58,7 +58,7 @@ import com.rabbitmq.client.AMQP.Confirm;
  *
  */
 
-public interface Channel extends ShutdownNotifier {
+public interface Channel extends ShutdownNotifier, AutoCloseable {
     /**
      * Retrieve this channel's channel number.
      * @return the channel number

--- a/src/com/rabbitmq/client/Connection.java
+++ b/src/com/rabbitmq/client/Connection.java
@@ -50,7 +50,7 @@ import java.util.Map;
  * Current implementations are thread-safe for code at the client API level,
  * and in fact thread-safe internally except for code within RPC calls.
  */
-public interface Connection extends ShutdownNotifier { // rename to AMQPConnection later, this is a temporary name
+public interface Connection extends ShutdownNotifier, AutoCloseable { // rename to AMQPConnection later, this is a temporary name
     /**
      * Retrieve the host.
      * @return the hostname of the peer we're connected to.


### PR DESCRIPTION
...resources

As mentioned in the description, this change will allow Connection and Channel instances to be compatible with the try-with-resources feature: http://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html

For try-with-resources to work, both interfaces need to extend AutoCloseable.  Since each interface already declares a close() method with the proper signature, the change is trivial.
