### PR TITLE
Allow to set an optional Executor to be used to send heartbeats

### DIFF
--- a/src/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/com/rabbitmq/client/impl/AMQConnection.java
@@ -25,11 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AuthenticationFailureException;
@@ -64,6 +60,7 @@ final class Copyright {
  */
 public class AMQConnection extends ShutdownNotifierComponent implements Connection, NetworkConnection {
     private final ExecutorService consumerWorkServiceExecutor;
+    private final ScheduledExecutorService heartbeatExecutor;
     private final ExecutorService shutdownExecutor;
     private Thread mainLoopThread;
     private ThreadFactory threadFactory = Executors.defaultThreadFactory();
@@ -222,6 +219,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         this.shutdownTimeout = params.getShutdownTimeout();
         this.saslConfig = params.getSaslConfig();
         this.consumerWorkServiceExecutor = params.getConsumerWorkServiceExecutor();
+        this.heartbeatExecutor = params.getHeartbeatExecutor();
         this.shutdownExecutor = params.getShutdownExecutor();
         this.threadFactory = params.getThreadFactory();
 
@@ -237,7 +235,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     private void initializeHeartbeatSender() {
-        this._heartbeatSender = new HeartbeatSender(_frameHandler, threadFactory);
+        this._heartbeatSender = new HeartbeatSender(_frameHandler, heartbeatExecutor, threadFactory);
     }
 
     /**

--- a/src/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/com/rabbitmq/client/impl/ConnectionParams.java
@@ -5,12 +5,14 @@ import com.rabbitmq.client.SaslConfig;
 
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 
 public class ConnectionParams {
     private String username;
     private String password;
     private ExecutorService consumerWorkServiceExecutor;
+    private ScheduledExecutorService heartbeatExecutor;
     private ExecutorService shutdownExecutor;
     private String virtualHost;
     private Map<String, Object> clientProperties;
@@ -154,5 +156,13 @@ public class ConnectionParams {
 
     public void setShutdownExecutor(ExecutorService shutdownExecutor) {
         this.shutdownExecutor = shutdownExecutor;
+    }
+
+    public ScheduledExecutorService getHeartbeatExecutor() {
+        return heartbeatExecutor;
+    }
+
+    public void setHeartbeatExecutor(ScheduledExecutorService heartbeatExecutor) {
+        this.heartbeatExecutor = heartbeatExecutor;
     }
 }


### PR DESCRIPTION
In a consistent fashion with the ability to set an Executor for shutdown and for ```ConsumerWorkService```, 
allow to set an optional ```ScheduledExecutorService``` to be used to send heartbeats.

If the ```ScheduledExecutorService``` is not provided to the ```ConnectionFactory```, one ```ScheduledExecutorService``` per Connection (and one Thread per Connection) will be created at runtime (as it was before).
If the ```ScheduledExecutorService``` is provided to the ```ConnectionFactory```, the provided ```ScheduledExecutorService``` will be used.

This feature can be useful for the following reasons : 
- Because sending a HeartBeat is generally really fast, it may be a waste to have 1 Thread per Connection in the JVM. HeartBeats can support to be a few millseconds/seconds late. Using a shared ```ScheduledExecutorService``` with a very small amount of Threads for all of the Connections allows to use less Threads, with no significant drawbacks.
- Threads will be named by the Executor, and are easier to find in a Thread Dump or a Profiler
