### PR TITLE
Add CompletableFuture async RPC to channel

### DIFF
--- a/src/main/java/com/rabbitmq/client/Channel.java
+++ b/src/main/java/com/rabbitmq/client/Channel.java
@@ -17,6 +17,7 @@ package com.rabbitmq.client;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
@@ -1361,5 +1362,7 @@ public interface Channel extends ShutdownNotifier {
      * @throws IOException Problem transmitting method.
      */
     long consumerCount(String queue) throws IOException;
+
+    CompletableFuture<Command> asyncCompletableRpc(Method method) throws IOException;
 
 }

--- a/src/main/java/com/rabbitmq/client/Channel.java
+++ b/src/main/java/com/rabbitmq/client/Channel.java
@@ -1363,6 +1363,12 @@ public interface Channel extends ShutdownNotifier {
      */
     long consumerCount(String queue) throws IOException;
 
+    /**
+     * Asynchronously send a method over this channel.
+     * @param method method to transmit over this channel.
+     * @return a completable future that completes when the result is received
+     * @throws IOException Problem transmitting method.
+     */
     CompletableFuture<Command> asyncCompletableRpc(Method method) throws IOException;
 
 }

--- a/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
@@ -17,6 +17,7 @@
 package com.rabbitmq.client.impl;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import com.rabbitmq.client.*;
@@ -58,7 +59,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     private AMQCommand _command = new AMQCommand();
 
     /** The current outstanding RPC request, if any. (Could become a queue in future.) */
-    private RpcContinuation _activeRpc = null;
+    private RpcWrapper _activeRpc = null;
 
     /** Whether transmission of content-bearing methods should be blocked */
     public volatile boolean _blockContent = false;
@@ -135,6 +136,20 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
         }
     }
 
+    public CompletableFuture<Command> exnWrappingAsyncRpc(Method m)
+        throws IOException
+    {
+        try {
+            return privateAsyncRpc(m);
+        } catch (AlreadyClosedException ace) {
+            // Do not wrap it since it means that connection/channel
+            // was closed in some action in the past
+            throw ace;
+        } catch (ShutdownSignalException ex) {
+            throw wrap(ex);
+        }
+    }
+
     /**
      * Private API - handle a command which has been assembled
      * @throws IOException if there's any problem
@@ -154,10 +169,10 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
         if (!processAsync(command)) {
             // The filter decided not to handle/consume the command,
             // so it must be some reply to an earlier RPC.
-            RpcContinuation nextOutstandingRpc = nextOutstandingRpc();
+            RpcWrapper nextOutstandingRpc = nextOutstandingRpc();
             // the outstanding RPC can be null when calling Channel#asyncRpc
             if(nextOutstandingRpc != null) {
-                nextOutstandingRpc.handleCommand(command);
+                nextOutstandingRpc.complete(command);
                 markRpcFinished();
             }
         }
@@ -177,7 +192,24 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
             if (waitClearedInterruptStatus) {
                 Thread.currentThread().interrupt();
             }
-            _activeRpc = k;
+            _activeRpc = new RpcContinuationRpcWrapper(k);
+        }
+    }
+
+    public void enqueueAsyncRpc(CompletableFuture<Command> future) {
+        synchronized (_channelMutex) {
+            boolean waitClearedInterruptStatus = false;
+            while (_activeRpc != null) {
+                try {
+                    _channelMutex.wait();
+                } catch (InterruptedException e) {
+                    waitClearedInterruptStatus = true;
+                }
+            }
+            if (waitClearedInterruptStatus) {
+                Thread.currentThread().interrupt();
+            }
+            _activeRpc = new CompletableFutureRpcWrapper(future);
         }
     }
 
@@ -188,10 +220,10 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
         }
     }
 
-    public RpcContinuation nextOutstandingRpc()
+    public RpcWrapper nextOutstandingRpc()
     {
         synchronized (_channelMutex) {
-            RpcContinuation result = _activeRpc;
+            RpcWrapper result = _activeRpc;
             _activeRpc = null;
             _channelMutex.notifyAll();
             return result;
@@ -255,6 +287,26 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
         }
     }
 
+    private CompletableFuture<Command> privateAsyncRpc(Method m)
+        throws IOException, ShutdownSignalException
+    {
+        SimpleBlockingRpcContinuation k = new SimpleBlockingRpcContinuation();
+        CompletableFuture<Command> future = new CompletableFuture<>();
+        asyncRpc(m, future);
+        // At this point, the request method has been sent, and we
+        // should wait for the reply to arrive.
+        //
+        // Calling getReply() on the continuation puts us to sleep
+        // until the connection's reader-thread throws the reply over
+        // the fence or the RPC times out (if enabled)
+
+        // TODO clean in case of error, timeout
+        //                    nextOutstandingRpc();
+        //                    markRpcFinished();
+
+        return future;
+    }
+
     private AMQCommand privateRpc(Method m, int timeout)
             throws IOException, ShutdownSignalException, TimeoutException {
         SimpleBlockingRpcContinuation k = new SimpleBlockingRpcContinuation();
@@ -277,6 +329,24 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     {
         synchronized (_channelMutex) {
             enqueueRpc(k);
+            quiescingTransmit(m);
+        }
+    }
+
+    public void asyncRpc(Method m, CompletableFuture<Command> future)
+        throws IOException
+    {
+        synchronized (_channelMutex) {
+            ensureIsOpen();
+            quiescingAsyncRpc(m, future);
+        }
+    }
+
+    public void quiescingAsyncRpc(Method m, CompletableFuture<Command> future)
+        throws IOException
+    {
+        synchronized (_channelMutex) {
+            enqueueAsyncRpc(future);
             quiescingTransmit(m);
         }
     }
@@ -321,9 +391,9 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     }
 
     public void notifyOutstandingRpc(ShutdownSignalException signal) {
-        RpcContinuation k = nextOutstandingRpc();
+        RpcWrapper k = nextOutstandingRpc();
         if (k != null) {
-            k.handleShutdownSignal(signal);
+            k.shutdown(signal);
         }
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
@@ -1529,6 +1530,11 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     @Override
     public AMQCommand rpc(Method method) throws IOException {
         return exnWrappingRpc(method);
+    }
+
+    @Override
+    public CompletableFuture<Command> asyncCompletableRpc(Method method) throws IOException {
+        return exnWrappingAsyncRpc(method);
     }
 
     @Override

--- a/src/main/java/com/rabbitmq/client/impl/CompletableFutureRpcWrapper.java
+++ b/src/main/java/com/rabbitmq/client/impl/CompletableFutureRpcWrapper.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2017-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import com.rabbitmq.client.Command;
+import com.rabbitmq.client.ShutdownSignalException;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ *
+ */
+public class CompletableFutureRpcWrapper implements RpcWrapper {
+
+    private final CompletableFuture<Command> completableFuture;
+
+    public CompletableFutureRpcWrapper(CompletableFuture<Command> completableFuture) {
+        this.completableFuture = completableFuture;
+    }
+
+    @Override
+    public void complete(AMQCommand command) {
+        completableFuture.complete(command);
+    }
+
+    @Override
+    public void shutdown(ShutdownSignalException signal) {
+        completableFuture.completeExceptionally(signal);
+    }
+}

--- a/src/main/java/com/rabbitmq/client/impl/RpcContinuationRpcWrapper.java
+++ b/src/main/java/com/rabbitmq/client/impl/RpcContinuationRpcWrapper.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import com.rabbitmq.client.ShutdownSignalException;
+
+/**
+ *
+ */
+public class RpcContinuationRpcWrapper implements RpcWrapper {
+
+    private final AMQChannel.RpcContinuation continuation;
+
+    public RpcContinuationRpcWrapper(AMQChannel.RpcContinuation continuation) {
+        this.continuation = continuation;
+    }
+
+    @Override
+    public void complete(AMQCommand command) {
+        continuation.handleCommand(command);
+    }
+
+    @Override
+    public void shutdown(ShutdownSignalException signal) {
+        continuation.handleShutdownSignal(signal);
+    }
+}

--- a/src/main/java/com/rabbitmq/client/impl/RpcWrapper.java
+++ b/src/main/java/com/rabbitmq/client/impl/RpcWrapper.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2017-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import com.rabbitmq.client.ShutdownSignalException;
+
+/**
+ *
+ */
+public interface RpcWrapper {
+
+    void complete(AMQCommand command);
+
+    void shutdown(ShutdownSignalException signal);
+
+}

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
@@ -20,6 +20,7 @@ import com.rabbitmq.client.RecoverableChannel;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
 
@@ -893,6 +894,11 @@ public class AutorecoveringChannel implements RecoverableChannel {
             consumerTags.remove(tag);
             consumerTags.add(newTag);
         }
+    }
+
+    @Override
+    public CompletableFuture<Command> asyncCompletableRpc(Method method) throws IOException {
+        return this.delegate.asyncCompletableRpc(method);
     }
 
     @Override

--- a/src/test/java/com/rabbitmq/client/test/ChannelAsyncCompletableFutureTest.java
+++ b/src/test/java/com/rabbitmq/client/test/ChannelAsyncCompletableFutureTest.java
@@ -1,0 +1,81 @@
+// Copyright (c) 2017-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.test;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Command;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.impl.AMQImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.*;
+
+import static org.junit.Assert.assertTrue;
+
+public class ChannelAsyncCompletableFutureTest extends BrokerTestCase {
+
+    ExecutorService executor;
+
+    String queue;
+
+    @Before public void init() {
+        executor = Executors.newSingleThreadExecutor();
+        queue = UUID.randomUUID().toString();
+    }
+
+    @After public void tearDown() throws IOException {
+        executor.shutdownNow();
+        channel.queueDelete(queue);
+    }
+
+    @Test
+    public void async() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        AMQP.Queue.Declare method = new AMQImpl.Queue.Declare.Builder()
+            .queue(queue)
+            .durable(true)
+            .exclusive(false)
+            .autoDelete(false)
+            .arguments(null)
+            .build();
+        CompletableFuture<Command> future = channel.asyncCompletableRpc(method);
+        future.thenAcceptAsync(action -> {
+            try {
+                channel.basicPublish("", queue, null, "dummy".getBytes());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }, executor).thenAccept((whatever) -> {
+            try {
+                channel.basicConsume(queue, true, new DefaultConsumer(channel) {
+                    @Override
+                    public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
+                        latch.countDown();
+                    }
+                });
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertTrue(latch.await(1, TimeUnit.SECONDS));
+    }
+
+}

--- a/src/test/java/com/rabbitmq/client/test/ClientTests.java
+++ b/src/test/java/com/rabbitmq/client/test/ClientTests.java
@@ -47,7 +47,8 @@ import org.junit.runners.Suite;
     DnsSrvRecordAddressResolverTest.class,
     JavaNioTest.class,
     RpcTest.class,
-    LambdaCallbackTest.class
+    LambdaCallbackTest.class,
+    ChannelAsyncCompletableFutureTest.class
 })
 public class ClientTests {
 


### PR DESCRIPTION
Add `CompletableFuture<Command> asyncCompletableRpc(Method method)` to `Channel`. This is foundation to react to asynchronous AMQP methods (most of the resource management methods). Right now, the RPC calls are serialized at the channel level, but this could be improved in the future by using a queue for the outstanding RPC calls.

Fixes #215