### PR TITLE
Handle interrupts correctly, switch to a monotonically growing clock function in BlockingCell and SingleShotLinearTimer

### DIFF
--- a/src/main/java/com/rabbitmq/utility/BlockingCell.java
+++ b/src/main/java/com/rabbitmq/utility/BlockingCell.java
@@ -66,9 +66,9 @@ public class BlockingCell<T> {
         if (timeout < 0)
             throw new AssertionError("Timeout cannot be less than zero");
 
-        long maxTime = System.currentTimeMillis() + timeout;
-        long now;
-        while (!_filled && (now = System.currentTimeMillis()) < maxTime) {
+        long now = System.nanoTime() / NANOS_IN_MILLI;
+        long maxTime = now + timeout;
+        while (!_filled && (now = (System.nanoTime() / NANOS_IN_MILLI)) < maxTime) {
             wait(maxTime - now);
         }
 

--- a/src/main/java/com/rabbitmq/utility/SingleShotLinearTimer.java
+++ b/src/main/java/com/rabbitmq/utility/SingleShotLinearTimer.java
@@ -72,21 +72,27 @@ public class SingleShotLinearTimer {
         public void run() {
             try {
                 long now;
-                while ((now = System.nanoTime() / NANOS_IN_MILLI) < _runTime) {
-                    if (_task == null) break;
+                boolean wasInterrupted = false;
+                try {
+                    while ((now = System.nanoTime() / NANOS_IN_MILLI) < _runTime) {
+                        if (_task == null) break;
 
-                    try {
-                        synchronized(this) {
-                            wait(_runTime - now);
+                        try {
+                            synchronized(this) {
+                                wait(_runTime - now);
+                            }
+                        } catch (InterruptedException e) {
+                            wasInterrupted = true;
                         }
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
                     }
+                } finally {
+                    if (wasInterrupted)
+                        Thread.currentThread().interrupt();
                 }
                 
                 Runnable task = _task;
                 if (task != null) {
-                    task.run();                    
+                    task.run();
                 }
 
             } finally {


### PR DESCRIPTION
Trivial threading changes in BlockingCell and SingleShotLinearTimer java utility classes
BlockingCell now consistently uses System.nanoTime rather than System.currentTimeMillis

Relates to #52 