### PR TITLE
Use custom thread factory on RecoveryAware connection / channel manager

### DIFF
--- a/src/com/rabbitmq/client/impl/Environment.java
+++ b/src/com/rabbitmq/client/impl/Environment.java
@@ -9,9 +9,11 @@ import java.util.concurrent.ThreadFactory;
 class Environment {
     public static boolean isAllowedToModifyThreads() {
         try {
-            SecurityManager sm = new SecurityManager();
-            sm.checkPermission(new RuntimePermission("modifyThread"));
-            sm.checkPermission(new RuntimePermission("modifyThreadGroup"));
+            SecurityManager sm = System.getSecurityManager();
+            if(sm != null) {
+                sm.checkPermission(new RuntimePermission("modifyThread"));
+                sm.checkPermission(new RuntimePermission("modifyThreadGroup"));
+            }
             return true;
         } catch (SecurityException se) {
             return false;

--- a/src/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnection.java
+++ b/src/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnection.java
@@ -17,6 +17,6 @@ public class RecoveryAwareAMQConnection extends AMQConnection {
 
     @Override
     protected RecoveryAwareChannelManager instantiateChannelManager(int channelMax, ThreadFactory threadFactory) {
-        return new RecoveryAwareChannelManager(super._workService, channelMax);
+        return new RecoveryAwareChannelManager(super._workService, channelMax, threadFactory);
     }
 }

--- a/src/com/rabbitmq/client/impl/recovery/RecoveryAwareChannelManager.java
+++ b/src/com/rabbitmq/client/impl/recovery/RecoveryAwareChannelManager.java
@@ -5,12 +5,19 @@ import com.rabbitmq.client.impl.ChannelManager;
 import com.rabbitmq.client.impl.ChannelN;
 import com.rabbitmq.client.impl.ConsumerWorkService;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
 /**
  * @since 3.3.0
  */
 public class RecoveryAwareChannelManager extends ChannelManager {
     public RecoveryAwareChannelManager(ConsumerWorkService workService, int channelMax) {
-        super(workService, channelMax);
+        this(workService, channelMax, Executors.defaultThreadFactory());
+    }
+
+    public RecoveryAwareChannelManager(ConsumerWorkService workService, int channelMax, ThreadFactory threadFactory) {
+        super(workService, channelMax, threadFactory);
     }
 
     @Override


### PR DESCRIPTION
Uplift RecoveryAwareAMQConnection and RecoveryAwareChannelManager to use ConnectionFactory's custom threadFactory. Also, get the current SecurityManager instead of
creating a new one in Environment.isAllowedToModifyThreads()

https://groups.google.com/forum/#!topic/rabbitmq-users/JteMdVaaPho