### PR TITLE
Support client specified connection name

### DIFF
--- a/src/com/rabbitmq/client/Connection.java
+++ b/src/com/rabbitmq/client/Connection.java
@@ -94,6 +94,13 @@ public interface Connection extends ShutdownNotifier { // rename to AMQPConnecti
     Map<String, Object> getClientProperties();
 
     /**
+     * Get connection name client property value
+     *
+     * @return string connection name from client properties, or null if there is not such property.
+     */
+    String getConnectionName();
+
+    /**
      * Retrieve the server properties.
      * @return a map of the server properties. This typically includes the product name and version of the server.
      */

--- a/src/com/rabbitmq/client/Connection.java
+++ b/src/com/rabbitmq/client/Connection.java
@@ -19,6 +19,7 @@ package com.rabbitmq.client;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Public API: Interface to an AMQ connection. See the see the <a href="http://www.amqp.org/">spec</a> for details.
@@ -94,11 +95,17 @@ public interface Connection extends ShutdownNotifier { // rename to AMQPConnecti
     Map<String, Object> getClientProperties();
 
     /**
-     * Get connection name client property value
+     * Returns client-provided connection name, if any. Note that the value
+     * returned does not uniquely identify a connection and cannot be used
+     * as a connection identifier in HTTP API requests.
      *
-     * @return string connection name from client properties, or null if there is not such property.
+     *
+     *
+     * @return client-provided connection name, if any
+     * @see ConnectionFactory#newConnection(Address[], String)
+     * @see ConnectionFactory#newConnection(ExecutorService, Address[], String)
      */
-    String getConnectionName();
+    String getClientProvidedName();
 
     /**
      * Retrieve the server properties.

--- a/src/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/com/rabbitmq/client/ConnectionFactory.java
@@ -848,12 +848,43 @@ public class ConnectionFactory implements Cloneable {
      * is enabled, the connection returned by this method will be {@link Recoverable}. Reconnection
      * attempts will always use the address configured on {@link ConnectionFactory}.
      *
+     * @param connectionName arbitrary sring for connection name client property
+     * @return an interface to the connection
+     * @throws IOException if it encounters a problem
+     */
+    public Connection newConnection(String connectionName) throws IOException, TimeoutException {
+        return newConnection(this.sharedExecutor, Collections.singletonList(new Address(getHost(), getPort())), connectionName);
+    }
+
+    /**
+     * Create a new broker connection.
+     *
+     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * is enabled, the connection returned by this method will be {@link Recoverable}. Reconnection
+     * attempts will always use the address configured on {@link ConnectionFactory}.
+     *
      * @param executor thread execution service for consumers on the connection
      * @return an interface to the connection
      * @throws IOException if it encounters a problem
      */
     public Connection newConnection(ExecutorService executor) throws IOException, TimeoutException {
         return newConnection(executor, Collections.singletonList(new Address(getHost(), getPort())));
+    }
+
+    /**
+     * Create a new broker connection.
+     *
+     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * is enabled, the connection returned by this method will be {@link Recoverable}. Reconnection
+     * attempts will always use the address configured on {@link ConnectionFactory}.
+     *
+     * @param executor thread execution service for consumers on the connection
+     * @param connectionName arbitrary sring for connection name client property
+     * @return an interface to the connection
+     * @throws IOException if it encounters a problem
+     */
+    public Connection newConnection(ExecutorService executor, String connectionName) throws IOException, TimeoutException {
+        return newConnection(executor, Collections.singletonList(new Address(getHost(), getPort())), connectionName);
     }
 
     @Override public ConnectionFactory clone(){

--- a/src/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/com/rabbitmq/client/ConnectionFactory.java
@@ -650,7 +650,7 @@ public class ConnectionFactory implements Cloneable {
 
 
     /**
-     * Create a new broker connection, picking the first available address from
+     * Create a new broker connection with a client-provided name, picking the first available address from
      * the list.
      *
      * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
@@ -658,12 +658,16 @@ public class ConnectionFactory implements Cloneable {
      * reconnection attempts will pick a random accessible address from the provided list.
      *
      * @param addrs an array of known broker addresses (hostname/port pairs) to try in order
-     * @param connectionName arbitrary sring for connection name client property
+     * @param clientProvidedName application-specific connection name, will be displayed
+     *                           in the management UI if RabbitMQ server supports it.
+     *                           This value doesn't have to be unique and cannot be used
+     *                           as a connection identifier e.g. in HTTP API requests.
+     *                           This value is supposed to be human-readable.
      * @return an interface to the connection
      * @throws IOException if it encounters a problem
      */
-    public Connection newConnection(Address[] addrs, String connectionName) throws IOException, TimeoutException {
-        return newConnection(this.sharedExecutor, Arrays.asList(addrs), connectionName);
+    public Connection newConnection(Address[] addrs, String clientProvidedName) throws IOException, TimeoutException {
+        return newConnection(this.sharedExecutor, Arrays.asList(addrs), clientProvidedName);
     }
 
     /**
@@ -683,7 +687,7 @@ public class ConnectionFactory implements Cloneable {
     }
 
     /**
-     * Create a new broker connection, picking the first available address from
+     * Create a new broker connection with a client-provided name, picking the first available address from
      * the list.
      *
      * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
@@ -691,12 +695,16 @@ public class ConnectionFactory implements Cloneable {
      * reconnection attempts will pick a random accessible address from the provided list.
      *
      * @param addrs a List of known broker addresses (hostname/port pairs) to try in order
-     * @param connectionName arbitrary sring for connection name client property
+     * @param clientProvidedName application-specific connection name, will be displayed
+     *                           in the management UI if RabbitMQ server supports it.
+     *                           This value doesn't have to be unique and cannot be used
+     *                           as a connection identifier e.g. in HTTP API requests.
+     *                           This value is supposed to be human-readable.
      * @return an interface to the connection
      * @throws IOException if it encounters a problem
      */
-    public Connection newConnection(List<Address> addrs, String connectionName) throws IOException, TimeoutException {
-        return newConnection(this.sharedExecutor, addrs, connectionName);
+    public Connection newConnection(List<Address> addrs, String clientProvidedName) throws IOException, TimeoutException {
+        return newConnection(this.sharedExecutor, addrs, clientProvidedName);
     }
 
     /**
@@ -719,7 +727,7 @@ public class ConnectionFactory implements Cloneable {
 
 
     /**
-     * Create a new broker connection, picking the first available address from
+     * Create a new broker connection with a client-provided name, picking the first available address from
      * the list.
      *
      * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
@@ -728,13 +736,17 @@ public class ConnectionFactory implements Cloneable {
      *
      * @param executor thread execution service for consumers on the connection
      * @param addrs an array of known broker addresses (hostname/port pairs) to try in order
-     * @param connectionName arbitrary sring for connection name client property
+     * @param clientProvidedName application-specific connection name, will be displayed
+     *                           in the management UI if RabbitMQ server supports it.
+     *                           This value doesn't have to be unique and cannot be used
+     *                           as a connection identifier e.g. in HTTP API requests.
+     *                           This value is supposed to be human-readable.
      * @return an interface to the connection
      * @throws java.io.IOException if it encounters a problem
      * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
-    public Connection newConnection(ExecutorService executor, Address[] addrs, String connectionName) throws IOException, TimeoutException {
-        return newConnection(executor, Arrays.asList(addrs), connectionName);
+    public Connection newConnection(ExecutorService executor, Address[] addrs, String clientProvidedName) throws IOException, TimeoutException {
+        return newConnection(executor, Arrays.asList(addrs), clientProvidedName);
     }
 
     /**
@@ -756,7 +768,7 @@ public class ConnectionFactory implements Cloneable {
     }
 
     /**
-     * Create a new broker connection, picking the first available address from
+     * Create a new broker connection with a client-provided name, picking the first available address from
      * the list.
      *
      * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
@@ -765,20 +777,24 @@ public class ConnectionFactory implements Cloneable {
      *
      * @param executor thread execution service for consumers on the connection
      * @param addrs a List of known broker addrs (hostname/port pairs) to try in order
-     * @param connectionName arbitrary sring for connection name client property
+     * @param clientProvidedName application-specific connection name, will be displayed
+     *                           in the management UI if RabbitMQ server supports it.
+     *                           This value doesn't have to be unique and cannot be used
+     *                           as a connection identifier e.g. in HTTP API requests.
+     *                           This value is supposed to be human-readable.
      * @return an interface to the connection
      * @throws java.io.IOException if it encounters a problem
      * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
-    public Connection newConnection(ExecutorService executor, List<Address> addrs, String connectionName)
+    public Connection newConnection(ExecutorService executor, List<Address> addrs, String clientProvidedName)
             throws IOException, TimeoutException {
         // make sure we respect the provided thread factory
         FrameHandlerFactory fhFactory = createFrameHandlerFactory();
         ConnectionParams params = params(executor);
-        // set connection name client property
-        if (connectionName != null) {
+        // set client-provided via a client property
+        if (clientProvidedName != null) {
             Map<String, Object> properties = new HashMap<String, Object>(params.getClientProperties());
-            properties.put("connection_name", connectionName);
+            properties.put("connection_name", clientProvidedName);
             params.setClientProperties(properties);
         }
 

--- a/src/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/com/rabbitmq/client/ConnectionFactory.java
@@ -644,7 +644,11 @@ public class ConnectionFactory implements Cloneable {
      * @throws IOException if it encounters a problem
      */
     public Connection newConnection(Address[] addrs) throws IOException, TimeoutException {
-        return newConnection(this.sharedExecutor, Arrays.asList(addrs));
+        return newConnection(this.sharedExecutor, Arrays.asList(addrs), null);
+    }
+
+    public Connection newConnection(Address[] addrs, String connectionName) throws IOException, TimeoutException {
+        return newConnection(this.sharedExecutor, Arrays.asList(addrs), connectionName);
     }
 
     /**
@@ -660,7 +664,11 @@ public class ConnectionFactory implements Cloneable {
      * @throws IOException if it encounters a problem
      */
     public Connection newConnection(List<Address> addrs) throws IOException, TimeoutException {
-        return newConnection(this.sharedExecutor, addrs);
+        return newConnection(this.sharedExecutor, addrs, null);
+    }
+
+    public Connection newConnection(List<Address> addrs, String connectionName) throws IOException, TimeoutException {
+        return newConnection(this.sharedExecutor, addrs, connectionName);
     }
 
     /**
@@ -678,7 +686,11 @@ public class ConnectionFactory implements Cloneable {
      * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public Connection newConnection(ExecutorService executor, Address[] addrs) throws IOException, TimeoutException {
-        return newConnection(executor, Arrays.asList(addrs));
+        return newConnection(executor, Arrays.asList(addrs), null);
+    }
+
+    public Connection newConnection(ExecutorService executor, Address[] addrs, String connectionName) throws IOException, TimeoutException {
+        return newConnection(executor, Arrays.asList(addrs), connectionName);
     }
 
     /**
@@ -695,11 +707,16 @@ public class ConnectionFactory implements Cloneable {
      * @throws java.io.IOException if it encounters a problem
      * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
-    public Connection newConnection(ExecutorService executor, List<Address> addrs)
+    public Connection newConnection(ExecutorService executor, List<Address> addrs, String connectionName)
             throws IOException, TimeoutException {
         // make sure we respect the provided thread factory
         FrameHandlerFactory fhFactory = createFrameHandlerFactory();
         ConnectionParams params = params(executor);
+        if (connectionName != null) {
+            Map<String, Object> properties = params.getClientProperties().clone();
+            properties.put("connection_name", connectionName);
+            params.setClientProperties(properties);
+        }
 
         if (isAutomaticRecoveryEnabled()) {
             // see com.rabbitmq.client.impl.recovery.RecoveryAwareAMQConnectionFactory#newConnection

--- a/src/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/com/rabbitmq/client/ConnectionFactory.java
@@ -21,6 +21,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.concurrent.*;
 import java.util.List;
 import java.util.Arrays;
@@ -647,6 +648,20 @@ public class ConnectionFactory implements Cloneable {
         return newConnection(this.sharedExecutor, Arrays.asList(addrs), null);
     }
 
+
+    /**
+     * Create a new broker connection, picking the first available address from
+     * the list.
+     *
+     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * is enabled, the connection returned by this method will be {@link Recoverable}. Future
+     * reconnection attempts will pick a random accessible address from the provided list.
+     *
+     * @param addrs an array of known broker addresses (hostname/port pairs) to try in order
+     * @param connectionName arbitrary sring for connection name client property
+     * @return an interface to the connection
+     * @throws IOException if it encounters a problem
+     */
     public Connection newConnection(Address[] addrs, String connectionName) throws IOException, TimeoutException {
         return newConnection(this.sharedExecutor, Arrays.asList(addrs), connectionName);
     }
@@ -667,6 +682,19 @@ public class ConnectionFactory implements Cloneable {
         return newConnection(this.sharedExecutor, addrs, null);
     }
 
+    /**
+     * Create a new broker connection, picking the first available address from
+     * the list.
+     *
+     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * is enabled, the connection returned by this method will be {@link Recoverable}. Future
+     * reconnection attempts will pick a random accessible address from the provided list.
+     *
+     * @param addrs a List of known broker addresses (hostname/port pairs) to try in order
+     * @param connectionName arbitrary sring for connection name client property
+     * @return an interface to the connection
+     * @throws IOException if it encounters a problem
+     */
     public Connection newConnection(List<Address> addrs, String connectionName) throws IOException, TimeoutException {
         return newConnection(this.sharedExecutor, addrs, connectionName);
     }
@@ -689,6 +717,22 @@ public class ConnectionFactory implements Cloneable {
         return newConnection(executor, Arrays.asList(addrs), null);
     }
 
+
+    /**
+     * Create a new broker connection, picking the first available address from
+     * the list.
+     *
+     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * is enabled, the connection returned by this method will be {@link Recoverable}. Future
+     * reconnection attempts will pick a random accessible address from the provided list.
+     *
+     * @param executor thread execution service for consumers on the connection
+     * @param addrs an array of known broker addresses (hostname/port pairs) to try in order
+     * @param connectionName arbitrary sring for connection name client property
+     * @return an interface to the connection
+     * @throws java.io.IOException if it encounters a problem
+     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     */
     public Connection newConnection(ExecutorService executor, Address[] addrs, String connectionName) throws IOException, TimeoutException {
         return newConnection(executor, Arrays.asList(addrs), connectionName);
     }
@@ -707,13 +751,33 @@ public class ConnectionFactory implements Cloneable {
      * @throws java.io.IOException if it encounters a problem
      * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
+    public Connection newConnection(ExecutorService executor, List<Address> addrs) throws IOException, TimeoutException {
+        return newConnection(executor, addrs, null);
+    }
+
+    /**
+     * Create a new broker connection, picking the first available address from
+     * the list.
+     *
+     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * is enabled, the connection returned by this method will be {@link Recoverable}. Future
+     * reconnection attempts will pick a random accessible address from the provided list.
+     *
+     * @param executor thread execution service for consumers on the connection
+     * @param addrs a List of known broker addrs (hostname/port pairs) to try in order
+     * @param connectionName arbitrary sring for connection name client property
+     * @return an interface to the connection
+     * @throws java.io.IOException if it encounters a problem
+     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     */
     public Connection newConnection(ExecutorService executor, List<Address> addrs, String connectionName)
             throws IOException, TimeoutException {
         // make sure we respect the provided thread factory
         FrameHandlerFactory fhFactory = createFrameHandlerFactory();
         ConnectionParams params = params(executor);
+        // set connection name client property
         if (connectionName != null) {
-            Map<String, Object> properties = params.getClientProperties().clone();
+            Map<String, Object> properties = new HashMap<String, Object>(params.getClientProperties());
             properties.put("connection_name", connectionName);
             params.setClientProperties(properties);
         }

--- a/src/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/com/rabbitmq/client/impl/AMQConnection.java
@@ -470,6 +470,15 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         return new HashMap<String, Object>(_clientProperties);
     }
 
+    public String getConnectionName() {
+        Object connectionName = _clientProperties.get("connection_name");
+        if (connectionName == null){
+            return null;
+        } else {
+            return connectionName.toString();
+        }
+    }
+
     /**
      * Protected API - retrieve the current ExceptionHandler
      */

--- a/src/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/com/rabbitmq/client/impl/AMQConnection.java
@@ -470,13 +470,8 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         return new HashMap<String, Object>(_clientProperties);
     }
 
-    public String getConnectionName() {
-        Object connectionName = _clientProperties.get("connection_name");
-        if (connectionName == null){
-            return null;
-        } else {
-            return connectionName.toString();
-        }
+    public String getClientProvidedName() {
+        return (String) _clientProperties.get("connection_name");
     }
 
     /**

--- a/src/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -157,6 +157,13 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     }
 
     /**
+     * @see com.rabbitmq.client.Connection#getConnectionName()
+     */
+    public String getConnectionName() {
+        return delegate.getConnectionName();
+    }
+
+    /**
      * @see com.rabbitmq.client.Connection#getFrameMax()
      */
     public int getFrameMax() {

--- a/src/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -5,6 +5,7 @@ import com.rabbitmq.client.Address;
 import com.rabbitmq.client.BlockedListener;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.MissedHeartbeatException;
 import com.rabbitmq.client.Recoverable;
 import com.rabbitmq.client.RecoveryListener;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -157,10 +159,12 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     }
 
     /**
-     * @see com.rabbitmq.client.Connection#getConnectionName()
+     * @see com.rabbitmq.client.Connection#getClientProvidedName()
+     * @see ConnectionFactory#newConnection(Address[], String)
+     * @see ConnectionFactory#newConnection(ExecutorService, Address[], String)
      */
-    public String getConnectionName() {
-        return delegate.getConnectionName();
+    public String getClientProvidedName() {
+        return delegate.getClientProvidedName();
     }
 
     /**

--- a/test/src/com/rabbitmq/client/test/AMQConnectionTest.java
+++ b/test/src/com/rabbitmq/client/test/AMQConnectionTest.java
@@ -25,6 +25,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.ExecutorService;
+import com.rabbitmq.client.Address;
+import java.util.Arrays;
 
 import com.rabbitmq.client.impl.ConnectionParams;
 import com.rabbitmq.client.TopologyRecoveryException;
@@ -172,6 +175,36 @@ public class AMQConnectionTest extends TestCase {
         List<Throwable> exceptionList = exceptionHandler.getHandledExceptions();
         assertEquals("Only one exception expected", 1, exceptionList.size());
         assertEquals("Wrong type of exception returned.", SocketTimeoutException.class, exceptionList.get(0).getClass());
+    }
+
+    public void testConnectionName() throws IOException, TimeoutException {
+        String connectionName = "custom name";
+        Connection connection = factory.newConnection(connectionName);
+        assertEquals(connectionName, connection.getConnectionName());
+        connection.close();
+
+        List<Address> addresses_list = Arrays.asList(new Address("127.0.0.1"), new Address("127.0.0.1", 5672));
+        connection = factory.newConnection(addresses_list, connectionName);
+        assertEquals(connectionName, connection.getConnectionName());
+        connection.close();
+
+        Address[] addresses_arr = {new Address("127.0.0.1"), new Address("127.0.0.1", 5672)};
+        connection = factory.newConnection(addresses_arr, connectionName);
+        assertEquals(connectionName, connection.getConnectionName());
+        connection.close();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        connection = factory.newConnection(executor, connectionName);
+        assertEquals(connectionName, connection.getConnectionName());
+        connection.close();
+
+        connection = factory.newConnection(executor, addresses_list, connectionName);
+        assertEquals(connectionName, connection.getConnectionName());
+        connection.close();
+
+        connection = factory.newConnection(executor, addresses_arr, connectionName);
+        assertEquals(connectionName, connection.getConnectionName());
+        connection.close();
     }
 
     /** Mock frame handler to facilitate testing. */

--- a/test/src/com/rabbitmq/client/test/AMQConnectionTest.java
+++ b/test/src/com/rabbitmq/client/test/AMQConnectionTest.java
@@ -177,33 +177,33 @@ public class AMQConnectionTest extends TestCase {
         assertEquals("Wrong type of exception returned.", SocketTimeoutException.class, exceptionList.get(0).getClass());
     }
 
-    public void testConnectionName() throws IOException, TimeoutException {
-        String connectionName = "custom name";
-        Connection connection = factory.newConnection(connectionName);
-        assertEquals(connectionName, connection.getConnectionName());
+    public void testClientProvidedConnectionName() throws IOException, TimeoutException {
+        String providedName = "event consumers connection";
+        Connection connection = factory.newConnection(providedName);
+        assertEquals(providedName, connection.getClientProvidedName());
         connection.close();
 
-        List<Address> addresses_list = Arrays.asList(new Address("127.0.0.1"), new Address("127.0.0.1", 5672));
-        connection = factory.newConnection(addresses_list, connectionName);
-        assertEquals(connectionName, connection.getConnectionName());
+        List<Address> addrs1 = Arrays.asList(new Address("127.0.0.1"), new Address("127.0.0.1", 5672));
+        connection = factory.newConnection(addrs1, providedName);
+        assertEquals(providedName, connection.getClientProvidedName());
         connection.close();
 
-        Address[] addresses_arr = {new Address("127.0.0.1"), new Address("127.0.0.1", 5672)};
-        connection = factory.newConnection(addresses_arr, connectionName);
-        assertEquals(connectionName, connection.getConnectionName());
+        Address[] addrs2 = {new Address("127.0.0.1"), new Address("127.0.0.1", 5672)};
+        connection = factory.newConnection(addrs2, providedName);
+        assertEquals(providedName, connection.getClientProvidedName());
         connection.close();
 
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        connection = factory.newConnection(executor, connectionName);
-        assertEquals(connectionName, connection.getConnectionName());
+        ExecutorService xs = Executors.newSingleThreadExecutor();
+        connection = factory.newConnection(xs, providedName);
+        assertEquals(providedName, connection.getClientProvidedName());
         connection.close();
 
-        connection = factory.newConnection(executor, addresses_list, connectionName);
-        assertEquals(connectionName, connection.getConnectionName());
+        connection = factory.newConnection(xs, addrs1, providedName);
+        assertEquals(providedName, connection.getClientProvidedName());
         connection.close();
 
-        connection = factory.newConnection(executor, addresses_arr, connectionName);
-        assertEquals(connectionName, connection.getConnectionName());
+        connection = factory.newConnection(xs, addrs2, providedName);
+        assertEquals(providedName, connection.getClientProvidedName());
         connection.close();
     }
 

--- a/test/src/com/rabbitmq/client/test/functional/ConnectionRecovery.java
+++ b/test/src/com/rabbitmq/client/test/functional/ConnectionRecovery.java
@@ -36,10 +36,10 @@ public class ConnectionRecovery extends BrokerTestCase {
         AutorecoveringConnection c = newRecoveringConnection(connectionName);
         try {
             assertTrue(c.isOpen());
-            assertEquals(connectionName, c.getConnectionName());
+            assertEquals(connectionName, c.getClientProvidedName());
             closeAndWaitForRecovery(c);
             assertTrue(c.isOpen());
-            assertEquals(connectionName, c.getConnectionName());
+            assertEquals(connectionName, c.getClientProvidedName());
         } finally {
             c.abort();
         }

--- a/test/src/com/rabbitmq/client/test/functional/ConnectionRecovery.java
+++ b/test/src/com/rabbitmq/client/test/functional/ConnectionRecovery.java
@@ -30,6 +30,21 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertTrue(connection.isOpen());
     }
 
+    public void testNamedConnectionRecovery()
+            throws IOException, InterruptedException, TimeoutException  {
+        String connectionName = "custom name";
+        AutorecoveringConnection c = newRecoveringConnection(connectionName);
+        try {
+            assertTrue(c.isOpen());
+            assertEquals(connectionName, c.getConnectionName());
+            closeAndWaitForRecovery(c);
+            assertTrue(c.isOpen());
+            assertEquals(connectionName, c.getConnectionName());
+        } finally {
+            c.abort();
+        }
+    }
+
     public void testConnectionRecoveryWithServerRestart() throws IOException, InterruptedException {
         assertTrue(connection.isOpen());
         restartPrimaryAndWaitForRecovery();
@@ -737,6 +752,17 @@ public class ConnectionRecovery extends BrokerTestCase {
     private AutorecoveringConnection newRecoveringConnection(List<Address> addresses)
             throws IOException, TimeoutException {
         return newRecoveringConnection(false, addresses);
+    }
+
+    private AutorecoveringConnection newRecoveringConnection(boolean disableTopologyRecovery, String connectionName)
+            throws IOException, TimeoutException {
+        ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
+        return (AutorecoveringConnection) cf.newConnection(connectionName);
+    }
+
+    private AutorecoveringConnection newRecoveringConnection(String connectionName)
+            throws IOException, TimeoutException {
+        return newRecoveringConnection(false, connectionName);
     }
 
     private ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery) {


### PR DESCRIPTION
Related to https://github.com/rabbitmq/rabbitmq-server/issues/104 and #99 
Overloaded `newConnection` to be able to specify connection name.
Added `getConnectionName` to `AMQConnection` to retrieve client property value or null.