### PR TITLE
Close InputStream of version.properties in ClientVersion after reading

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/ClientVersion.java
+++ b/src/main/java/com/rabbitmq/client/impl/ClientVersion.java
@@ -36,7 +36,7 @@ public class ClientVersion {
         } catch (IOException e) {
         } finally {
             try {
-                if(inputStream!=null) {
+                if(inputStream != null) {
                     inputStream.close();
                 }
             } catch (IOException e) {

--- a/src/main/java/com/rabbitmq/client/impl/ClientVersion.java
+++ b/src/main/java/com/rabbitmq/client/impl/ClientVersion.java
@@ -16,6 +16,7 @@
 package com.rabbitmq.client.impl;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 /**
@@ -28,10 +29,18 @@ public class ClientVersion {
 
     static {
         version = new Properties();
+        InputStream inputStream = ClientVersion.class.getClassLoader()
+                .getResourceAsStream("version.properties");
         try {
-            version.load(ClientVersion.class.getClassLoader()
-              .getResourceAsStream("version.properties"));
+            version.load(inputStream);
         } catch (IOException e) {
+        } finally {
+            try {
+                if(inputStream!=null) {
+                    inputStream.close();
+                }
+            } catch (IOException e) {
+            }
         }
 
         VERSION = version.getProperty("com.rabbitmq.client.version",


### PR DESCRIPTION
May not break anything important, but breaks when run on Android with StrictMode enabled - which I would rather not disable.

Sorry, but I could not run the tests after the change, as I could not get the test setup (not event the build itself) running, because of missing tls-certs when running the rabbitmq-java-client, or missing makefiles in dependencies when trying to run stuff in the public-umbrella. So it would be nice if someone would run the tests for the change.