### PR TITLE
Set the nowait flag in queueBindNoWait()

### DIFF
--- a/src/main/java/com/rabbitmq/client/Channel.java
+++ b/src/main/java/com/rabbitmq/client/Channel.java
@@ -616,7 +616,7 @@ public interface Channel extends ShutdownNotifier {
     Queue.BindOk queueBind(String queue, String exchange, String routingKey, Map<String, Object> arguments) throws IOException;
 
     /**
-     * Same as {@link Channel#queueDeclare(String, boolean, boolean, boolean, java.util.Map)} but sets nowait
+     * Same as {@link Channel#queueBind(String, String, String, java.util.Map)} but sets nowait
      * parameter to true and returns void (as there will be no response
      * from the server).
      * @param queue the name of the queue

--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -970,6 +970,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
                                 .exchange(exchange)
                                 .routingKey(routingKey)
                                 .arguments(arguments)
+                                .nowait(true)
                                 .build()));
     }
 


### PR DESCRIPTION
This prevents us from being confused by a reply we didn't expect.

Also fix the associated javadoc comment.