### PR TITLE
GH-217: Add toString() to AutorecoveringChannel

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
@@ -596,7 +596,7 @@ public class AutorecoveringChannel implements RecoverableChannel {
     public void automaticallyRecover(AutorecoveringConnection connection, Connection connDelegate) throws IOException {
         RecoveryAwareChannelN defunctChannel = this.delegate;
         this.connection = connection;
-        
+
         final RecoveryAwareChannelN newChannel = (RecoveryAwareChannelN) connDelegate.createChannel(this.getChannelNumber());
         if (newChannel == null)
             throw new IOException("Failed to create new channel for channel number=" + this.getChannelNumber() + " during recovery");
@@ -734,6 +734,11 @@ public class AutorecoveringChannel implements RecoverableChannel {
             consumerTags.remove(tag);
             consumerTags.add(newTag);
         }
+    }
+
+    @Override
+    public String toString() {
+        return this.delegate.toString();
     }
 
 }


### PR DESCRIPTION
Resolves https://github.com/rabbitmq/rabbitmq-java-client/issues/217

I didn't add a prefix; to be consistent with `AutrorecoveringConnection`.