### PR TITLE
Prevent deadlock/hanging on JDK socket write

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -642,7 +642,7 @@ public class ConnectionFactory implements Cloneable {
     }
 
     protected FrameHandlerFactory createFrameHandlerFactory() throws IOException {
-        return new FrameHandlerFactory(connectionTimeout, factory, socketConf, isSSL());
+        return new FrameHandlerFactory(connectionTimeout, factory, socketConf, isSSL(), this.shutdownExecutor);
     }
 
     /**

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -45,6 +45,9 @@ final class Copyright {
 public class AMQConnection extends ShutdownNotifierComponent implements Connection, NetworkConnection {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AMQConnection.class);
+    // we want socket write and channel shutdown timeouts to kick in after
+    // the heartbeat one, so we use a value of 105% of the effective heartbeat timeout
+    public static final double CHANNEL_SHUTDOWN_TIMEOUT_MULTIPLIER = 1.05;
 
     private final ExecutorService consumerWorkServiceExecutor;
     private final ScheduledExecutorService heartbeatExecutor;
@@ -393,7 +396,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     protected ChannelManager instantiateChannelManager(int channelMax, ThreadFactory threadFactory) {
         ChannelManager result = new ChannelManager(this._workService, channelMax, threadFactory, this.metricsCollector);
         result.setShutdownExecutor(this.shutdownExecutor);
-        result.setChannelShutdownTimeout((int) ((requestedHeartbeat * 1.05) * 1000));
+        result.setChannelShutdownTimeout((int) ((requestedHeartbeat * CHANNEL_SHUTDOWN_TIMEOUT_MULTIPLIER) * 1000));
         return result;
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -393,6 +393,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     protected ChannelManager instantiateChannelManager(int channelMax, ThreadFactory threadFactory) {
         ChannelManager result = new ChannelManager(this._workService, channelMax, threadFactory, this.metricsCollector);
         result.setShutdownExecutor(this.shutdownExecutor);
+        result.setChannelShutdownTimeout((int) (requestedHeartbeat * 1000.0 + requestedHeartbeat * 1000.0 * (5.0 / 100.0)));
         return result;
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -393,7 +393,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     protected ChannelManager instantiateChannelManager(int channelMax, ThreadFactory threadFactory) {
         ChannelManager result = new ChannelManager(this._workService, channelMax, threadFactory, this.metricsCollector);
         result.setShutdownExecutor(this.shutdownExecutor);
-        result.setChannelShutdownTimeout((int) (requestedHeartbeat * 1000.0 + requestedHeartbeat * 1000.0 * (5.0 / 100.0)));
+        result.setChannelShutdownTimeout((int) ((requestedHeartbeat * 1.05) * 1000));
         return result;
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/ChannelManager.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelManager.java
@@ -52,7 +52,7 @@ public class ChannelManager {
     private ExecutorService shutdownExecutor;
     private final ThreadFactory threadFactory;
 
-    private int channelShutdownTimeout = (int) (ConnectionFactory.DEFAULT_HEARTBEAT + ConnectionFactory.DEFAULT_HEARTBEAT * (5.0 / 100.0)) * 1000;
+    private int channelShutdownTimeout = (int) ((ConnectionFactory.DEFAULT_HEARTBEAT * 1.05) * 1000);
 
     protected final MetricsCollector metricsCollector;
 

--- a/src/main/java/com/rabbitmq/client/impl/ChannelManager.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelManager.java
@@ -15,26 +15,27 @@
 
 package com.rabbitmq.client.impl;
 
+import com.rabbitmq.client.MetricsCollector;
+import com.rabbitmq.client.NoOpMetricsCollector;
+import com.rabbitmq.client.ShutdownSignalException;
+import com.rabbitmq.utility.IntAllocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-
-import com.rabbitmq.client.NoOpMetricsCollector;
-import com.rabbitmq.client.ShutdownSignalException;
-import com.rabbitmq.client.MetricsCollector;
-import com.rabbitmq.utility.IntAllocator;
+import java.util.concurrent.*;
 
 /**
  * Manages a set of channels, indexed by channel number (<code><b>1.._channelMax</b></code>).
  */
 public class ChannelManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChannelManager.class);
+
     /** Monitor for <code>_channelMap</code> and <code>channelNumberAllocator</code> */
     private final Object monitor = new Object();
         /** Mapping from <code><b>1.._channelMax</b></code> to {@link ChannelN} instance */
@@ -97,16 +98,33 @@ public class ChannelManager {
      * Handle shutdown. All the managed {@link com.rabbitmq.client.Channel Channel}s are shutdown.
      * @param signal reason for shutdown
      */
-    public void handleSignal(ShutdownSignalException signal) {
+    public void handleSignal(final ShutdownSignalException signal) {
         Set<ChannelN> channels;
         synchronized(this.monitor) {
             channels = new HashSet<ChannelN>(_channelMap.values());
         }
-        for (ChannelN channel : channels) {
-            releaseChannelNumber(channel);
-            channel.processShutdownSignal(signal, true, true);
-            shutdownSet.add(channel.getShutdownLatch());
-            channel.notifyListeners();
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            for (final ChannelN channel : channels) {
+                releaseChannelNumber(channel);
+                Future<?> channelShutdownTask = executorService.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        channel.processShutdownSignal(signal, true, true);
+                        shutdownSet.add(channel.getShutdownLatch());
+                    }
+                });
+                try {
+                    // FIXME make the timeout configurable
+                    channelShutdownTask.get(1, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    LOGGER.warn("Couldn't properly close channel {}", channel.getChannelNumber());
+                } finally {
+                    channel.notifyListeners();
+                }
+            }
+        } finally {
+            executorService.shutdownNow();
         }
         scheduleShutdownProcessing();
     }

--- a/src/main/java/com/rabbitmq/client/impl/FrameHandlerFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/FrameHandlerFactory.java
@@ -23,18 +23,25 @@ import javax.net.SocketFactory;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
 
 public class FrameHandlerFactory {
     private final int connectionTimeout;
     private final SocketFactory factory;
     private final SocketConfigurator configurator;
+    private final ExecutorService shutdownExecutor;
     private final boolean ssl;
 
     public FrameHandlerFactory(int connectionTimeout, SocketFactory factory, SocketConfigurator configurator, boolean ssl) {
+        this(connectionTimeout, factory, configurator, ssl, null);
+    }
+
+    public FrameHandlerFactory(int connectionTimeout, SocketFactory factory, SocketConfigurator configurator, boolean ssl, ExecutorService shutdownExecutor) {
         this.connectionTimeout = connectionTimeout;
         this.factory = factory;
         this.configurator = configurator;
         this.ssl = ssl;
+        this.shutdownExecutor = shutdownExecutor;
     }
 
     public FrameHandler create(Address addr) throws IOException {
@@ -55,7 +62,7 @@ public class FrameHandlerFactory {
 
     public FrameHandler create(Socket sock) throws IOException
     {
-        return new SocketFrameHandler(sock);
+        return new SocketFrameHandler(sock, this.shutdownExecutor);
     }
 
     private static void quietTrySocketClose(Socket socket) {

--- a/src/main/java/com/rabbitmq/client/impl/SocketFrameHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/SocketFrameHandler.java
@@ -35,6 +35,11 @@ public class SocketFrameHandler implements FrameHandler {
     /** The underlying socket */
     private final Socket _socket;
 
+    /**
+     * Optional {@link ExecutorService} for final flush.
+     */
+    private final ExecutorService _shutdownExecutor;
+
     /** Socket's inputstream - data from the broker - synchronized on */
     private final DataInputStream _inputStream;
 
@@ -48,7 +53,15 @@ public class SocketFrameHandler implements FrameHandler {
      * @param socket the socket to use
      */
     public SocketFrameHandler(Socket socket) throws IOException {
+        this(socket, null);
+    }
+
+    /**
+     * @param socket the socket to use
+     */
+    public SocketFrameHandler(Socket socket, ExecutorService shutdownExecutor) throws IOException {
         _socket = socket;
+        _shutdownExecutor = shutdownExecutor;
 
         _inputStream = new DataInputStream(new BufferedInputStream(socket.getInputStream()));
         _outputStream = new DataOutputStream(new BufferedOutputStream(socket.getOutputStream()));
@@ -153,20 +166,24 @@ public class SocketFrameHandler implements FrameHandler {
     @SuppressWarnings("unused")
     public void close() {
         try { _socket.setSoLinger(true, SOCKET_CLOSING_TIMEOUT); } catch (Exception _e) {}
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        // async flush if possible
+        // see https://github.com/rabbitmq/rabbitmq-java-client/issues/194
+        Callable<Void> flushCallable = new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                flush();
+                return null;
+            }
+        };
         try {
-            Future<Void> flushTask = executorService.submit(new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                    flush();
-                    return null;
-                }
-            });
-            flushTask.get(SOCKET_CLOSING_TIMEOUT, TimeUnit.SECONDS);
-        } catch (Exception _e) {
+            if(this._shutdownExecutor == null) {
+                flushCallable.call();
+            } else {
+                Future<Void> flushTask = this._shutdownExecutor.submit(flushCallable);
+                flushTask.get(SOCKET_CLOSING_TIMEOUT, TimeUnit.SECONDS);
+            }
+        } catch(Exception e) {
 
-        } finally {
-            executorService.shutdownNow();
         }
         try { _socket.close();                                   } catch (Exception _e) {}
     }


### PR DESCRIPTION
Add a timeout do some shutdown operations as they can deadlock (mainly because JDK sockets don't support a timeout on write operations). This can solve the problem which gave birth to #11, and thus avoids a complete NIO2 rewrite.

Fixes #194 
References #11