### PR TITLE
Overload ConnectionFactory.newConnection methods to use lists as well…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -87,7 +87,8 @@
 	<filter token="VERSION" value="${impl.version}"/>
       </filterset>
     </copy>
-    <javac destdir="${javac.out}"
+    <javac
+           destdir="${javac.out}"
 	   classpathref="javac.classpath"
 	   source="${standard.javac.source}"
 	   target="${standard.javac.target}"

--- a/src/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -82,6 +82,13 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
         this.channels = new ConcurrentHashMap<Integer, AutorecoveringChannel>();
     }
 
+    public AutorecoveringConnection(ConnectionParams params, FrameHandlerFactory f, List<Address> addr_list) {
+        this.cf = new RecoveryAwareAMQConnectionFactory(params, f, addr_list);
+        this.params = params;
+
+        this.channels = new ConcurrentHashMap<Integer, AutorecoveringChannel>();
+    }
+
     /**
      * Private API.
      * @throws IOException

--- a/src/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnectionFactory.java
+++ b/src/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnectionFactory.java
@@ -13,42 +13,46 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 public class RecoveryAwareAMQConnectionFactory {
-    private final ConnectionParams params;
-    private final FrameHandlerFactory factory;
-    private final Address[] addrs;
+  private final ConnectionParams params;
+  private final FrameHandlerFactory factory;
+  private final List<Address> addrs;
 
-    public RecoveryAwareAMQConnectionFactory(ConnectionParams params, FrameHandlerFactory factory, Address[] addrs) {
-        this.params = params;
-        this.factory = factory;
-        this.addrs = addrs;
+  public RecoveryAwareAMQConnectionFactory(ConnectionParams params, FrameHandlerFactory factory, Address[] addrs) {
+    this.params = params;
+    this.factory = factory;
+    this.addrs = Arrays.asList(addrs);
+  }
+
+  public RecoveryAwareAMQConnectionFactory(ConnectionParams params, FrameHandlerFactory factory, List<Address> addrs){
+    this.params = params;
+    this.factory = factory;
+    this.addrs = addrs;
+  }
+  /**
+   * @return an interface to the connection
+   * @throws java.io.IOException if it encounters a problem
+   */
+  RecoveryAwareAMQConnection newConnection() throws IOException, TimeoutException {
+    IOException lastException = null;
+    List<Address> shuffled = shuffle(addrs);
+
+    for (Address addr : shuffled) {
+      try {
+        FrameHandler frameHandler = factory.create(addr);
+        RecoveryAwareAMQConnection conn = new RecoveryAwareAMQConnection(params, frameHandler);
+        conn.start();
+        return conn;
+      } catch (IOException e) {
+        lastException = e;
+      }
     }
 
-    /**
-     * @return an interface to the connection
-     * @throws java.io.IOException if it encounters a problem
-     */
-    RecoveryAwareAMQConnection newConnection() throws IOException, TimeoutException {
-        IOException lastException = null;
-        Address[] shuffled = shuffle(addrs);
-        for (Address addr : shuffled) {
-            try {
-                FrameHandler frameHandler = factory.create(addr);
-                RecoveryAwareAMQConnection conn = new RecoveryAwareAMQConnection(params, frameHandler);
-                conn.start();
-                return conn;
-            } catch (IOException e) {
-                lastException = e;
-            }
-        }
+    throw (lastException != null) ? lastException : new IOException("failed to connect");
+  }
 
-        throw (lastException != null) ? lastException : new IOException("failed to connect");
-    }
-
-    private Address[] shuffle(Address[] addrs) {
-        List<Address> list = new ArrayList<Address>(Arrays.asList(addrs));
-        Collections.shuffle(list);
-        Address[] result = new Address[addrs.length];
-        list.toArray(result);
-        return result;
-    }
+  private List<Address> shuffle(List<Address> addrs) {
+    List<Address> list = new ArrayList<Address>(addrs);
+    Collections.shuffle(list);
+    return list;
+  }
 }

--- a/test/src/com/rabbitmq/client/test/functional/ConnectionRecovery.java
+++ b/test/src/com/rabbitmq/client/test/functional/ConnectionRecovery.java
@@ -11,6 +11,7 @@ import com.rabbitmq.client.test.BrokerTestCase;
 import com.rabbitmq.tools.Host;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.UUID;
@@ -35,7 +36,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertTrue(connection.isOpen());
     }
 
-    public void testConnectionRecoveryWithMultipleAddresses()
+    public void testConnectionRecoveryWithArrayOfAddresses()
             throws IOException, InterruptedException, TimeoutException {
         final Address[] addresses = {new Address("127.0.0.1"), new Address("127.0.0.1", 5672)};
         AutorecoveringConnection c = newRecoveringConnection(addresses);
@@ -47,6 +48,21 @@ public class ConnectionRecovery extends BrokerTestCase {
             c.abort();
         }
 
+    }
+
+    public void testConnectionRecoveryWithListOfAddresses()
+            throws IOException, InterruptedException, TimeoutException {
+
+        final List<Address> addresses = Arrays.asList(new Address("127.0.0.1"), new Address("127.0.0.1", 5672));
+
+        AutorecoveringConnection c = newRecoveringConnection(addresses);
+        try {
+            assertTrue(c.isOpen());
+            closeAndWaitForRecovery(c);
+            assertTrue(c.isOpen());
+        } finally {
+            c.abort();
+        }
     }
 
     public void testConnectionRecoveryWithDisabledTopologyRecovery()
@@ -705,15 +721,26 @@ public class ConnectionRecovery extends BrokerTestCase {
         return (AutorecoveringConnection) cf.newConnection();
     }
 
-    private AutorecoveringConnection newRecoveringConnection(Address[] addresses)
-            throws IOException, TimeoutException {
-        return newRecoveringConnection(false, addresses);
-    }
-
     private AutorecoveringConnection newRecoveringConnection(boolean disableTopologyRecovery, Address[] addresses)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
         return (AutorecoveringConnection) cf.newConnection(addresses);
+    }
+
+    private AutorecoveringConnection newRecoveringConnection(Address[] addresses)
+            throws IOException, TimeoutException {
+        return newRecoveringConnection(false, Arrays.asList(addresses));
+    }
+
+    private AutorecoveringConnection newRecoveringConnection(boolean disableTopologyRecovery, List<Address> addresses)
+            throws IOException, TimeoutException {
+        ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
+        return (AutorecoveringConnection) cf.newConnection(addresses);
+    }
+
+    private AutorecoveringConnection newRecoveringConnection(List<Address> addresses)
+            throws IOException, TimeoutException {
+        return newRecoveringConnection(false, addresses);
     }
 
     private ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery) {

--- a/test/src/com/rabbitmq/client/test/functional/FrameMax.java
+++ b/test/src/com/rabbitmq/client/test/functional/FrameMax.java
@@ -17,25 +17,15 @@
 
 package com.rabbitmq.client.test.functional;
 
-import com.rabbitmq.client.impl.ConnectionParams;
+import com.rabbitmq.client.*;
+import com.rabbitmq.client.impl.*;
 import com.rabbitmq.client.test.BrokerTestCase;
 
 import java.io.IOException;
 import java.net.Socket;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
-
-import com.rabbitmq.client.Address;
-import com.rabbitmq.client.AMQP;
-import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.GetResponse;
-import com.rabbitmq.client.impl.AMQConnection;
-import com.rabbitmq.client.impl.AMQCommand;
-import com.rabbitmq.client.impl.Frame;
-import com.rabbitmq.client.impl.FrameHandler;
-import com.rabbitmq.client.impl.LongStringHelper;
-import com.rabbitmq.client.impl.SocketFrameHandler;
 
 public class FrameMax extends BrokerTestCase {
     /* This value for FrameMax is larger than the minimum and less
@@ -147,7 +137,7 @@ public class FrameMax extends BrokerTestCase {
 
     private static class GenerousConnectionFactory extends ConnectionFactory {
 
-        @Override public Connection newConnection(ExecutorService executor, Address[] addrs)
+        @Override public Connection newConnection(ExecutorService executor, List<Address> addrs)
                 throws IOException, TimeoutException {
             IOException lastException = null;
             for (Address addr : addrs) {


### PR DESCRIPTION
… as arrays.

* Public newConnection() methods that took arrays as inputs are still present, but wrap around list-based invocations.

Addresses [issue #125](https://github.com/rabbitmq/rabbitmq-java-client/issues/125).