### PR TITLE
RpcClient: Make reply-to queue name configurable

### DIFF
--- a/src/main/java/com/rabbitmq/client/RpcClient.java
+++ b/src/main/java/com/rabbitmq/client/RpcClient.java
@@ -48,6 +48,8 @@ public class RpcClient {
     private final String _exchange;
     /** Routing key to use for requests */
     private final String _routingKey;
+    /** Queue where the server should put the reply */
+    private final String _replyTo;
     /** timeout to use on call responses */
     private final int _timeout;
     /** NO_TIMEOUT value must match convention on {@link BlockingCell#uninterruptibleGet(int)} */
@@ -65,17 +67,20 @@ public class RpcClient {
      * Construct a new RpcClient that will communicate on the given channel, sending
      * requests to the given exchange with the given routing key.
      * <p/>
-     * Causes the creation of a temporary private autodelete queue.
+     * Causes the creation of a temporary private autodelete queue. The name of this queue can be specified.
      * @param channel the channel to use for communication
      * @param exchange the exchange to connect to
      * @param routingKey the routing key
+     * @param replyTo the queue where the server should put the reply
      * @param timeout milliseconds before timing out on wait for response
      * @throws IOException if an error is encountered
      */
-    public RpcClient(Channel channel, String exchange, String routingKey, int timeout) throws IOException {
+    public RpcClient(Channel channel, String exchange, String routingKey, String replyTo, int timeout) throws
+            IOException {
         _channel = channel;
         _exchange = exchange;
         _routingKey = routingKey;
+        _replyTo = replyTo;
         if (timeout < NO_TIMEOUT) throw new IllegalArgumentException("Timeout arguument must be NO_TIMEOUT(-1) or non-negative.");
         _timeout = timeout;
         _correlationId = 0;
@@ -87,7 +92,24 @@ public class RpcClient {
      * Construct a new RpcClient that will communicate on the given channel, sending
      * requests to the given exchange with the given routing key.
      * <p/>
-     * Causes the creation of a temporary private autodelete queue.
+     * Causes the creation of a temporary private autodelete queue. The name of the queue can be provided
+     * <p/>
+     * Waits forever for responses (that is, no timeout).
+     * @param channel the channel to use for communication
+     * @param exchange the exchange to connect to
+     * @param routingKey the routing key
+     * @param replyTo the queue where the server should put the reply
+     * @throws IOException if an error is encountered
+     */
+    public RpcClient(Channel channel, String exchange, String routingKey, String replyTo) throws IOException {
+        this(channel, exchange, routingKey, replyTo, NO_TIMEOUT);
+    }
+
+    /**
+     * Construct a new RpcClient that will communicate on the given channel, sending
+     * requests to the given exchange with the given routing key.
+     * <p/>
+     * Causes the creation of a temporary private autodelete queue. This queue will be named "amq.rabbitmq.reply-to".
      * <p/>
      * Waits forever for responses (that is, no timeout).
      * @param channel the channel to use for communication
@@ -96,8 +118,26 @@ public class RpcClient {
      * @throws IOException if an error is encountered
      */
     public RpcClient(Channel channel, String exchange, String routingKey) throws IOException {
-        this(channel, exchange, routingKey, NO_TIMEOUT);
+        this(channel, exchange, routingKey, "amq.rabbitmq.reply-to", NO_TIMEOUT);
     }
+
+
+    /**
+     * Construct a new RpcClient that will communicate on the given channel, sending
+     * requests to the given exchange with the given routing key.
+     * <p/>
+     * Causes the creation of a temporary private autodelete queue. The name of this queue will be
+     * "amq.rabbitmq.reply-to".
+     * @param channel the channel to use for communication
+     * @param exchange the exchange to connect to
+     * @param routingKey the routing key
+     * @param timeout milliseconds before timing out on wait for response
+     * @throws IOException if an error is encountered
+     */
+    public RpcClient(Channel channel, String exchange, String routingKey, int timeout) throws IOException {
+        this(channel, exchange, routingKey, "amq.rabbitmq.reply-to", timeout);
+    }
+
 
     /**
      * Private API - ensures the RpcClient is correctly open.
@@ -152,7 +192,7 @@ public class RpcClient {
                 }
             }
         };
-        _channel.basicConsume("amq.rabbitmq.reply-to", true, consumer);
+        _channel.basicConsume(_replyTo, true, consumer);
         return consumer;
     }
 
@@ -171,7 +211,7 @@ public class RpcClient {
             _correlationId++;
             String replyId = "" + _correlationId;
             props = ((props==null) ? new AMQP.BasicProperties.Builder() : props.builder())
-                    .correlationId(replyId).replyTo("amq.rabbitmq.reply-to").build();
+                    .correlationId(replyId).replyTo(_replyTo).build();
             _continuationMap.put(replyId, k);
         }
         publish(props, message);


### PR DESCRIPTION
Until now the queue name where the RpcClient expects the answers to be put is not configurable. The queue is statically set to `amq.rabbitmq.reply-to`.

This commit changes the two places where this queue name is used (for sending the request and when listening for responses): A member variable is used instead of the constant string. Default constructors are added so this **keeps backwards compatibility**.

The server doesn't need to be adapted: It takes the queue name from the header which the client puts in.