### PR TITLE
rabbitmq-java-client #120: unsynchronized access to recordedBindings gives undesired results

### DIFF
--- a/src/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -766,7 +766,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
         return result;
     }
 
-    Set<RecordedBinding> removeBindingsWithDestination(String s) {
+    synchronized Set<RecordedBinding> removeBindingsWithDestination(String s) {
         Set<RecordedBinding> result = new HashSet<RecordedBinding>();
         for (Iterator<RecordedBinding> it = this.recordedBindings.iterator(); it.hasNext(); ) {
             RecordedBinding b = it.next();


### PR DESCRIPTION
Fix is to simply make `removeBindingsWithDestination` a synchronized method (like the other methods which access recordedBindings).