### PR TITLE
Bump default TLS version to v1.2 with a fallback for older JDKs

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -81,8 +81,9 @@ public class ConnectionFactory implements Cloneable {
      *  zero means wait indefinitely */
     public static final int    DEFAULT_SHUTDOWN_TIMEOUT = 10000;
 
-    /** The default SSL protocol */
-    private static final String DEFAULT_SSL_PROTOCOL = "TLSv1";
+    private static final String PREFERED_TLS_PROTOCOL = "TLSv1.2";
+
+    private static final String FALLBACK_TLS_PROTOCOL = "TLSv1";
 
     private String username                       = DEFAULT_USER;
     private String password                       = DEFAULT_PASS;
@@ -552,7 +553,7 @@ public class ConnectionFactory implements Cloneable {
     public void useSslProtocol()
         throws NoSuchAlgorithmException, KeyManagementException
     {
-        useSslProtocol(DEFAULT_SSL_PROTOCOL);
+        useSslProtocol(computeDefaultTlsProcotol(SSLContext.getDefault().getSupportedSSLParameters().getProtocols()));
     }
 
     /**
@@ -587,6 +588,17 @@ public class ConnectionFactory implements Cloneable {
      */
     public void useSslProtocol(SSLContext context) {
         setSocketFactory(context.getSocketFactory());
+    }
+
+    public String computeDefaultTlsProcotol(String [] supportedProtocols) {
+        if(supportedProtocols != null) {
+            for (String supportedProtocol : supportedProtocols) {
+                if(PREFERED_TLS_PROTOCOL.equalsIgnoreCase(supportedProtocol)) {
+                    return supportedProtocol;
+                }
+            }
+        }
+        return FALLBACK_TLS_PROTOCOL;
     }
 
     /**

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -590,7 +590,7 @@ public class ConnectionFactory implements Cloneable {
         setSocketFactory(context.getSocketFactory());
     }
 
-    public String computeDefaultTlsProcotol(String [] supportedProtocols) {
+    public static String computeDefaultTlsProcotol(String[] supportedProtocols) {
         if(supportedProtocols != null) {
             for (String supportedProtocol : supportedProtocols) {
                 if(PREFERED_TLS_PROTOCOL.equalsIgnoreCase(supportedProtocol)) {

--- a/src/test/java/com/rabbitmq/client/test/ssl/ConnectionFactoryDefaultTlsVersion.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/ConnectionFactoryDefaultTlsVersion.java
@@ -10,19 +10,19 @@ public class ConnectionFactoryDefaultTlsVersion extends TestCase {
 
     public void testDefaultTlsVersionJdk16ShouldTakeFallback() {
         String [] supportedProtocols = {"SSLv2Hello", "SSLv3", "TLSv1"};
-        String tlsProtocol = connectionFactory.computeDefaultTlsProcotol(supportedProtocols);
+        String tlsProtocol = ConnectionFactory.computeDefaultTlsProcotol(supportedProtocols);
         Assert.assertEquals("TLSv1",tlsProtocol);
     }
 
     public void testDefaultTlsVersionJdk17ShouldTakePrefered() {
         String [] supportedProtocols = {"SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
-        String tlsProtocol = connectionFactory.computeDefaultTlsProcotol(supportedProtocols);
+        String tlsProtocol = ConnectionFactory.computeDefaultTlsProcotol(supportedProtocols);
         Assert.assertEquals("TLSv1.2",tlsProtocol);
     }
 
     public void testDefaultTlsVersionJdk18ShouldTakePrefered() {
         String [] supportedProtocols = {"SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
-        String tlsProtocol = connectionFactory.computeDefaultTlsProcotol(supportedProtocols);
+        String tlsProtocol = ConnectionFactory.computeDefaultTlsProcotol(supportedProtocols);
         Assert.assertEquals("TLSv1.2",tlsProtocol);
     }
 

--- a/src/test/java/com/rabbitmq/client/test/ssl/ConnectionFactoryDefaultTlsVersion.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/ConnectionFactoryDefaultTlsVersion.java
@@ -1,0 +1,29 @@
+package com.rabbitmq.client.test.ssl;
+
+import com.rabbitmq.client.ConnectionFactory;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+public class ConnectionFactoryDefaultTlsVersion extends TestCase {
+
+    private ConnectionFactory connectionFactory = new ConnectionFactory();
+
+    public void testDefaultTlsVersionJdk16ShouldTakeFallback() {
+        String [] supportedProtocols = {"SSLv2Hello", "SSLv3", "TLSv1"};
+        String tlsProtocol = connectionFactory.computeDefaultTlsProcotol(supportedProtocols);
+        Assert.assertEquals("TLSv1",tlsProtocol);
+    }
+
+    public void testDefaultTlsVersionJdk17ShouldTakePrefered() {
+        String [] supportedProtocols = {"SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
+        String tlsProtocol = connectionFactory.computeDefaultTlsProcotol(supportedProtocols);
+        Assert.assertEquals("TLSv1.2",tlsProtocol);
+    }
+
+    public void testDefaultTlsVersionJdk18ShouldTakePrefered() {
+        String [] supportedProtocols = {"SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
+        String tlsProtocol = connectionFactory.computeDefaultTlsProcotol(supportedProtocols);
+        Assert.assertEquals("TLSv1.2",tlsProtocol);
+    }
+
+}

--- a/src/test/java/com/rabbitmq/client/test/ssl/SSLTests.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/SSLTests.java
@@ -24,7 +24,8 @@ import com.rabbitmq.client.test.AbstractRMQTestSuite;
 public class SSLTests extends AbstractRMQTestSuite {
     public static TestSuite suite() {
         TestSuite suite = new TestSuite("ssl");
-        //Skip the tests if not under umbrella and not SSL available
+        suite.addTestSuite(ConnectionFactoryDefaultTlsVersion.class);
+        // Skip the tests if not under umbrella and no TLS setup available
         if (!requiredProperties()) return suite;
         if (!(isUnderUmbrella() && isSSLAvailable())) return suite;
         suite.addTestSuite(UnverifiedConnection.class);


### PR DESCRIPTION
Namely JDK 6.

Fixes #139.