### PR TITLE
Recovery related changes

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConsumerCancelledException.java
+++ b/src/main/java/com/rabbitmq/client/ConsumerCancelledException.java
@@ -23,6 +23,7 @@ public class ConsumerCancelledException extends RuntimeException implements
     /** Default for non-checking. */
     private static final long serialVersionUID = 1L;
 
+    @Override
     public ConsumerCancelledException sensibleClone() {
         try {
             return (ConsumerCancelledException) super.clone();

--- a/src/main/java/com/rabbitmq/client/DefaultConsumer.java
+++ b/src/main/java/com/rabbitmq/client/DefaultConsumer.java
@@ -40,6 +40,7 @@ public class DefaultConsumer implements Consumer {
      * Stores the most recently passed-in consumerTag - semantically, there should be only one.
      * @see Consumer#handleConsumeOk
      */
+    @Override
     public void handleConsumeOk(String consumerTag) {
         this._consumerTag = consumerTag;
     }
@@ -48,6 +49,7 @@ public class DefaultConsumer implements Consumer {
      * No-op implementation of {@link Consumer#handleCancelOk}.
      * @param consumerTag the defined consumer tag (client- or server-generated)
      */
+    @Override
     public void handleCancelOk(String consumerTag) {
         // no work to do
     }
@@ -56,6 +58,7 @@ public class DefaultConsumer implements Consumer {
      * No-op implementation of {@link Consumer#handleCancel(String)}
      * @param consumerTag the defined consumer tag (client- or server-generated)
      */
+    @Override
     public void handleCancel(String consumerTag) throws IOException {
         // no work to do
     }
@@ -63,6 +66,7 @@ public class DefaultConsumer implements Consumer {
     /**
      * No-op implementation of {@link Consumer#handleShutdownSignal}.
      */
+    @Override
     public void handleShutdownSignal(String consumerTag, ShutdownSignalException sig) {
         // no work to do
     }
@@ -70,6 +74,7 @@ public class DefaultConsumer implements Consumer {
      /**
      * No-op implementation of {@link Consumer#handleRecoverOk}.
      */
+    @Override
     public void handleRecoverOk(String consumerTag) {
         // no work to do
     }
@@ -77,6 +82,7 @@ public class DefaultConsumer implements Consumer {
     /**
      * No-op implementation of {@link Consumer#handleDelivery}.
      */
+    @Override
     public void handleDelivery(String consumerTag,
                                Envelope envelope,
                                AMQP.BasicProperties properties,

--- a/src/main/java/com/rabbitmq/client/DefaultSaslConfig.java
+++ b/src/main/java/com/rabbitmq/client/DefaultSaslConfig.java
@@ -40,6 +40,7 @@ public class DefaultSaslConfig implements SaslConfig {
         this.mechanism = mechanism;
     }
 
+    @Override
     public SaslMechanism getSaslMechanism(String[] serverMechanisms) {
         Set<String> server = new HashSet<String>(Arrays.asList(serverMechanisms));
 

--- a/src/main/java/com/rabbitmq/client/DefaultSocketConfigurator.java
+++ b/src/main/java/com/rabbitmq/client/DefaultSocketConfigurator.java
@@ -30,6 +30,7 @@ public class DefaultSocketConfigurator implements SocketConfigurator {
      *
      *  @param socket The socket that is to be used for the Connection
      */
+    @Override
     public void configure(Socket socket) throws IOException {
         // disable Nagle's algorithm, for more consistently low latency
         socket.setTcpNoDelay(true);

--- a/src/main/java/com/rabbitmq/client/JDKSaslConfig.java
+++ b/src/main/java/com/rabbitmq/client/JDKSaslConfig.java
@@ -64,6 +64,7 @@ public class JDKSaslConfig implements SaslConfig {
         this.mechanisms = Arrays.asList(mechanisms);
     }
 
+    @Override
     public SaslMechanism getSaslMechanism(String[] serverMechanisms) {
         Set<String> server = new HashSet<String>(Arrays.asList(serverMechanisms));
 
@@ -88,10 +89,12 @@ public class JDKSaslConfig implements SaslConfig {
             this.client = client;
         }
 
+        @Override
         public String getName() {
             return client.getMechanismName();
         }
 
+        @Override
         public LongString handleChallenge(LongString challenge, String username, String password) {
             try {
                 return LongStringHelper.asLongString(client.evaluateChallenge(challenge.getBytes()));
@@ -107,6 +110,7 @@ public class JDKSaslConfig implements SaslConfig {
             this.factory = factory;
         }
 
+        @Override
         public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
             for (Callback callback: callbacks) {
                 if (callback instanceof NameCallback) {

--- a/src/main/java/com/rabbitmq/client/LongString.java
+++ b/src/main/java/com/rabbitmq/client/LongString.java
@@ -57,5 +57,6 @@ public interface LongString
      * Get the content as a String. Uses UTF-8 as encoding.
      * @return he content of the {@link LongString} as a string
      */
+    @Override
     public String toString();
 }

--- a/src/main/java/com/rabbitmq/client/MapRpcServer.java
+++ b/src/main/java/com/rabbitmq/client/MapRpcServer.java
@@ -43,6 +43,7 @@ public class MapRpcServer extends RpcServer {
     /**
      * Overridden to delegate to handleMapCall.
      */
+    @Override
     public byte[] handleCall(byte[] requestBody, AMQP.BasicProperties replyProperties)
     {
         try {
@@ -93,6 +94,7 @@ public class MapRpcServer extends RpcServer {
     /**
      * Overridden to delegate to handleMapCast.
      */
+    @Override
     public void handleCast(byte[] requestBody)
     {
         try {

--- a/src/main/java/com/rabbitmq/client/NullTrustManager.java
+++ b/src/main/java/com/rabbitmq/client/NullTrustManager.java
@@ -29,6 +29,7 @@ public class NullTrustManager implements X509TrustManager {
      * Doesn't even bother looking at its arguments, simply returns,
      * which makes the check succeed.
      */
+    @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType) {
         // Do nothing.
     }
@@ -37,6 +38,7 @@ public class NullTrustManager implements X509TrustManager {
      * Doesn't even bother looking at its arguments, simply returns,
      * which makes the check succeed.
      */
+    @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType) {
         // Do nothing.
     }
@@ -44,6 +46,7 @@ public class NullTrustManager implements X509TrustManager {
     /**
      * Always returns an empty array of X509Certificates.
      */
+    @Override
     public X509Certificate[] getAcceptedIssuers() {
         return new X509Certificate[0];
     }

--- a/src/main/java/com/rabbitmq/client/SaslMechanism.java
+++ b/src/main/java/com/rabbitmq/client/SaslMechanism.java
@@ -15,8 +15,6 @@
 
 package com.rabbitmq.client;
 
-import java.io.IOException;
-
 /**
  * Our own view of a SASL authentication mechanism, introduced to remove a
  * dependency on javax.security.sasl.

--- a/src/main/java/com/rabbitmq/client/ShutdownSignalException.java
+++ b/src/main/java/com/rabbitmq/client/ShutdownSignalException.java
@@ -111,6 +111,7 @@ public class ShutdownSignalException extends RuntimeException implements Sensibl
     /** @return Reference to Connection or Channel object that fired the signal **/
     public Object getReference() { return _ref; }
 
+    @Override
     public ShutdownSignalException sensibleClone() {
         try {
             return (ShutdownSignalException)super.clone();

--- a/src/main/java/com/rabbitmq/client/StringRpcServer.java
+++ b/src/main/java/com/rabbitmq/client/StringRpcServer.java
@@ -35,6 +35,7 @@ public class StringRpcServer extends RpcServer {
      * handleStringCall. If UTF-8 is not understood by this JVM, falls
      * back to the platform default.
      */
+    @Override
     @SuppressWarnings("unused")
     public byte[] handleCall(byte[] requestBody, AMQP.BasicProperties replyProperties)
     {
@@ -73,6 +74,7 @@ public class StringRpcServer extends RpcServer {
      * handleStringCast. If requestBody cannot be interpreted as UTF-8
      * tries the platform default.
      */
+    @Override
     public void handleCast(byte[] requestBody)
     {
         try {

--- a/src/main/java/com/rabbitmq/client/UnexpectedMethodError.java
+++ b/src/main/java/com/rabbitmq/client/UnexpectedMethodError.java
@@ -40,6 +40,7 @@ public class UnexpectedMethodError extends Error {
      * Return a string representation of this error.
      * @return a string describing the error
      */
+    @Override
     public String toString() {
         return super.toString() + ": " + _method;
     }

--- a/src/main/java/com/rabbitmq/client/UnknownClassOrMethodId.java
+++ b/src/main/java/com/rabbitmq/client/UnknownClassOrMethodId.java
@@ -34,6 +34,7 @@ public class UnknownClassOrMethodId extends IOException {
         this.classId = classId;
         this.methodId = methodId;
     }
+    @Override
     public String toString() {
         if (this.methodId == NO_METHOD_ID) {
             return super.toString() + "<" + classId + ">";

--- a/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
@@ -347,10 +347,12 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
         public final BlockingValueOrException<T, ShutdownSignalException> _blocker =
             new BlockingValueOrException<T, ShutdownSignalException>();
 
+        @Override
         public void handleCommand(AMQCommand command) {
             _blocker.setValue(transformReply(command));
         }
 
+        @Override
         public void handleShutdownSignal(ShutdownSignalException signal) {
             _blocker.setException(signal);
         }
@@ -372,6 +374,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     public static class SimpleBlockingRpcContinuation
         extends BlockingRpcContinuation<AMQCommand>
     {
+        @Override
         public AMQCommand transformReply(AMQCommand command) {
             return command;
         }

--- a/src/main/java/com/rabbitmq/client/impl/AMQCommand.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQCommand.java
@@ -68,16 +68,19 @@ public class AMQCommand implements Command {
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Method getMethod() {
         return this.assembler.getMethod();
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public AMQContentHeader getContentHeader() {
         return this.assembler.getContentHeader();
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public byte[] getContentBody() {
         return this.assembler.getContentBody();
     }

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -168,19 +168,23 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     /** {@inheritDoc} */
+    @Override
     public InetAddress getAddress() {
         return _frameHandler.getAddress();
     }
 
+    @Override
     public InetAddress getLocalAddress() {
         return _frameHandler.getLocalAddress();
     }
 
     /** {@inheritDoc} */
+    @Override
     public int getPort() {
         return _frameHandler.getPort();
     }
 
+    @Override
     public int getLocalPort() {
         return _frameHandler.getLocalPort();
     }
@@ -190,6 +194,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     /** {@inheritDoc} */
+    @Override
     public Map<String, Object> getServerProperties() {
         return _serverProperties;
     }
@@ -415,6 +420,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     /** {@inheritDoc} */
+    @Override
     public int getChannelMax() {
         ChannelManager cm = _channelManager;
         if (cm == null) return 0;
@@ -422,11 +428,13 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     /** {@inheritDoc} */
+    @Override
     public int getFrameMax() {
         return _frameMax;
     }
 
     /** {@inheritDoc} */
+    @Override
     public int getHeartbeat() {
         return _heartbeat;
     }
@@ -455,7 +463,6 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
      * in the environments with restricted
      * @param threadFactory thread factory to use
      */
-    @SuppressWarnings("unused")
     public void setThreadFactory(ThreadFactory threadFactory) {
         this.threadFactory = threadFactory;
     }
@@ -463,15 +470,16 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     /**
      * @return Thread factory used by this connection.
      */
-    @SuppressWarnings("unused")
     public ThreadFactory getThreadFactory() {
         return threadFactory;
     }
 
+    @Override
     public Map<String, Object> getClientProperties() {
         return new HashMap<String, Object>(_clientProperties);
     }
 
+    @Override
     public String getClientProvidedName() {
         return (String) _clientProperties.get("connection_name");
     }
@@ -479,6 +487,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     /**
      * Protected API - retrieve the current ExceptionHandler
      */
+    @Override
     public ExceptionHandler getExceptionHandler() {
         return _exceptionHandler;
     }
@@ -494,6 +503,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
 
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Channel createChannel(int channelNumber) throws IOException {
         ensureIsOpen();
         ChannelManager cm = _channelManager;
@@ -504,6 +514,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Channel createChannel() throws IOException {
         ensureIsOpen();
         ChannelManager cm = _channelManager;
@@ -542,6 +553,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
          * Continues running until the "running" flag is set false by
          * shutdown().
          */
+        @Override
         public void run() {
             try {
                 while (_running) {
@@ -616,7 +628,6 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         this.recoveryCanBeginListeners.add(fn);
     }
 
-    @SuppressWarnings(value = "unused")
     public void removeRecoveryCanBeginListener(RecoveryCanBeginListener fn) {
         this.recoveryCanBeginListeners.remove(fn);
     }
@@ -704,7 +715,6 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         }
     }
 
-    @SuppressWarnings("unused")
     public void handleConnectionClose(Command closeCommand) {
         ShutdownSignalException sse = shutdown(closeCommand.getMethod(), false, null, _inConnectionNegotiation);
         try {
@@ -736,6 +746,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
             cause = sse;
         }
 
+        @Override
         public void run() {
             try {
                 // TODO: use a sensible timeout here
@@ -799,6 +810,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void close()
         throws IOException
     {
@@ -806,6 +818,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void close(int timeout)
         throws IOException
     {
@@ -813,6 +826,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void close(int closeCode, String closeMessage)
         throws IOException
     {
@@ -820,6 +834,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void close(int closeCode, String closeMessage, int timeout)
         throws IOException
     {
@@ -827,25 +842,28 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void abort()
     {
         abort(-1);
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void abort(int closeCode, String closeMessage)
     {
        abort(closeCode, closeMessage, -1);
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void abort(int timeout)
     {
         abort(AMQP.REPLY_SUCCESS, "OK", timeout);
     }
 
     /** Public API - {@inheritDoc} */
-    @SuppressWarnings("unused")
+    @Override
     public void abort(int closeCode, String closeMessage, int timeout)
     {
         try {
@@ -931,14 +949,17 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         return getAddress() == null ? null : getAddress().getHostAddress();
     }
 
+    @Override
     public void addBlockedListener(BlockedListener listener) {
         blockedListeners.add(listener);
     }
 
+    @Override
     public boolean removeBlockedListener(BlockedListener listener) {
         return blockedListeners.remove(listener);
     }
 
+    @Override
     public void clearBlockedListeners() {
         blockedListeners.clear();
     }

--- a/src/main/java/com/rabbitmq/client/impl/AMQContentHeader.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQContentHeader.java
@@ -56,6 +56,7 @@ public abstract class AMQContentHeader implements ContentHeader {
     public abstract void writePropertiesTo(ContentHeaderPropertyWriter writer) throws IOException;
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void appendPropertyDebugStringTo(StringBuilder acc) {
         acc.append("(?)");
     }
@@ -78,6 +79,7 @@ public abstract class AMQContentHeader implements ContentHeader {
         return frame;
     }
     
+    @Override
     public Object clone() throws CloneNotSupportedException {
         return super.clone();
     }

--- a/src/main/java/com/rabbitmq/client/impl/CRDemoMechanism.java
+++ b/src/main/java/com/rabbitmq/client/impl/CRDemoMechanism.java
@@ -33,10 +33,12 @@ public class CRDemoMechanism implements SaslMechanism {
 
     private int round = 0;
 
+    @Override
     public String getName() {
         return NAME;
     }
 
+    @Override
     public LongString handleChallenge(LongString challenge, String username, String password) {
         round++;
         if (round == 1) {
@@ -47,6 +49,7 @@ public class CRDemoMechanism implements SaslMechanism {
     }
 
     public static class CRDemoSaslConfig implements SaslConfig {
+        @Override
         public SaslMechanism getSaslMechanism(String[] mechanisms)  {
             if (Arrays.asList(mechanisms).contains(NAME)) {
                 return new CRDemoMechanism();

--- a/src/main/java/com/rabbitmq/client/impl/ChannelManager.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelManager.java
@@ -138,6 +138,7 @@ public class ChannelManager {
         final Set<CountDownLatch> sdSet = new HashSet<CountDownLatch>(shutdownSet);
         final ConsumerWorkService ssWorkService = workService;
         Runnable target = new Runnable() {
+            @Override
             public void run() {
                 for (CountDownLatch latch : sdSet) {
                     try {
@@ -189,7 +190,7 @@ public class ChannelManager {
         return ch;
     }
 
-    private ChannelN addNewChannel(AMQConnection connection, int channelNumber) throws IOException {
+    private ChannelN addNewChannel(AMQConnection connection, int channelNumber) {
         if (_channelMap.containsKey(channelNumber)) {
             // That number's already allocated! Can't do it
             // This should never happen unless something has gone

--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -132,49 +132,56 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
         exnWrappingRpc(new Channel.Open(UNSPECIFIED_OUT_OF_BAND));
     }
 
+    @Override
     public void addReturnListener(ReturnListener listener) {
         returnListeners.add(listener);
     }
 
+    @Override
     public boolean removeReturnListener(ReturnListener listener) {
         return returnListeners.remove(listener);
     }
 
+    @Override
     public void clearReturnListeners() {
         returnListeners.clear();
     }
 
-    @SuppressWarnings("deprecation")
+    @Override
     @Deprecated
     public void addFlowListener(FlowListener listener) {
         flowListeners.add(listener);
     }
 
-    @SuppressWarnings("deprecation")
+    @Override
     @Deprecated
     public boolean removeFlowListener(FlowListener listener) {
         return flowListeners.remove(listener);
     }
 
-    @SuppressWarnings("deprecation")
+    @Override
     @Deprecated
     public void clearFlowListeners() {
         flowListeners.clear();
     }
 
+    @Override
     public void addConfirmListener(ConfirmListener listener) {
         confirmListeners.add(listener);
     }
 
+    @Override
     public boolean removeConfirmListener(ConfirmListener listener) {
         return confirmListeners.remove(listener);
     }
 
+    @Override
     public void clearConfirmListeners() {
         confirmListeners.clear();
     }
 
     /** {@inheritDoc} */
+    @Override
     public boolean waitForConfirms()
         throws InterruptedException
     {
@@ -186,6 +193,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** {@inheritDoc} */
+    @Override
     public boolean waitForConfirms(long timeout)
             throws InterruptedException, TimeoutException {
         if (nextPublishSeqNo == 0L)
@@ -216,6 +224,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** {@inheritDoc} */
+    @Override
     public void waitForConfirmsOrDie()
         throws IOException, InterruptedException
     {
@@ -225,6 +234,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** {@inheritDoc} */
+    @Override
     public void waitForConfirmsOrDie(long timeout)
         throws IOException, InterruptedException, TimeoutException
     {
@@ -240,6 +250,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Returns the current default consumer. */
+    @Override
     public Consumer getDefaultConsumer() {
         return defaultConsumer;
     }
@@ -248,6 +259,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
      * Sets the current default consumer.
      * A null argument is interpreted to mean "do not use a default consumer".
      */
+    @Override
     public void setDefaultConsumer(Consumer consumer) {
         defaultConsumer = consumer;
     }
@@ -509,18 +521,21 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void close()
         throws IOException, TimeoutException {
         close(AMQP.REPLY_SUCCESS, "OK");
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void close(int closeCode, String closeMessage)
         throws IOException, TimeoutException {
         close(closeCode, closeMessage, true, null, false);
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void abort()
         throws IOException
     {
@@ -528,6 +543,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void abort(int closeCode, String closeMessage)
         throws IOException
     {
@@ -614,6 +630,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void basicQos(int prefetchSize, int prefetchCount, boolean global)
 	throws IOException
     {
@@ -621,6 +638,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void basicQos(int prefetchCount, boolean global)
             throws IOException
     {
@@ -628,6 +646,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void basicQos(int prefetchCount)
 	throws IOException
     {
@@ -635,6 +654,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void basicPublish(String exchange, String routingKey,
                              BasicProperties props, byte[] body)
         throws IOException
@@ -643,6 +663,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void basicPublish(String exchange, String routingKey,
                              boolean mandatory,
                              BasicProperties props, byte[] body)
@@ -652,6 +673,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void basicPublish(String exchange, String routingKey,
                              boolean mandatory, boolean immediate,
                              BasicProperties props, byte[] body)
@@ -678,6 +700,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
 
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeclareOk exchangeDeclare(String exchange, String type,
                                               boolean durable, boolean autoDelete,
                                               Map<String, Object> arguments)
@@ -689,6 +712,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type,
         boolean durable, boolean autoDelete,
         Map<String, Object> arguments)
@@ -699,6 +723,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
             arguments);
     }
 
+    @Override
     public void exchangeDeclareNoWait(String exchange,
                                       String type,
                                       boolean durable,
@@ -717,6 +742,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
                                 .build()));
     }
 
+    @Override
     public void exchangeDeclareNoWait(String exchange,
         BuiltinExchangeType type,
         boolean durable,
@@ -729,6 +755,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeclareOk exchangeDeclare(String exchange, String type,
                                               boolean durable,
                                               boolean autoDelete,
@@ -749,6 +776,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type,
         boolean durable,
         boolean autoDelete,
@@ -762,6 +790,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeclareOk exchangeDeclare(String exchange, String type,
                                               boolean durable)
         throws IOException
@@ -770,6 +799,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type,
         boolean durable)
         throws IOException
@@ -778,6 +808,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeclareOk exchangeDeclare(String exchange, String type)
         throws IOException
     {
@@ -785,6 +816,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type)
         throws IOException
     {
@@ -792,6 +824,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeclareOk exchangeDeclarePassive(String exchange)
         throws IOException
     {
@@ -805,6 +838,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeleteOk exchangeDelete(String exchange, boolean ifUnused)
         throws IOException
     {
@@ -817,6 +851,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void exchangeDeleteNoWait(String exchange, boolean ifUnused) throws IOException {
         transmit(new AMQCommand(new Exchange.Delete.Builder()
                                         .exchange(exchange)
@@ -826,6 +861,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.DeleteOk exchangeDelete(String exchange)
         throws IOException
     {
@@ -833,6 +869,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.BindOk exchangeBind(String destination, String source,
             String routingKey, Map<String, Object> arguments)
             throws IOException {
@@ -847,6 +884,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void exchangeBindNoWait(String destination,
                                    String source,
                                    String routingKey,
@@ -861,12 +899,14 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.BindOk exchangeBind(String destination, String source,
             String routingKey) throws IOException {
         return exchangeBind(destination, source, routingKey, null);
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.UnbindOk exchangeUnbind(String destination, String source,
             String routingKey, Map<String, Object> arguments)
             throws IOException {
@@ -881,12 +921,14 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Exchange.UnbindOk exchangeUnbind(String destination, String source,
             String routingKey) throws IOException {
         return exchangeUnbind(destination, source, routingKey, null);
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void exchangeUnbindNoWait(String destination, String source,
                                      String routingKey, Map<String, Object> arguments)
             throws IOException {
@@ -900,6 +942,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Queue.DeclareOk queueDeclare(String queue, boolean durable, boolean exclusive,
                                         boolean autoDelete, Map<String, Object> arguments)
         throws IOException
@@ -917,6 +960,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public com.rabbitmq.client.AMQP.Queue.DeclareOk queueDeclare()
         throws IOException
     {
@@ -924,6 +968,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void queueDeclareNoWait(String queue,
                                    boolean durable,
                                    boolean exclusive,
@@ -942,6 +987,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Queue.DeclareOk queueDeclarePassive(String queue)
         throws IOException
     {
@@ -957,18 +1003,21 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public long messageCount(String queue) throws IOException {
         Queue.DeclareOk ok = queueDeclarePassive(queue);
         return ok.getMessageCount();
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public long consumerCount(String queue) throws IOException {
         Queue.DeclareOk ok = queueDeclarePassive(queue);
         return ok.getConsumerCount();
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Queue.DeleteOk queueDelete(String queue, boolean ifUnused, boolean ifEmpty)
         throws IOException
     {
@@ -994,6 +1043,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Queue.DeleteOk queueDelete(String queue)
         throws IOException
     {
@@ -1001,6 +1051,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Queue.BindOk queueBind(String queue, String exchange,
                                   String routingKey, Map<String, Object> arguments)
         throws IOException
@@ -1017,6 +1068,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Queue.BindOk queueBind(String queue, String exchange, String routingKey)
         throws IOException
     {
@@ -1024,6 +1076,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void queueBindNoWait(String queue,
                                 String exchange,
                                 String routingKey,
@@ -1039,6 +1092,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Queue.UnbindOk queueUnbind(String queue, String exchange, String routingKey,
                                       Map<String, Object> arguments)
         throws IOException
@@ -1055,6 +1109,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Queue.PurgeOk queuePurge(String queue)
         throws IOException
     {
@@ -1067,6 +1122,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Queue.UnbindOk queueUnbind(String queue, String exchange, String routingKey)
         throws IOException
     {
@@ -1074,6 +1130,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public GetResponse basicGet(String queue, boolean autoAck)
         throws IOException
     {
@@ -1105,6 +1162,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void basicAck(long deliveryTag, boolean multiple)
         throws IOException
     {
@@ -1113,6 +1171,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void basicNack(long deliveryTag, boolean multiple, boolean requeue)
         throws IOException
     {
@@ -1121,6 +1180,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void basicReject(long deliveryTag, boolean requeue)
         throws IOException
     {
@@ -1129,6 +1189,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public String basicConsume(String queue, Consumer callback)
         throws IOException
     {
@@ -1136,6 +1197,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public String basicConsume(String queue, boolean autoAck, Consumer callback)
         throws IOException
     {
@@ -1143,6 +1205,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public String basicConsume(String queue, boolean autoAck, Map<String, Object> arguments,
                                Consumer callback)
         throws IOException
@@ -1151,6 +1214,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public String basicConsume(String queue, boolean autoAck, String consumerTag,
                                Consumer callback)
         throws IOException
@@ -1159,12 +1223,14 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public String basicConsume(String queue, final boolean autoAck, String consumerTag,
                                boolean noLocal, boolean exclusive, Map<String, Object> arguments,
                                final Consumer callback)
         throws IOException
     {
         BlockingRpcContinuation<String> k = new BlockingRpcContinuation<String>() {
+            @Override
             public String transformReply(AMQCommand replyCommand) {
                 String actualConsumerTag = ((Basic.ConsumeOk) replyCommand.getMethod()).getConsumerTag();
                 _consumers.put(actualConsumerTag, callback);
@@ -1195,6 +1261,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public void basicCancel(final String consumerTag)
         throws IOException
     {
@@ -1202,6 +1269,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
         if (originalConsumer == null)
             throw new IOException("Unknown consumerTag");
         BlockingRpcContinuation<Consumer> k = new BlockingRpcContinuation<Consumer>() {
+            @Override
             public Consumer transformReply(AMQCommand replyCommand) {
                 replyCommand.getMethod();
                 _consumers.remove(consumerTag); //may already have been removed
@@ -1222,6 +1290,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
 
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Basic.RecoverOk basicRecover()
         throws IOException
     {
@@ -1229,6 +1298,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Basic.RecoverOk basicRecover(boolean requeue)
         throws IOException
     {
@@ -1237,6 +1307,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
 
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Tx.SelectOk txSelect()
         throws IOException
     {
@@ -1244,6 +1315,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Tx.CommitOk txCommit()
         throws IOException
     {
@@ -1251,6 +1323,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Tx.RollbackOk txRollback()
         throws IOException
     {
@@ -1258,6 +1331,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public Confirm.SelectOk confirmSelect()
         throws IOException
     {
@@ -1268,21 +1342,24 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     }
 
     /** Public API - {@inheritDoc} */
-    @SuppressWarnings("deprecation")
+    @Override
     @Deprecated
     public boolean flowBlocked() {
         return _blockContent;
     }
 
     /** Public API - {@inheritDoc} */
+    @Override
     public long getNextPublishSeqNo() {
         return nextPublishSeqNo;
     }
 
+    @Override
     public void asyncRpc(Method method) throws IOException {
         transmit(method);
     }
 
+    @Override
     public AMQCommand rpc(Method method) throws IOException {
         return exnWrappingRpc(method);
     }
@@ -1315,7 +1392,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
         }
     }
 
-    private void validateQueueNameLength(String queue) {
+    private static void validateQueueNameLength(String queue) {
         if(queue.length() > 255) {
            throw new IllegalArgumentException("queue name must be no more than 255 characters long");
         }

--- a/src/main/java/com/rabbitmq/client/impl/ConsumerDispatcher.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConsumerDispatcher.java
@@ -70,6 +70,7 @@ final class ConsumerDispatcher {
                                 final String consumerTag) {
         executeUnlessShuttingDown(
         new Runnable() {
+            @Override
             public void run() {
                 try {
                     delegate.handleConsumeOk(consumerTag);
@@ -89,6 +90,7 @@ final class ConsumerDispatcher {
                                final String consumerTag) {
         executeUnlessShuttingDown(
         new Runnable() {
+            @Override
             public void run() {
                 try {
                     delegate.handleCancelOk(consumerTag);
@@ -107,7 +109,8 @@ final class ConsumerDispatcher {
     public void handleCancel(final Consumer delegate, final String consumerTag) {
         executeUnlessShuttingDown(
         new Runnable() {
-      public void run() {
+      @Override
+    public void run() {
                 try {
                     delegate.handleCancel(consumerTag);
                 } catch (Throwable ex) {
@@ -126,6 +129,7 @@ final class ConsumerDispatcher {
     public void handleRecoverOk(final Consumer delegate, final String consumerTag) {
         executeUnlessShuttingDown(
         new Runnable() {
+            @Override
             public void run() {
                 delegate.handleRecoverOk(consumerTag);
             }
@@ -139,6 +143,7 @@ final class ConsumerDispatcher {
                                final byte[] body) throws IOException {
         executeUnlessShuttingDown(
         new Runnable() {
+            @Override
             public void run() {
                 try {
                     delegate.handleDelivery(consumerTag,
@@ -166,6 +171,7 @@ final class ConsumerDispatcher {
             this.shutdownConsumersDriven = true;
             // Execute shutdown processing even if there are no consumers.
             execute(new Runnable() {
+                @Override
                 public void run() {
                     ConsumerDispatcher.this.notifyConsumersOfShutdown(consumers, signal);
                     ConsumerDispatcher.this.shutdown(signal);

--- a/src/main/java/com/rabbitmq/client/impl/ConsumerWorkService.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConsumerWorkService.java
@@ -88,6 +88,7 @@ final public class ConsumerWorkService {
 
     private final class WorkPoolRunnable implements Runnable {
 
+        @Override
         public void run() {
             int size = MAX_RUNNABLE_BLOCK_SIZE;
             List<Runnable> block = new ArrayList<Runnable>(size);

--- a/src/main/java/com/rabbitmq/client/impl/ExternalMechanism.java
+++ b/src/main/java/com/rabbitmq/client/impl/ExternalMechanism.java
@@ -22,10 +22,12 @@ import com.rabbitmq.client.SaslMechanism;
  * The EXTERNAL auth mechanism
  */
 public class ExternalMechanism implements SaslMechanism {
+    @Override
     public String getName() {
         return "EXTERNAL";
     }
 
+    @Override
     public LongString handleChallenge(LongString challenge, String username, String password) {
         return LongStringHelper.asLongString("");
     }

--- a/src/main/java/com/rabbitmq/client/impl/ForgivingExceptionHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/ForgivingExceptionHandler.java
@@ -32,26 +32,32 @@ import java.net.SocketException;
  * @see com.rabbitmq.client.ConnectionFactory#setExceptionHandler(com.rabbitmq.client.ExceptionHandler)
  */
 public class ForgivingExceptionHandler implements ExceptionHandler {
+    @Override
     public void handleUnexpectedConnectionDriverException(Connection conn, Throwable exception) {
         log("An unexpected connection driver error occured", exception);
     }
 
+    @Override
     public void handleReturnListenerException(Channel channel, Throwable exception) {
         handleChannelKiller(channel, exception, "ReturnListener.handleReturn");
     }
 
+    @Override
     public void handleFlowListenerException(Channel channel, Throwable exception) {
         handleChannelKiller(channel, exception, "FlowListener.handleFlow");
     }
 
+    @Override
     public void handleConfirmListenerException(Channel channel, Throwable exception) {
         handleChannelKiller(channel, exception, "ConfirmListener.handle{N,A}ck");
     }
 
+    @Override
     public void handleBlockedListenerException(Connection connection, Throwable exception) {
         handleConnectionKiller(connection, exception, "BlockedListener");
     }
 
+    @Override
     public void handleConsumerException(Channel channel, Throwable exception,
                                         Consumer consumer, String consumerTag,
                                         String methodName)
@@ -65,6 +71,7 @@ public class ForgivingExceptionHandler implements ExceptionHandler {
     /**
      * @since 3.3.0
      */
+    @Override
     public void handleConnectionRecoveryException(Connection conn, Throwable exception) {
         // ignore java.net.ConnectException as those are
         // expected during recovery and will only produce noisy
@@ -79,6 +86,7 @@ public class ForgivingExceptionHandler implements ExceptionHandler {
     /**
      * @since 3.3.0
      */
+    @Override
     public void handleChannelRecoveryException(Channel ch, Throwable exception) {
         log("Caught an exception when recovering channel " + ch.getChannelNumber(), exception);
     }
@@ -86,6 +94,7 @@ public class ForgivingExceptionHandler implements ExceptionHandler {
     /**
      * @since 3.3.0
      */
+    @Override
     public void handleTopologyRecoveryException(Connection conn, Channel ch, TopologyRecoveryException exception) {
         log("Caught an exception when recovering topology " + exception.getMessage(), exception);
     }
@@ -119,7 +128,7 @@ public class ForgivingExceptionHandler implements ExceptionHandler {
         }
     }
 
-    private boolean isSocketClosedOrConnectionReset(Throwable e) {
+    private static boolean isSocketClosedOrConnectionReset(Throwable e) {
         return e instanceof SocketException &&
             ("Connection reset".equals(e.getMessage()) || "Socket closed".equals(e.getMessage()));
     }

--- a/src/main/java/com/rabbitmq/client/impl/FrameHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/FrameHandler.java
@@ -16,7 +16,6 @@
 package com.rabbitmq.client.impl;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 

--- a/src/main/java/com/rabbitmq/client/impl/HeartbeatSender.java
+++ b/src/main/java/com/rabbitmq/client/impl/HeartbeatSender.java
@@ -130,6 +130,7 @@ final class HeartbeatSender {
             this.heartbeatNanos = heartbeatNanos;
         }
 
+        @Override
         public void run() {
             try {
                 long now = System.nanoTime();

--- a/src/main/java/com/rabbitmq/client/impl/LongStringHelper.java
+++ b/src/main/java/com/rabbitmq/client/impl/LongStringHelper.java
@@ -59,12 +59,14 @@ public class LongStringHelper
         }
 
         /** {@inheritDoc} */
+        @Override
         public byte[] getBytes()
         {
             return bytes;
         }
 
         /** {@inheritDoc} */
+        @Override
         public DataInputStream getStream()
             throws IOException
         {
@@ -72,6 +74,7 @@ public class LongStringHelper
         }
 
         /** {@inheritDoc} */
+        @Override
         public long length()
         {
             return bytes.length;

--- a/src/main/java/com/rabbitmq/client/impl/Method.java
+++ b/src/main/java/com/rabbitmq/client/impl/Method.java
@@ -28,12 +28,15 @@ import com.rabbitmq.client.impl.AMQImpl.MethodVisitor;
  */
 public abstract class Method implements com.rabbitmq.client.Method {
     /** {@inheritDoc} */
+    @Override
     public abstract int protocolClassId(); /* properly an unsigned short */
 
     /** {@inheritDoc} */
+    @Override
     public abstract int protocolMethodId(); /* properly an unsigned short */
 
     /** {@inheritDoc} */
+    @Override
     public abstract String protocolMethodName();
 
     /**

--- a/src/main/java/com/rabbitmq/client/impl/PlainMechanism.java
+++ b/src/main/java/com/rabbitmq/client/impl/PlainMechanism.java
@@ -22,10 +22,12 @@ import com.rabbitmq.client.SaslMechanism;
  * The PLAIN auth mechanism
  */
 public class PlainMechanism implements SaslMechanism {
+    @Override
     public String getName() {
         return "PLAIN";
     }
 
+    @Override
     public LongString handleChallenge(LongString challenge,
                                       String username,
                                       String password) {

--- a/src/main/java/com/rabbitmq/client/impl/ShutdownNotifierComponent.java
+++ b/src/main/java/com/rabbitmq/client/impl/ShutdownNotifierComponent.java
@@ -43,6 +43,7 @@ public class ShutdownNotifierComponent implements ShutdownNotifier {
      */
     private volatile ShutdownSignalException shutdownCause = null;
 
+    @Override
     public void addShutdownListener(ShutdownListener listener)
     {
         ShutdownSignalException sse = null;
@@ -54,12 +55,14 @@ public class ShutdownNotifierComponent implements ShutdownNotifier {
             listener.shutdownCompleted(sse);
     }
 
+    @Override
     public ShutdownSignalException getCloseReason() {
         synchronized(this.monitor) {
             return this.shutdownCause;
         }
     }
 
+    @Override
     public void notifyListeners()
     {
         ShutdownSignalException sse = null;
@@ -78,6 +81,7 @@ public class ShutdownNotifierComponent implements ShutdownNotifier {
         }
     }
 
+    @Override
     public void removeShutdownListener(ShutdownListener listener)
     {
         synchronized(this.monitor) {
@@ -85,6 +89,7 @@ public class ShutdownNotifierComponent implements ShutdownNotifier {
         }
     }
 
+    @Override
     public boolean isOpen() {
         synchronized(this.monitor) {
             return this.shutdownCause == null;

--- a/src/main/java/com/rabbitmq/client/impl/SocketFrameHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/SocketFrameHandler.java
@@ -67,10 +67,12 @@ public class SocketFrameHandler implements FrameHandler {
         _outputStream = new DataOutputStream(new BufferedOutputStream(socket.getOutputStream()));
     }
 
+    @Override
     public InetAddress getAddress() {
         return _socket.getInetAddress();
     }
 
+    @Override
     public InetAddress getLocalAddress() {
         return _socket.getLocalAddress();
     }
@@ -80,20 +82,24 @@ public class SocketFrameHandler implements FrameHandler {
         return _inputStream;
     }
 
+    @Override
     public int getPort() {
         return _socket.getPort();
     }
 
+    @Override
     public int getLocalPort() {
         return _socket.getLocalPort();
     }
 
+    @Override
     public void setTimeout(int timeoutMs)
         throws SocketException
     {
         _socket.setSoTimeout(timeoutMs);
     }
 
+    @Override
     public int getTimeout()
         throws SocketException
     {
@@ -143,27 +149,31 @@ public class SocketFrameHandler implements FrameHandler {
         }
     }
 
+    @Override
     public void sendHeader() throws IOException {
         sendHeader(AMQP.PROTOCOL.MAJOR, AMQP.PROTOCOL.MINOR, AMQP.PROTOCOL.REVISION);
     }
 
+    @Override
     public Frame readFrame() throws IOException {
         synchronized (_inputStream) {
             return Frame.readFrom(_inputStream);
         }
     }
 
+    @Override
     public void writeFrame(Frame frame) throws IOException {
         synchronized (_outputStream) {
             frame.writeTo(_outputStream);
         }
     }
 
+    @Override
     public void flush() throws IOException {
         _outputStream.flush();
     }
 
-    @SuppressWarnings("unused")
+    @Override
     public void close() {
         try { _socket.setSoLinger(true, SOCKET_CLOSING_TIMEOUT); } catch (Exception _e) {}
         // async flush if possible

--- a/src/main/java/com/rabbitmq/client/impl/StrictExceptionHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/StrictExceptionHandler.java
@@ -30,22 +30,27 @@ import java.util.concurrent.TimeoutException;
  * @see com.rabbitmq.client.ConnectionFactory#setExceptionHandler(ExceptionHandler)
  */
 public class StrictExceptionHandler extends ForgivingExceptionHandler implements ExceptionHandler {
+    @Override
     public void handleReturnListenerException(Channel channel, Throwable exception) {
         handleChannelKiller(channel, exception, "ReturnListener.handleReturn");
     }
 
+    @Override
     public void handleFlowListenerException(Channel channel, Throwable exception) {
         handleChannelKiller(channel, exception, "FlowListener.handleFlow");
     }
 
+    @Override
     public void handleConfirmListenerException(Channel channel, Throwable exception) {
         handleChannelKiller(channel, exception, "ConfirmListener.handle{N,A}ck");
     }
 
+    @Override
     public void handleBlockedListenerException(Connection connection, Throwable exception) {
         handleConnectionKiller(connection, exception, "BlockedListener");
     }
 
+    @Override
     public void handleConsumerException(Channel channel, Throwable exception,
                                         Consumer consumer, String consumerTag,
                                         String methodName)
@@ -56,6 +61,7 @@ public class StrictExceptionHandler extends ForgivingExceptionHandler implements
                                                         + " for channel " + channel);
     }
 
+    @Override
     protected void handleChannelKiller(Channel channel, Throwable exception, String what) {
         log(what + " threw an exception for channel " + channel, exception);
         try {

--- a/src/main/java/com/rabbitmq/client/impl/TruncatedInputStream.java
+++ b/src/main/java/com/rabbitmq/client/impl/TruncatedInputStream.java
@@ -36,16 +36,19 @@ public class TruncatedInputStream extends FilterInputStream {
         this.limit = limit;
     }
 
-    @Override public int available() throws IOException {
+    @Override
+    public int available() throws IOException {
         return (int) Math.min(limit - counter, super.available());
     }
 
-    @Override public void mark(int readlimit) {
+    @Override
+    public void mark(int readlimit) {
         super.mark(readlimit);
         mark = counter;
     }
 
-    @Override public int read() throws IOException {
+    @Override
+    public int read() throws IOException {
         if (counter < limit) {
             int result = super.read();
             if (result >= 0)
@@ -55,7 +58,8 @@ public class TruncatedInputStream extends FilterInputStream {
             return -1;
     }
 
-    @Override public int read(byte[] b, int off, int len) throws IOException {
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
 
         if (limit > counter) {
             int result = super.read(b, off, (int) Math.min(len, limit - counter));
@@ -66,12 +70,14 @@ public class TruncatedInputStream extends FilterInputStream {
             return -1;
     }
 
-    @Override public void reset() throws IOException {
+    @Override
+    public void reset() throws IOException {
         super.reset();
         counter = mark;
     }
 
-    @Override public long skip(long n) throws IOException {
+    @Override
+    public long skip(long n) throws IOException {
         long result = super.skip(Math.min(n, limit - counter));
         counter += result;
         return result;

--- a/src/main/java/com/rabbitmq/client/impl/VariableLinkedBlockingQueue.java
+++ b/src/main/java/com/rabbitmq/client/impl/VariableLinkedBlockingQueue.java
@@ -229,6 +229,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
      *
      * @return  the number of elements in this queue.
      */
+    @Override
     public int size() {
         return count.get();
     }
@@ -261,6 +262,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
      * case that a waiting consumer is ready to <tt>take</tt> an
      * element out of an otherwise full queue.
      */
+    @Override
     public int remainingCapacity() {
         return capacity - count.get();
     }
@@ -272,6 +274,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
      * @throws InterruptedException if interrupted while waiting.
      * @throws NullPointerException if the specified element is <tt>null</tt>.
      */
+    @Override
     public void put(E o) throws InterruptedException {
         if (o == null) throw new NullPointerException();
         // Note: convention in all put/take/etc is to preset
@@ -321,6 +324,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
      * @throws InterruptedException if interrupted while waiting.
      * @throws NullPointerException if the specified element is <tt>null</tt>.
      */
+    @Override
     public boolean offer(E o, long timeout, TimeUnit unit)
         throws InterruptedException {
 
@@ -365,6 +369,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
      *         this queue, else <tt>false</tt>
      * @throws NullPointerException if the specified element is <tt>null</tt>
      */
+    @Override
     public boolean offer(E o) {
         if (o == null) throw new NullPointerException();
         final AtomicInteger count = this.count;
@@ -389,6 +394,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
     }
 
 
+    @Override
     public E take() throws InterruptedException {
         E x;
         int c = -1;
@@ -416,6 +422,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         return x;
     }
 
+    @Override
     public E poll(long timeout, TimeUnit unit) throws InterruptedException {
         E x = null;
         int c = -1;
@@ -449,6 +456,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         return x;
     }
 
+    @Override
     public E poll() {
         final AtomicInteger count = this.count;
         if (count.get() == 0)
@@ -473,6 +481,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
     }
 
 
+    @Override
     public E peek() {
         if (count.get() == 0)
             return null;
@@ -489,6 +498,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         }
     }
 
+    @Override
     public boolean remove(Object o) {
         if (o == null) return false;
         boolean removed = false;
@@ -516,6 +526,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         return removed;
     }
 
+    @Override
     public Object[] toArray() {
         fullyLock();
         try {
@@ -530,6 +541,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         }
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public <T> T[] toArray(T[] a) {
         fullyLock();
@@ -540,7 +552,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
                     (a.getClass().getComponentType(), size);
 
             int k = 0;
-            for (Node p = head.next; p != null; p = p.next)
+            for (Node<?> p = head.next; p != null; p = p.next)
                 a[k++] = (T)p.item;
             return a;
         } finally {
@@ -548,6 +560,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         }
     }
 
+    @Override
     public String toString() {
         fullyLock();
         try {
@@ -557,6 +570,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         }
     }
 
+    @Override
     public void clear() {
         fullyLock();
         try {
@@ -568,6 +582,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         }
     }
 
+    @Override
     public int drainTo(Collection<? super E> c) {
         if (c == null)
             throw new NullPointerException();
@@ -593,6 +608,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
         return n;
     }
         
+    @Override
     public int drainTo(Collection<? super E> c, int maxElements) {
         if (c == null)
             throw new NullPointerException();
@@ -631,6 +647,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
      *
      * @return an iterator over the elements in this queue in proper sequence.
      */
+    @Override
     public Iterator<E> iterator() {
       return new Itr();
     }
@@ -660,10 +677,12 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
             }
         }
 
+        @Override
         public boolean hasNext() {
             return current != null;
         }
 
+        @Override
         public E next() {
             final ReentrantLock putLock = VariableLinkedBlockingQueue.this.putLock;
             final ReentrantLock takeLock = VariableLinkedBlockingQueue.this.takeLock;
@@ -684,6 +703,7 @@ public class VariableLinkedBlockingQueue<E> extends AbstractQueue<E>
             }
         }
 
+        @Override
         public void remove() {
             if (lastRet == null)
                 throw new IllegalStateException();

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
@@ -47,10 +47,12 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         this.delegate = delegate;
     }
 
+    @Override
     public int getChannelNumber() {
         return delegate.getChannelNumber();
     }
 
+    @Override
     public Connection getConnection() {
         return delegate.getConnection();
     }
@@ -59,6 +61,7 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         return delegate;
     }
 
+    @Override
     public void close() throws IOException, TimeoutException {
         try {
           delegate.close();
@@ -67,6 +70,7 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         }
     }
 
+    @Override
     public void close(int closeCode, String closeMessage) throws IOException, TimeoutException {
         try {
           delegate.close(closeCode, closeMessage);
@@ -75,79 +79,90 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @Override
     @Deprecated
     public boolean flowBlocked() {
         return delegate.flowBlocked();
     }
 
+    @Override
     public void abort() throws IOException {
         delegate.abort();
     }
 
+    @Override
     public void abort(int closeCode, String closeMessage) throws IOException {
         delegate.abort(closeCode, closeMessage);
     }
 
+    @Override
     public void addReturnListener(ReturnListener listener) {
         this.returnListeners.add(listener);
         delegate.addReturnListener(listener);
     }
 
+    @Override
     public boolean removeReturnListener(ReturnListener listener) {
         this.returnListeners.remove(listener);
         return delegate.removeReturnListener(listener);
     }
 
+    @Override
     public void clearReturnListeners() {
         this.returnListeners.clear();
         delegate.clearReturnListeners();
     }
 
-    @SuppressWarnings("deprecation")
+    @Override
     @Deprecated
     public void addFlowListener(FlowListener listener) {
         this.flowListeners.add(listener);
         delegate.addFlowListener(listener);
     }
 
-    @SuppressWarnings("deprecation")
+    @Override
     @Deprecated
     public boolean removeFlowListener(FlowListener listener) {
         this.flowListeners.remove(listener);
         return delegate.removeFlowListener(listener);
     }
 
-    @SuppressWarnings("deprecation")
+    @Override
     @Deprecated
     public void clearFlowListeners() {
         this.flowListeners.clear();
         delegate.clearFlowListeners();
     }
 
+    @Override
     public void addConfirmListener(ConfirmListener listener) {
         this.confirmListeners.add(listener);
         delegate.addConfirmListener(listener);
     }
 
+    @Override
     public boolean removeConfirmListener(ConfirmListener listener) {
         this.confirmListeners.remove(listener);
         return delegate.removeConfirmListener(listener);
     }
 
+    @Override
     public void clearConfirmListeners() {
         this.confirmListeners.clear();
         delegate.clearConfirmListeners();
     }
 
+    @Override
     public Consumer getDefaultConsumer() {
         return delegate.getDefaultConsumer();
     }
 
+    @Override
     public void setDefaultConsumer(Consumer consumer) {
         delegate.setDefaultConsumer(consumer);
     }
 
+    @Override
     public void basicQos(int prefetchSize, int prefetchCount, boolean global) throws IOException {
         if (global) {
             this.prefetchCountGlobal = prefetchCount;
@@ -158,50 +173,62 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         delegate.basicQos(prefetchSize, prefetchCount, global);
     }
 
+    @Override
     public void basicQos(int prefetchCount) throws IOException {
         basicQos(0, prefetchCount, false);
     }
 
+    @Override
     public void basicQos(int prefetchCount, boolean global) throws IOException {
         basicQos(0, prefetchCount, global);
     }
 
+    @Override
     public void basicPublish(String exchange, String routingKey, AMQP.BasicProperties props, byte[] body) throws IOException {
         delegate.basicPublish(exchange, routingKey, props, body);
     }
 
+    @Override
     public void basicPublish(String exchange, String routingKey, boolean mandatory, AMQP.BasicProperties props, byte[] body) throws IOException {
         delegate.basicPublish(exchange, routingKey, mandatory, props, body);
     }
 
+    @Override
     public void basicPublish(String exchange, String routingKey, boolean mandatory, boolean immediate, AMQP.BasicProperties props, byte[] body) throws IOException {
         delegate.basicPublish(exchange, routingKey, mandatory, immediate, props, body);
     }
 
+    @Override
     public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, String type) throws IOException {
         return exchangeDeclare(exchange, type, false, false, null);
     }
 
+    @Override
     public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type) throws IOException {
         return exchangeDeclare(exchange, type.getType());
     }
 
+    @Override
     public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, String type, boolean durable) throws IOException {
         return exchangeDeclare(exchange, type, durable, false, null);
     }
 
+    @Override
     public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type, boolean durable) throws IOException {
         return exchangeDeclare(exchange, type.getType(), durable);
     }
 
+    @Override
     public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, Map<String, Object> arguments) throws IOException {
         return exchangeDeclare(exchange, type, durable, autoDelete, false, arguments);
     }
 
+    @Override
     public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type, boolean durable, boolean autoDelete, Map<String, Object> arguments) throws IOException {
         return exchangeDeclare(exchange, type.getType(), durable, autoDelete, arguments);
     }
 
+    @Override
     public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, boolean internal, Map<String, Object> arguments) throws IOException {
         final AMQP.Exchange.DeclareOk ok = delegate.exchangeDeclare(exchange, type, durable, autoDelete, internal, arguments);
         RecordedExchange x = new RecordedExchange(this, exchange).
@@ -213,6 +240,7 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         return ok;
     }
 
+    @Override
     public AMQP.Exchange.DeclareOk exchangeDeclare(String exchange, BuiltinExchangeType type, boolean durable, boolean autoDelete, boolean internal, Map<String, Object> arguments) throws IOException {
         return exchangeDeclare(exchange, type.getType(), durable, autoDelete, internal, arguments);
     }
@@ -233,58 +261,70 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         exchangeDeclareNoWait(exchange, type.getType(), durable, autoDelete, internal, arguments);
     }
 
+    @Override
     public AMQP.Exchange.DeclareOk exchangeDeclarePassive(String name) throws IOException {
         return delegate.exchangeDeclarePassive(name);
     }
 
+    @Override
     public AMQP.Exchange.DeleteOk exchangeDelete(String exchange, boolean ifUnused) throws IOException {
         deleteRecordedExchange(exchange);
         return delegate.exchangeDelete(exchange, ifUnused);
     }
 
+    @Override
     public void exchangeDeleteNoWait(String exchange, boolean ifUnused) throws IOException {
         deleteRecordedExchange(exchange);
         delegate.exchangeDeleteNoWait(exchange, ifUnused);
     }
 
+    @Override
     public AMQP.Exchange.DeleteOk exchangeDelete(String exchange) throws IOException {
         return exchangeDelete(exchange, false);
     }
 
+    @Override
     public AMQP.Exchange.BindOk exchangeBind(String destination, String source, String routingKey) throws IOException {
         return exchangeBind(destination, source, routingKey, null);
     }
 
+    @Override
     public AMQP.Exchange.BindOk exchangeBind(String destination, String source, String routingKey, Map<String, Object> arguments) throws IOException {
         final AMQP.Exchange.BindOk ok = delegate.exchangeBind(destination, source, routingKey, arguments);
         recordExchangeBinding(destination, source, routingKey, arguments);
         return ok;
     }
 
+    @Override
     public void exchangeBindNoWait(String destination, String source, String routingKey, Map<String, Object> arguments) throws IOException {
         delegate.exchangeBindNoWait(destination, source, routingKey, arguments);
         recordExchangeBinding(destination, source, routingKey, arguments);
     }
 
+    @Override
     public AMQP.Exchange.UnbindOk exchangeUnbind(String destination, String source, String routingKey) throws IOException {
         return exchangeUnbind(destination, source, routingKey, null);
     }
 
+    @Override
     public AMQP.Exchange.UnbindOk exchangeUnbind(String destination, String source, String routingKey, Map<String, Object> arguments) throws IOException {
         deleteRecordedExchangeBinding(destination, source, routingKey, arguments);
         this.maybeDeleteRecordedAutoDeleteExchange(source);
         return delegate.exchangeUnbind(destination, source, routingKey, arguments);
     }
 
+    @Override
     public void exchangeUnbindNoWait(String destination, String source, String routingKey, Map<String, Object> arguments) throws IOException {
         delegate.exchangeUnbindNoWait(destination, source, routingKey, arguments);
         deleteRecordedExchangeBinding(destination, source, routingKey, arguments);
     }
 
+    @Override
     public AMQP.Queue.DeclareOk queueDeclare() throws IOException {
         return queueDeclare("", false, true, true, null);
     }
 
+    @Override
     public AMQP.Queue.DeclareOk queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, Map<String, Object> arguments) throws IOException {
         final AMQP.Queue.DeclareOk ok = delegate.queueDeclare(queue, durable, exclusive, autoDelete, arguments);
         RecordedQueue q = new RecordedQueue(this, ok.getQueue()).
@@ -299,6 +339,7 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         return ok;
     }
 
+    @Override
     public void queueDeclareNoWait(String queue,
                                    boolean durable,
                                    boolean exclusive,
@@ -314,99 +355,121 @@ public class AutorecoveringChannel implements Channel, Recoverable {
 
     }
 
+    @Override
     public AMQP.Queue.DeclareOk queueDeclarePassive(String queue) throws IOException {
         return delegate.queueDeclarePassive(queue);
     }
 
+    @Override
     public long messageCount(String queue) throws IOException {
         return delegate.messageCount(queue);
     }
 
+    @Override
     public long consumerCount(String queue) throws IOException {
         return delegate.consumerCount(queue);
     }
 
+    @Override
     public AMQP.Queue.DeleteOk queueDelete(String queue) throws IOException {
         return queueDelete(queue, false, false);
     }
 
+    @Override
     public AMQP.Queue.DeleteOk queueDelete(String queue, boolean ifUnused, boolean ifEmpty) throws IOException {
         deleteRecordedQueue(queue);
         return delegate.queueDelete(queue, ifUnused, ifEmpty);
     }
 
+    @Override
     public void queueDeleteNoWait(String queue, boolean ifUnused, boolean ifEmpty) throws IOException {
         deleteRecordedQueue(queue);
         delegate.queueDeleteNoWait(queue, ifUnused, ifEmpty);
     }
 
+    @Override
     public AMQP.Queue.BindOk queueBind(String queue, String exchange, String routingKey) throws IOException {
         return queueBind(queue, exchange, routingKey, null);
     }
 
+    @Override
     public AMQP.Queue.BindOk queueBind(String queue, String exchange, String routingKey, Map<String, Object> arguments) throws IOException {
         AMQP.Queue.BindOk ok = delegate.queueBind(queue, exchange, routingKey, arguments);
         recordQueueBinding(queue, exchange, routingKey, arguments);
         return ok;
     }
 
+    @Override
     public void queueBindNoWait(String queue, String exchange, String routingKey, Map<String, Object> arguments) throws IOException {
         delegate.queueBindNoWait(queue, exchange, routingKey, arguments);
         recordQueueBinding(queue, exchange, routingKey, arguments);
     }
 
+    @Override
     public AMQP.Queue.UnbindOk queueUnbind(String queue, String exchange, String routingKey) throws IOException {
         return queueUnbind(queue, exchange, routingKey, null);
     }
 
+    @Override
     public AMQP.Queue.UnbindOk queueUnbind(String queue, String exchange, String routingKey, Map<String, Object> arguments) throws IOException {
         deleteRecordedQueueBinding(queue, exchange, routingKey, arguments);
         this.maybeDeleteRecordedAutoDeleteExchange(exchange);
         return delegate.queueUnbind(queue, exchange, routingKey, arguments);
     }
 
+    @Override
     public AMQP.Queue.PurgeOk queuePurge(String queue) throws IOException {
         return delegate.queuePurge(queue);
     }
 
+    @Override
     public GetResponse basicGet(String queue, boolean autoAck) throws IOException {
         return delegate.basicGet(queue, autoAck);
     }
 
+    @Override
     public void basicAck(long deliveryTag, boolean multiple) throws IOException {
         delegate.basicAck(deliveryTag, multiple);
     }
 
+    @Override
     public void basicNack(long deliveryTag, boolean multiple, boolean requeue) throws IOException {
         delegate.basicNack(deliveryTag, multiple, requeue);
     }
 
+    @Override
     public void basicReject(long deliveryTag, boolean requeue) throws IOException {
         delegate.basicReject(deliveryTag, requeue);
     }
 
+    @Override
     public String basicConsume(String queue, Consumer callback) throws IOException {
         return basicConsume(queue, false, callback);
     }
 
+    @Override
     public String basicConsume(String queue, boolean autoAck, Consumer callback) throws IOException {
         return basicConsume(queue, autoAck, "", callback);
     }
 
+    @Override
     public String basicConsume(String queue, boolean autoAck, String consumerTag, Consumer callback) throws IOException {
         return basicConsume(queue, autoAck, consumerTag, false, false, null, callback);
     }
 
+    @Override
     public String basicConsume(String queue, boolean autoAck, Map<String, Object> arguments, Consumer callback) throws IOException {
         return basicConsume(queue, autoAck, "", false, false, arguments, callback);
     }
 
+    @Override
     public String basicConsume(String queue, boolean autoAck, String consumerTag, boolean noLocal, boolean exclusive, Map<String, Object> arguments, Consumer callback) throws IOException {
         final String result = delegate.basicConsume(queue, autoAck, consumerTag, noLocal, exclusive, arguments, callback);
         recordConsumer(result, queue, autoAck, exclusive, arguments, callback);
         return result;
     }
 
+    @Override
     public void basicCancel(String consumerTag) throws IOException {
         RecordedConsumer c = this.deleteRecordedConsumer(consumerTag);
         if(c != null) {
@@ -415,56 +478,69 @@ public class AutorecoveringChannel implements Channel, Recoverable {
         delegate.basicCancel(consumerTag);
     }
 
+    @Override
     public AMQP.Basic.RecoverOk basicRecover() throws IOException {
         return delegate.basicRecover();
     }
 
+    @Override
     public AMQP.Basic.RecoverOk basicRecover(boolean requeue) throws IOException {
         return delegate.basicRecover(requeue);
     }
 
+    @Override
     public AMQP.Tx.SelectOk txSelect() throws IOException {
         this.usesTransactions = true;
         return delegate.txSelect();
     }
 
+    @Override
     public AMQP.Tx.CommitOk txCommit() throws IOException {
         return delegate.txCommit();
     }
 
+    @Override
     public AMQP.Tx.RollbackOk txRollback() throws IOException {
         return delegate.txRollback();
     }
 
+    @Override
     public AMQP.Confirm.SelectOk confirmSelect() throws IOException {
         this.usesPublisherConfirms = true;
         return delegate.confirmSelect();
     }
 
+    @Override
     public long getNextPublishSeqNo() {
         return delegate.getNextPublishSeqNo();
     }
 
+    @Override
     public boolean waitForConfirms() throws InterruptedException {
         return delegate.waitForConfirms();
     }
 
+    @Override
     public boolean waitForConfirms(long timeout) throws InterruptedException, TimeoutException {
         return delegate.waitForConfirms(timeout);
     }
 
+    @Override
     public void waitForConfirmsOrDie() throws IOException, InterruptedException {
         delegate.waitForConfirmsOrDie();
     }
 
+    @Override
     public void waitForConfirmsOrDie(long timeout) throws IOException, InterruptedException, TimeoutException {
         delegate.waitForConfirmsOrDie(timeout);
     }
 
+    @Override
     public void asyncRpc(Method method) throws IOException {
         delegate.asyncRpc(method);
     }
 
+    @Override
     public Command rpc(Method method) throws IOException {
         return delegate.rpc(method);
     }
@@ -472,32 +548,39 @@ public class AutorecoveringChannel implements Channel, Recoverable {
     /**
      * @see Connection#addShutdownListener(com.rabbitmq.client.ShutdownListener)
      */
+    @Override
     public void addShutdownListener(ShutdownListener listener) {
         this.shutdownHooks.add(listener);
         delegate.addShutdownListener(listener);
     }
 
+    @Override
     public void removeShutdownListener(ShutdownListener listener) {
         this.shutdownHooks.remove(listener);
         delegate.removeShutdownListener(listener);
     }
 
+    @Override
     public ShutdownSignalException getCloseReason() {
         return delegate.getCloseReason();
     }
 
+    @Override
     public void notifyListeners() {
         delegate.notifyListeners();
     }
 
+    @Override
     public boolean isOpen() {
         return delegate.isOpen();
     }
 
+    @Override
     public void addRecoveryListener(RecoveryListener listener) {
         this.recoveryListeners.add(listener);
     }
 
+    @Override
     public void removeRecoveryListener(RecoveryListener listener) {
         this.recoveryListeners.remove(listener);
     }
@@ -509,7 +592,11 @@ public class AutorecoveringChannel implements Channel, Recoverable {
     public void automaticallyRecover(AutorecoveringConnection connection, Connection connDelegate) throws IOException {
         RecoveryAwareChannelN defunctChannel = this.delegate;
         this.connection = connection;
-        this.delegate = (RecoveryAwareChannelN) connDelegate.createChannel(this.getChannelNumber());
+        
+        final RecoveryAwareChannelN newChannel = (RecoveryAwareChannelN) connDelegate.createChannel(this.getChannelNumber());
+        if (newChannel == null)
+            throw new IOException("Failed to create new channel for channel number=" + this.getChannelNumber() + " during recovery");
+        this.delegate = newChannel;
         this.delegate.inheritOffsetFrom(defunctChannel);
 
         this.recoverShutdownListeners();
@@ -539,7 +626,6 @@ public class AutorecoveringChannel implements Channel, Recoverable {
     }
 
     @Deprecated
-    @SuppressWarnings("deprecation")
     private void recoverFlowListeners() {
         for(FlowListener fl : this.flowListeners) {
             this.delegate.addFlowListener(fl);

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -103,17 +103,13 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      */
     public void init() throws IOException, TimeoutException {
         this.delegate = this.cf.newConnection();
-        this.addAutomaticRecoveryListener();
-    }
-
-    public void start() throws IOException {
-        // no-op, AMQConnection#start is executed in ConnectionFactory#newConnection
-        // and invoking it again will result in a framing error. MK.
+        this.addAutomaticRecoveryListener(delegate);
     }
 
     /**
      * @see com.rabbitmq.client.Connection#createChannel()
      */
+    @Override
     public Channel createChannel() throws IOException {
         RecoveryAwareChannelN ch = (RecoveryAwareChannelN) delegate.createChannel();
         if (ch == null) {
@@ -126,6 +122,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#createChannel(int)
      */
+    @Override
     public Channel createChannel(int channelNumber) throws IOException {
         return delegate.createChannel(channelNumber);
     }
@@ -159,6 +156,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#getServerProperties()
      */
+    @Override
     public Map<String, Object> getServerProperties() {
         return delegate.getServerProperties();
     }
@@ -166,6 +164,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#getClientProperties()
      */
+    @Override
     public Map<String, Object> getClientProperties() {
         return delegate.getClientProperties();
     }
@@ -175,6 +174,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see ConnectionFactory#newConnection(Address[], String)
      * @see ConnectionFactory#newConnection(ExecutorService, Address[], String)
      */
+    @Override
     public String getClientProvidedName() {
         return delegate.getClientProvidedName();
     }
@@ -182,6 +182,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#getFrameMax()
      */
+    @Override
     public int getFrameMax() {
         return delegate.getFrameMax();
     }
@@ -189,6 +190,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#getHeartbeat()
      */
+    @Override
     public int getHeartbeat() {
         return delegate.getHeartbeat();
     }
@@ -196,6 +198,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#getChannelMax()
      */
+    @Override
     public int getChannelMax() {
         return delegate.getChannelMax();
     }
@@ -203,6 +206,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#isOpen()
      */
+    @Override
     public boolean isOpen() {
         return delegate.isOpen();
     }
@@ -210,6 +214,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#close()
      */
+    @Override
     public void close() throws IOException {
 		synchronized(recoveryLock) {
 			this.manuallyClosed = true;
@@ -220,6 +225,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see Connection#close(int)
      */
+    @Override
     public void close(int timeout) throws IOException {
 		synchronized(recoveryLock) {
 			this.manuallyClosed = true;
@@ -230,6 +236,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see Connection#close(int, String, int)
      */
+    @Override
     public void close(int closeCode, String closeMessage, int timeout) throws IOException {
 		synchronized(recoveryLock) {
 			this.manuallyClosed = true;
@@ -240,6 +247,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#abort()
      */
+    @Override
     public void abort() {
 		synchronized(recoveryLock) {
 			this.manuallyClosed = true;
@@ -250,6 +258,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see Connection#abort(int, String, int)
      */
+    @Override
     public void abort(int closeCode, String closeMessage, int timeout) {
 		synchronized(recoveryLock) {
 			this.manuallyClosed = true;
@@ -260,6 +269,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see Connection#abort(int, String)
      */
+    @Override
     public void abort(int closeCode, String closeMessage) {
 		synchronized(recoveryLock) {
 			this.manuallyClosed = true;
@@ -270,6 +280,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see Connection#abort(int)
      */
+    @Override
     public void abort(int timeout) {
 		synchronized(recoveryLock) {
 			this.manuallyClosed = true;
@@ -287,6 +298,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#getCloseReason()
      */
+    @Override
     public ShutdownSignalException getCloseReason() {
         return delegate.getCloseReason();
     }
@@ -294,6 +306,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.ShutdownNotifier#addShutdownListener(com.rabbitmq.client.ShutdownListener)
      */
+    @Override
     public void addBlockedListener(BlockedListener listener) {
         this.blockedListeners.add(listener);
         delegate.addBlockedListener(listener);
@@ -302,6 +315,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see Connection#removeBlockedListener(com.rabbitmq.client.BlockedListener)
      */
+    @Override
     public boolean removeBlockedListener(BlockedListener listener) {
         this.blockedListeners.remove(listener);
         return delegate.removeBlockedListener(listener);
@@ -310,6 +324,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#clearBlockedListeners()
      */
+    @Override
     public void clearBlockedListeners() {
         this.blockedListeners.clear();
         delegate.clearBlockedListeners();
@@ -318,6 +333,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#close(int, String)
      */
+    @Override
     public void close(int closeCode, String closeMessage) throws IOException {
 		synchronized(recoveryLock) {
 			this.manuallyClosed = true;
@@ -328,6 +344,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see Connection#addShutdownListener(com.rabbitmq.client.ShutdownListener)
      */
+    @Override
     public void addShutdownListener(ShutdownListener listener) {
         this.shutdownHooks.add(listener);
         delegate.addShutdownListener(listener);
@@ -336,6 +353,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.ShutdownNotifier#removeShutdownListener(com.rabbitmq.client.ShutdownListener)
      */
+    @Override
     public void removeShutdownListener(ShutdownListener listener) {
         this.shutdownHooks.remove(listener);
         delegate.removeShutdownListener(listener);
@@ -344,6 +362,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.ShutdownNotifier#notifyListeners()
      */
+    @Override
     public void notifyListeners() {
         delegate.notifyListeners();
     }
@@ -352,6 +371,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * Adds the recovery listener
      * @param listener {@link com.rabbitmq.client.RecoveryListener} to execute after this connection recovers from network failure
      */
+    @Override
     public void addRecoveryListener(RecoveryListener listener) {
         this.recoveryListeners.add(listener);
     }
@@ -360,6 +380,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * Removes the recovery listener
      * @param listener {@link com.rabbitmq.client.RecoveryListener} to remove
      */
+    @Override
     public void removeRecoveryListener(RecoveryListener listener) {
         this.recoveryListeners.remove(listener);
     }
@@ -367,7 +388,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.impl.AMQConnection#getExceptionHandler()
      */
-    @SuppressWarnings("unused")
+    @Override
     public ExceptionHandler getExceptionHandler() {
         return this.delegate.getExceptionHandler();
     }
@@ -375,6 +396,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#getPort()
      */
+    @Override
     public int getPort() {
         return delegate.getPort();
     }
@@ -382,6 +404,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @see com.rabbitmq.client.Connection#getAddress()
      */
+    @Override
     public InetAddress getAddress() {
         return delegate.getAddress();
     }
@@ -389,6 +412,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @return client socket address
      */
+    @Override
     public InetAddress getLocalAddress() {
         return this.delegate.getLocalAddress();
     }
@@ -396,6 +420,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     /**
      * @return client socket port
      */
+    @Override
     public int getLocalPort() {
         return this.delegate.getLocalPort();
     }
@@ -404,23 +429,24 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
     // Recovery
     //
 
-    private void addAutomaticRecoveryListener() {
+    private void addAutomaticRecoveryListener(final RecoveryAwareAMQConnection newConn) {
         final AutorecoveringConnection c = this;
         // this listener will run after shutdown listeners,
         // see https://github.com/rabbitmq/rabbitmq-java-client/issues/135
         RecoveryCanBeginListener starter = new RecoveryCanBeginListener() {
+            @Override
             public void recoveryCanBegin(ShutdownSignalException cause) {
                 try {
                     if (shouldTriggerConnectionRecovery(cause)) {
                         c.beginAutomaticRecovery();
                     }
                 } catch (Exception e) {
-                    c.delegate.getExceptionHandler().handleConnectionRecoveryException(c, e);
+                    newConn.getExceptionHandler().handleConnectionRecoveryException(c, e);
                 }
             }
         };
         synchronized (this) {
-            this.delegate.addRecoveryCanBeginListener(starter);
+            newConn.addRecoveryCanBeginListener(starter);
         }
     }
 
@@ -443,7 +469,6 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see com.rabbitmq.client.impl.recovery.AutorecoveringConnection#addQueueRecoveryListener
      * @param listener listener to be removed
      */
-    @SuppressWarnings("unused")
     public void removeQueueRecoveryListener(QueueRecoveryListener listener) {
         this.queueRecoveryListeners.remove(listener);
     }
@@ -463,60 +488,61 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
      * @see com.rabbitmq.client.impl.recovery.AutorecoveringConnection#addConsumerRecoveryListener(ConsumerRecoveryListener)
      * @param listener listener to be removed
      */
-    @SuppressWarnings("unused")
     public void removeConsumerRecoveryListener(ConsumerRecoveryListener listener) {
         this.consumerRecoveryListeners.remove(listener);
     }
 
-    synchronized private void beginAutomaticRecovery() throws InterruptedException, IOException, TopologyRecoveryException {
+    synchronized private void beginAutomaticRecovery() throws InterruptedException {
         Thread.sleep(this.params.getNetworkRecoveryInterval());
-        if (!this.recoverConnection()) {
+        final RecoveryAwareAMQConnection newConn = this.recoverConnection();
+        if (newConn == null) {
             return;
         }
 
-        this.addAutomaticRecoveryListener();
-		    this.recoverShutdownListeners();
-		    this.recoverBlockedListeners();
-		    this.recoverChannels();
-		    if(this.params.isTopologyRecoveryEnabled()) {
-			      this.recoverEntities();
-			      this.recoverConsumers();
-		    }
+        this.addAutomaticRecoveryListener(newConn);
+	    this.recoverShutdownListeners(newConn);
+	    this.recoverBlockedListeners(newConn);
+	    this.recoverChannels(newConn);
+	    // don't assign new delegate connection until channel recovery is complete
+	    this.delegate = newConn;
+	    if(this.params.isTopologyRecoveryEnabled()) {
+		      this.recoverEntities();
+		      this.recoverConsumers();
+	    }
 
-		    this.notifyRecoveryListeners();
+	    this.notifyRecoveryListeners();
     }
 
-    private void recoverShutdownListeners() {
+    private void recoverShutdownListeners(final RecoveryAwareAMQConnection newConn) {
         for (ShutdownListener sh : this.shutdownHooks) {
-            this.delegate.addShutdownListener(sh);
+            newConn.addShutdownListener(sh);
         }
     }
 
-    private void recoverBlockedListeners() {
+    private void recoverBlockedListeners(final RecoveryAwareAMQConnection newConn) {
         for (BlockedListener bl : this.blockedListeners) {
-            this.delegate.addBlockedListener(bl);
+            newConn.addBlockedListener(bl);
         }
     }
 
-	// Returns true if the connection was recovered, 
-	// false if application initiated shutdown while attempting recovery.  
-    private boolean recoverConnection() throws IOException, InterruptedException {
+	// Returns new connection if the connection was recovered, 
+	// null if application initiated shutdown while attempting recovery.  
+    private RecoveryAwareAMQConnection recoverConnection() throws InterruptedException {
         while (!manuallyClosed)
 		{
             try {
 				RecoveryAwareAMQConnection newConn = this.cf.newConnection();
 				synchronized(recoveryLock) {
 					if (!manuallyClosed) {
-						// This is the standard case.
-						this.delegate = newConn;					
-						return true;
+						// This is the standard case.				
+						return newConn;
 					}
 				}
 				// This is the once in a blue moon case.  
 				// Application code just called close as the connection
 				// was being re-established.  So we attempt to close the newly created connection.
 				newConn.abort();
-				return false;
+				return null;
             } catch (Exception e) {
                 // TODO: exponential back-off
                 Thread.sleep(this.params.getNetworkRecoveryInterval());
@@ -524,15 +550,15 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
             }
         }
 		
-		return false;
+		return null;
     }
 
-    private void recoverChannels() {
+    private void recoverChannels(final RecoveryAwareAMQConnection newConn) {
         for (AutorecoveringChannel ch : this.channels.values()) {
             try {
-                ch.automaticallyRecover(this, this.delegate);
+                ch.automaticallyRecover(this, newConn);
             } catch (Throwable t) {
-                this.delegate.getExceptionHandler().handleChannelRecoveryException(ch, t);
+                newConn.getExceptionHandler().handleChannelRecoveryException(ch, t);
             }
         }
     }
@@ -543,7 +569,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
         }
     }
 
-    private void recoverEntities() throws TopologyRecoveryException {
+    private void recoverEntities() {
         // The recovery sequence is the following:
         //
         // 1. Recover exchanges
@@ -579,19 +605,21 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
             try {
                 q.recover();
                 String newName = q.getName();
-                // make sure server-named queues are re-added with
-                // their new names. MK.
-                synchronized (this.recordedQueues) {
-                    this.propagateQueueNameChangeToBindings(oldName, newName);
-                    this.propagateQueueNameChangeToConsumers(oldName, newName);
-                    // bug26552:
-                    // remove old name after we've updated the bindings and consumers,
-                    // plus only for server-named queues, both to make sure we don't lose
-                    // anything to recover. MK.
-                    if(q.isServerNamed()) {
-                        deleteRecordedQueue(oldName);
+                if (!oldName.equals(newName)) {
+                    // make sure server-named queues are re-added with
+                    // their new names. MK.
+                    synchronized (this.recordedQueues) {
+                        this.propagateQueueNameChangeToBindings(oldName, newName);
+                        this.propagateQueueNameChangeToConsumers(oldName, newName);
+                        // bug26552:
+                        // remove old name after we've updated the bindings and consumers,
+                        // plus only for server-named queues, both to make sure we don't lose
+                        // anything to recover. MK.
+                        if(q.isServerNamed()) {
+                            deleteRecordedQueue(oldName);
+                        }
+                        this.recordedQueues.put(newName, q);
                     }
-                    this.recordedQueues.put(newName, q);
                 }
                 for(QueueRecoveryListener qrl : this.queueRecoveryListeners) {
                     qrl.queueRecovered(oldName, newName);
@@ -669,9 +697,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
                                          destination(queue).
                                          routingKey(routingKey).
                                          arguments(arguments);
-        if (this.recordedBindings.contains(binding)) {
-            this.recordedBindings.remove(binding);
-        }
+        this.recordedBindings.remove(binding);
         this.recordedBindings.add(binding);
     }
 
@@ -698,9 +724,7 @@ public class AutorecoveringConnection implements Connection, Recoverable, Networ
                                           destination(destination).
                                           routingKey(routingKey).
                                           arguments(arguments);
-        if (this.recordedBindings.contains(binding)) {
-            this.recordedBindings.remove(binding);
-        }
+        this.recordedBindings.remove(binding);
         this.recordedBindings.add(binding);
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedBinding.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedBinding.java
@@ -67,9 +67,7 @@ public abstract class RecordedBinding extends RecordedEntity {
         this.destination = destination;
     }
 
-    public void recover() throws IOException {
-        // Implemented by subclasses
-    }
+    public abstract void recover() throws IOException;
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedExchangeBinding.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedExchangeBinding.java
@@ -25,6 +25,7 @@ public class RecordedExchangeBinding extends RecordedBinding {
         super(channel);
     }
 
+    @Override
     public void recover() throws IOException {
         this.channel.getDelegate().exchangeBind(this.destination, this.source, this.routingKey, this.arguments);
     }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueueBinding.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueueBinding.java
@@ -25,6 +25,7 @@ public class RecordedQueueBinding extends RecordedBinding {
         super(channel);
     }
 
+    @Override
     public void recover() throws IOException {
         this.channel.getDelegate().queueBind(this.getDestination(), this.getSource(), this.routingKey, this.arguments);
     }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnectionFactory.java
@@ -70,7 +70,7 @@ public class RecoveryAwareAMQConnectionFactory {
         throw (lastException != null) ? lastException : new IOException("failed to connect");
     }
 
-    private List<Address> shuffle(List<Address> addrs) {
+    private static List<Address> shuffle(List<Address> addrs) {
         List<Address> list = new ArrayList<Address>(addrs);
         Collections.shuffle(list);
         return list;

--- a/src/main/java/com/rabbitmq/tools/Tracer.java
+++ b/src/main/java/com/rabbitmq/tools/Tracer.java
@@ -178,6 +178,7 @@ public class Tracer implements Runnable {
         }
     }
 
+    @Override
     public void run() {
         try {
             byte[] handshake = new byte[8];
@@ -323,6 +324,7 @@ public class Tracer implements Runnable {
             }
         }
 
+        @Override
         public void run() {
             try {
                 while (true) {
@@ -442,6 +444,7 @@ public class Tracer implements Runnable {
                     flushInterval, this.queue);
         }
 
+        @Override
         public void log(String message) {
             if (message != null) {
                 try {
@@ -452,6 +455,7 @@ public class Tracer implements Runnable {
             }
         }
 
+        @Override
         public boolean start() {
             if (this.countStarted.testZeroAndIncrement()) {
                 this.loggerThread = new Thread(this.loggerRunnable);
@@ -461,6 +465,7 @@ public class Tracer implements Runnable {
             return false; // meaning already started
         }
 
+        @Override
         public boolean stop() {
             if (this.countStarted.decrementAndTestZero()) {
                 if (this.loggerThread != null) {
@@ -489,6 +494,7 @@ public class Tracer implements Runnable {
                 this.queue = queue;
             }
 
+            @Override
             public void run() {
                 try {
                     long timeOfNextFlush = System.currentTimeMillis()

--- a/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcClient.java
+++ b/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcClient.java
@@ -127,6 +127,7 @@ public class JsonRpcClient extends RpcClient implements InvocationHandler {
      * useful for constructing dynamic proxies for JSON-RPC
      * interfaces.
      */
+    @Override
     public Object invoke(Object proxy, Method method, Object[] args)
         throws Throwable
     {

--- a/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcServer.java
+++ b/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcServer.java
@@ -97,6 +97,7 @@ public class JsonRpcServer extends StringRpcServer {
     /**
      * Override our superclass' method, dispatching to doCall.
      */
+    @Override
     public String handleStringCall(String requestBody, AMQP.BasicProperties replyProperties)
     {
         String replyBody = doCall(requestBody);

--- a/src/main/java/com/rabbitmq/utility/SingleShotLinearTimer.java
+++ b/src/main/java/com/rabbitmq/utility/SingleShotLinearTimer.java
@@ -68,6 +68,7 @@ public class SingleShotLinearTimer {
             _runTime = System.nanoTime() / NANOS_IN_MILLI + timeoutMillisec;
         }
 
+        @Override
         public void run() {
             try {
                 long now;

--- a/src/main/java/com/rabbitmq/utility/Utility.java
+++ b/src/main/java/com/rabbitmq/utility/Utility.java
@@ -32,7 +32,8 @@ public class Utility {
           this.setStackTrace(throwable.getStackTrace());
         }
 
-        @Override public Throwable fillInStackTrace(){
+        @Override
+        public Throwable fillInStackTrace(){
             return this;
         }
     }


### PR DESCRIPTION
This PR contains some changes related to recovery. Note i cleaned up a bunch of compiler warnings by adding the missing Override tags on methods. I can submit another PR without those changes if you guys would prefer.

Non-cosmetic changes are in AutorecoveringConnection and AutorecoveringChannel.

Fixes:
1) fixes a NPE that can occur when a thread attempts to create a new channel after a connection has been recovered but before channel recovery has completed. More details of issue at https://groups.google.com/forum/#!topic/rabbitmq-users/7P5fYQLLP6g. Fixes the NPE in AutorecoveringChannel, but then also changed the AutorecoveryingConnection to not set the connection delegate until channel recovery is complete. This allows channel recovery to complete without error at the expense of the separate thread attempting to create a new channel of getting an AlreadyClosedException because it would happen on the old delegate.

Other changes:
1) Added a check in recoverQueues() that skips over all the queue name change logic if the name remained the same.