### PR TITLE
Idea: recovery started listener gets called when recovery begins

### DIFF
--- a/src/main/java/com/rabbitmq/client/RecoveryListener.java
+++ b/src/main/java/com/rabbitmq/client/RecoveryListener.java
@@ -8,4 +8,5 @@ package com.rabbitmq.client;
  */
 public interface RecoveryListener {
     public void handleRecovery(Recoverable recoverable);
+    public void handleRecoveryStarted(Recoverable recoverable);
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
@@ -489,12 +489,13 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         this.delegate = (RecoveryAwareChannelN) connDelegate.createChannel(this.getChannelNumber());
         this.delegate.inheritOffsetFrom(defunctChannel);
 
+        this.notifyRecoveryListenersStarted();
         this.recoverShutdownListeners();
         this.recoverReturnListeners();
         this.recoverConfirmListeners();
         this.recoverFlowListeners();
         this.recoverState();
-        this.notifyRecoveryListeners();
+        this.notifyRecoveryListenersComplete();
     }
 
     private void recoverShutdownListeners() {
@@ -538,9 +539,15 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         }
     }
 
-    private void notifyRecoveryListeners() {
+    private void notifyRecoveryListenersComplete() {
         for (RecoveryListener f : this.recoveryListeners) {
             f.handleRecovery(this);
+        }
+    }
+
+    private void notifyRecoveryListenersStarted() {
+        for (RecoveryListener f : this.recoveryListeners) {
+            f.handleRecoveryStarted(this);
         }
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -448,6 +448,9 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
 
     synchronized private void beginAutomaticRecovery() throws InterruptedException, IOException, TopologyRecoveryException {
         Thread.sleep(this.params.getNetworkRecoveryInterval());
+
+        this.notifyRecoveryListenersStarted();
+
         if (!this.recoverConnection()) {
             return;
         }
@@ -461,7 +464,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
 			      this.recoverConsumers();
 		    }
 
-		    this.notifyRecoveryListeners();
+		this.notifyRecoveryListeners();
     }
 
     private void recoverShutdownListeners() {
@@ -515,9 +518,15 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
         }
     }
 
-    private void notifyRecoveryListeners() {
+    private void notifyRecoveryListenersComplete() {
         for (RecoveryListener f : this.recoveryListeners) {
             f.handleRecovery(this);
+        }
+    }
+
+    private void notifyRecoveryListenersStarted() {
+        for (RecoveryListener f : this.recoveryListeners) {
+            f.handleRecoveryStarted(this);
         }
     }
 

--- a/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
@@ -115,6 +115,10 @@ public class ConnectionRecovery extends BrokerTestCase {
             public void handleRecovery(Recoverable recoverable) {
                 latch.countDown();
             }
+            @Override
+            public void handleRecoveryStarted(Recoverable recoverable) {
+                // todo
+            }
         });
         assertTrue(connection.isOpen());
         closeAndWaitForRecovery();

--- a/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
@@ -587,9 +587,13 @@ public class ConnectionRecovery extends BrokerTestCase {
 
     public void testChannelRecoveryCallback() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(2);
+        final CountDownLatch startLatch = new CountDownLatch(2);
         final RecoveryListener listener = new RecoveryListener() {
             public void handleRecovery(Recoverable recoverable) {
                 latch.countDown();
+            }
+            public void handleRecoveryStarted(Recoverable recoverable) {
+                startLatch.countDown();
             }
         };
         AutorecoveringChannel ch1 = (AutorecoveringChannel) connection.createChannel();
@@ -603,6 +607,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         expectChannelRecovery(ch1);
         expectChannelRecovery(ch2);
         wait(latch);
+        wait(startLatch);
     }
 
     public void testBasicAckAfterChannelRecovery() throws IOException, InterruptedException, TimeoutException {
@@ -706,6 +711,9 @@ public class ConnectionRecovery extends BrokerTestCase {
         ((AutorecoveringConnection)conn).addRecoveryListener(new RecoveryListener() {
             public void handleRecovery(Recoverable recoverable) {
                 latch.countDown();
+            }
+            public void handleRecoveryStarted(Recoverable recoverable) {
+                // No-op
             }
         });
         return latch;


### PR DESCRIPTION
Recent rebase from master hopefully makes this cleaner.

This is still in a rough "idea" kind of state, just to communicate the notion of having an event to fire immediately prior to recovery beginning, in case someone wants to do something when that happens.  Might not be valuable anymore since ShutdownHooks are going to fire first (provided we can tell somehow that a recovery is going to happen).