### PR TITLE
Use 2 * number of cores for ConsumerWorkService by default

### DIFF
--- a/src/com/rabbitmq/client/impl/ConsumerWorkService.java
+++ b/src/com/rabbitmq/client/impl/ConsumerWorkService.java
@@ -25,7 +25,7 @@ import com.rabbitmq.client.Channel;
 
 final public class ConsumerWorkService {
     private static final int MAX_RUNNABLE_BLOCK_SIZE = 16;
-    private static final int DEFAULT_NUM_THREADS = 5;
+    private static final int DEFAULT_NUM_THREADS = Runtime.getRuntime().availableProcessors() * 2;
     private final ExecutorService executor;
     private final boolean privateExecutor;
     private final WorkPool<Channel, Runnable> workPool;


### PR DESCRIPTION
Machines with 8 cores are fairly common today (e.g. MBP 2013+
has 8 hyperthreaded cores). This value is per connection
factory, so 16 or even 64 isn't excessive.