### PR TITLE
Issue #42: AMQConnection missing "/" for non-default virtual hosts.

### DIFF
--- a/src/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/com/rabbitmq/client/impl/AMQConnection.java
@@ -862,7 +862,8 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     @Override public String toString() {
-        return "amqp://" + this.username + "@" + getHostAddress() + ":" + getPort() + _virtualHost;
+        final String virtualHost = "/".equals(_virtualHost) ? _virtualHost : "/" + _virtualHost;
+        return "amqp://" + this.username + "@" + getHostAddress() + ":" + getPort() + virtualHost;
     }
 
     private String getHostAddress() {


### PR DESCRIPTION
If the virtual host is not the default virtual host, then there needs
to be a separator between the port and the name of the virtual host.

-=david=-