### PR TITLE
Added Closable-inteface to Connection-class for future try-with-resou…

### DIFF
--- a/src/main/java/com/rabbitmq/client/Connection.java
+++ b/src/main/java/com/rabbitmq/client/Connection.java
@@ -16,6 +16,7 @@
 
 package com.rabbitmq.client;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Map;
@@ -50,7 +51,7 @@ import java.util.Map;
  * Current implementations are thread-safe for code at the client API level,
  * and in fact thread-safe internally except for code within RPC calls.
  */
-public interface Connection extends ShutdownNotifier { // rename to AMQPConnection later, this is a temporary name
+public interface Connection extends ShutdownNotifier, Closeable { // rename to AMQPConnection later, this is a temporary name
     /**
      * Retrieve the host.
      * @return the hostname of the peer we're connected to.


### PR DESCRIPTION
Fixes #131.

Added Closable in the Connection-class. This will enable try-with-resources if somebody compiles it with JDK7 or later.

I wanted to add it to Channel-class also but it had a checked exception TimedOutException that broke the contract of Closeable so I avoided it.

