### PR TITLE
Activate by default the setup-test-cluster profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,9 +166,6 @@
         <property>
           <name>!skipTests</name>
         </property>
-        <file>
-          <exists>${rabbitmq.dir}</exists>
-        </file>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
As the activation cannot use properties in the file tag.

Follow-up to #122.