### PR TITLE
Add travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: false
+language: erlang
+addons:
+  apt:
+    packages:
+      - xsltproc
+services:
+  - rabbitmq
+otp_release:
+  - "R16B03-1"
+install:
+  - if [ ! -d "$HOME/rabbitmq-public-umbrella/.git" ]; then git clone https://github.com/rabbitmq/rabbitmq-public-umbrella.git $HOME/rabbitmq-public-umbrella; fi
+  - cd $HOME/rabbitmq-public-umbrella
+  - make co
+  - make up
+before_script:
+  - IFS="/" read -a PARTS <<< "$TRAVIS_REPO_SLUG"
+  - export TEST_DIR=$HOME/rabbitmq-public-umbrella/${PARTS[1]}
+  - rm -rf ${TEST_DIR}
+  - cp -r ${TRAVIS_BUILD_DIR} ${TEST_DIR}
+  - cd ${TEST_DIR}
+script: ant test-client
+before_cache:
+  - rm -rf ${TEST_DIR}
+  - cd $HOME
+cache:
+  apt: true
+  directories:
+    - $HOME/rabbitmq-public-umbrella


### PR DESCRIPTION
This is a minimal configuration that only adds ``test-client``.

I'd like to enhance it to support more but with the current structure, it'll prove a bit difficult. I'm thinking given Travis's support for docker, it makes sense to make a RabbitMQ image specifically for testing that has the SSL config setup since Travis's RabbitMQ service doesn't appear to support SSL.

Additionally, the requirement of accessing RabbitMQ via rabbitmqctl makes me think having a testing docker image makes sense as well, as we would have more control over the service/process than the travis service level abstraction.