### PR TITLE
Cannot Close AutorecoveringConnection While Disconnected From Network

### DIFF
--- a/src/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -67,7 +67,14 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     private final Map<String, RecordedConsumer> consumers = new ConcurrentHashMap<String, RecordedConsumer>();
     private final List<ConsumerRecoveryListener> consumerRecoveryListeners = new ArrayList<ConsumerRecoveryListener>();
     private final List<QueueRecoveryListener> queueRecoveryListeners = new ArrayList<QueueRecoveryListener>();
-
+	
+	//Used to block connection recovery attempts after close() is invoked.
+	private volatile boolean manuallyClosed = false;
+	
+	//This lock guards the manuallyClosed flag and the delegate connection.  Guarding these two ensures that a new connection can never
+	//be created after application code has initiated shutdown.  
+	private Object recoveryLock = new Object();
+	
     public AutorecoveringConnection(ConnectionParams params, FrameHandlerFactory f, Address[] addrs) {
         this.cf = new RecoveryAwareAMQConnectionFactory(params, f, addrs);
         this.params = params;
@@ -181,6 +188,10 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see com.rabbitmq.client.Connection#close()
      */
     public void close() throws IOException {
+		synchronized(recoveryLock)
+		{
+			this.manuallyClosed = true;
+		}
         delegate.close();
     }
 
@@ -188,6 +199,10 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see Connection#close(int)
      */
     public void close(int timeout) throws IOException {
+		synchronized(recoveryLock)
+		{
+			this.manuallyClosed = true;
+		}
         delegate.close(timeout);
     }
 
@@ -195,6 +210,10 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see Connection#close(int, String, int)
      */
     public void close(int closeCode, String closeMessage, int timeout) throws IOException {
+		synchronized(recoveryLock)
+		{
+			this.manuallyClosed = true;
+		}
         delegate.close(closeCode, closeMessage, timeout);
     }
 
@@ -202,6 +221,10 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see com.rabbitmq.client.Connection#abort()
      */
     public void abort() {
+		synchronized(recoveryLock)
+		{
+			this.manuallyClosed = true;
+		}
         delegate.abort();
     }
 
@@ -209,6 +232,10 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see Connection#abort(int, String, int)
      */
     public void abort(int closeCode, String closeMessage, int timeout) {
+		synchronized(recoveryLock)
+		{
+			this.manuallyClosed = true;
+		}
         delegate.abort(closeCode, closeMessage, timeout);
     }
 
@@ -216,6 +243,10 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see Connection#abort(int, String)
      */
     public void abort(int closeCode, String closeMessage) {
+		synchronized(recoveryLock)
+		{
+			this.manuallyClosed = true;
+		}
         delegate.abort(closeCode, closeMessage);
     }
 
@@ -223,6 +254,10 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see Connection#abort(int)
      */
     public void abort(int timeout) {
+		synchronized(recoveryLock)
+		{
+			this.manuallyClosed = true;
+		}
         delegate.abort(timeout);
     }
 
@@ -261,7 +296,11 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see com.rabbitmq.client.Connection#close(int, String)
      */
     public void close(int closeCode, String closeMessage) throws IOException {
-        delegate.close(closeCode, closeMessage);
+		synchronized(recoveryLock)
+		{
+			this.manuallyClosed = true;
+		}
+		delegate.close(closeCode, closeMessage);
     }
 
     /**
@@ -402,18 +441,21 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
         this.consumerRecoveryListeners.remove(listener);
     }
 
-    synchronized private void beginAutomaticRecovery() throws InterruptedException, IOException, TopologyRecoveryException {
+    synchronized private void beginAutomaticRecovery() throws InterruptedException, IOException, TopologyRecoveryException 
+	{
         Thread.sleep(this.params.getNetworkRecoveryInterval());
-        this.recoverConnection();
-        this.recoverShutdownListeners();
-        this.recoverBlockedListeners();
-        this.recoverChannels();
-        if(this.params.isTopologyRecoveryEnabled()) {
-            this.recoverEntities();
-            this.recoverConsumers();
-        }
+        if (!this.recoverConnection())
+			return; //Application initiated a shutdown during automatic recovery, don't attempt further recovery
+		
+		this.recoverShutdownListeners();
+		this.recoverBlockedListeners();
+		this.recoverChannels();
+		if(this.params.isTopologyRecoveryEnabled()) {
+			this.recoverEntities();
+			this.recoverConsumers();
+		}
 
-        this.notifyRecoveryListeners();
+		this.notifyRecoveryListeners();		
     }
 
     private void recoverShutdownListeners() {
@@ -428,18 +470,43 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
         }
     }
 
-    private void recoverConnection() throws IOException, InterruptedException {
-        boolean recovering = true;
-        while (recovering) {
+	//Returns true if the connection was recovered, 
+	//false if application initiated shutdown while attempting recovery.  
+    private boolean recoverConnection() throws IOException, InterruptedException {
+        while (!manuallyClosed) //manuallyClosed marked volatile -ensures thread cannot cache value of manuallyClosed.
+		{
             try {
-                this.delegate = this.cf.newConnection();
-                recovering = false;
+				RecoveryAwareAMQConnection newConn = this.cf.newConnection();
+				synchronized(recoveryLock)
+				{
+					if (!manuallyClosed)
+					{
+						//This is the standard case.
+						this.delegate = newConn;					
+						return true;
+					}
+				}
+
+				//This is the once in a blue moon case.  
+				//Application code just called close as the connection
+				//was being re-established.  So we attempt to close the newly created connection.
+				try
+				{
+					newConn.close(); //Is there a standard error code/shutdown message to use here? 
+				}
+				catch (Exception e)
+				{
+					//Ugh, we just leaked the new connection object, hopefully some kind of heartbeat/expiration timeout will take care of it.
+				}
+				return false;
             } catch (Exception e) {
                 // TODO: exponential back-off
                 Thread.sleep(this.params.getNetworkRecoveryInterval());
                 this.getExceptionHandler().handleConnectionRecoveryException(this, e);
             }
         }
+		
+		return false;
     }
 
     private void recoverChannels() {


### PR DESCRIPTION
I took a look at your changes to the dotnet client for handling close/abort while disconnect from network and added something similar to the java client.  

Added manuallyClosed flag to AutorecoveringConnection which prevents recovery of connections after application code has closed/aborted the connection.

I've run it through tests in my application, Android no longer leaks threads named AMQP Connection <ip>:<port> when closing while WiFi is disabled.  