### PR TITLE
Make sure missed heartbeats trigger connection recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.idea/
 /build/
 /cover/
+/debug/
 /dist/
 /ebin/
 /out/


### PR DESCRIPTION
Fixes #57. To be merged after `3.5.5` is tagged.