### PR TITLE
Fix deadlock on close() with congested server.

### DIFF
--- a/src/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/com/rabbitmq/client/impl/ChannelN.java
@@ -571,7 +571,9 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
             // we wait for the reply. We ignore the result.
             // (It's NOT always close-ok.)
             notify = true;
-            k.getReply(-1);
+			// Should not wait indefinately, since if the server is congested
+			// the call will lock and never return. This stalls and kills the current thread.
+            k.getReply(10000);
         } catch (TimeoutException ise) {
             // Will never happen since we wait infinitely
         } catch (ShutdownSignalException sse) {


### PR DESCRIPTION
The call BlockingRPCContinuation#getReply used in the close() method of ChannelN does not specify a timeout. If the server is congested, this call to close() can (and does) block indefinitely and eats up the current thread.

From an API point of view, a close() method should really have a timeout associated with it, and if the server doesn't respond with a cleanly closed connection, the channel should just be discarded.