### PR TITLE
update rpc server

### DIFF
--- a/src/main/java/com/rabbitmq/client/MapRpcServer.java
+++ b/src/main/java/com/rabbitmq/client/MapRpcServer.java
@@ -44,10 +44,10 @@ public class MapRpcServer extends RpcServer {
      * Overridden to delegate to handleMapCall.
      */
     @Override
-    public byte[] handleCall(byte[] requestBody, AMQP.BasicProperties replyProperties)
+    public byte[] handleCall(byte[] requestBody, AMQP.BasicProperties.Builder replyPropertiesBuilder)
     {
         try {
-            return encode(handleMapCall(decode(requestBody), replyProperties));
+            return encode(handleMapCall(decode(requestBody), replyPropertiesBuilder));
         } catch (IOException ioe) {
             return new byte[0];
         }
@@ -78,7 +78,7 @@ public class MapRpcServer extends RpcServer {
      * Delegates to {@link MapRpcServer#handleMapCall(Map)}.
      */
     public Map<String, Object> handleMapCall(Map<String, Object> request,
-                                             AMQP.BasicProperties replyProperties)
+                                             AMQP.BasicProperties.Builder replyPropertiesBuilder)
     {
         return handleMapCall(request);
     }

--- a/src/main/java/com/rabbitmq/client/RpcServer.java
+++ b/src/main/java/com/rabbitmq/client/RpcServer.java
@@ -148,10 +148,10 @@ public class RpcServer {
         String replyTo = requestProperties.getReplyTo();
         if (correlationId != null && replyTo != null)
         {
-            AMQP.BasicProperties replyProperties
-                = new AMQP.BasicProperties.Builder().correlationId(correlationId).build();
-            byte[] replyBody = handleCall(request, replyProperties);
-            _channel.basicPublish("", replyTo, replyProperties, replyBody);
+            AMQP.BasicProperties.Builder replyPropertiesBuilder
+                = new AMQP.BasicProperties.Builder().correlationId(correlationId);
+            byte[] replyBody = handleCall(request, replyPropertiesBuilder);
+            _channel.basicPublish("", replyTo, replyPropertiesBuilder.build(), replyBody);
         } else {
             handleCast(request);
         }
@@ -159,25 +159,25 @@ public class RpcServer {
 
     /**
      * Lowest-level response method. Calls
-     * handleCall(AMQP.BasicProperties,byte[],AMQP.BasicProperties).
+     * handleCall(AMQP.BasicProperties,byte[],AMQP.BasicProperties.Builder).
      */
     public byte[] handleCall(Delivery request,
-                             AMQP.BasicProperties replyProperties)
+                             AMQP.BasicProperties.Builder replyPropertiesBuilder)
     {
         return handleCall(request.getProperties(),
                           request.getBody(),
-                          replyProperties);
+                          replyPropertiesBuilder);
     }
 
     /**
      * Mid-level response method. Calls
-     * handleCall(byte[],AMQP.BasicProperties).
+     * handleCall(byte[],AMQP.BasicProperties.Builder).
      */
     public byte[] handleCall(AMQP.BasicProperties requestProperties,
                              byte[] requestBody,
-                             AMQP.BasicProperties replyProperties)
+                             AMQP.BasicProperties.Builder replyPropertiesBuilder)
     {
-        return handleCall(requestBody, replyProperties);
+        return handleCall(requestBody, replyPropertiesBuilder);
     }
 
     /**
@@ -186,7 +186,7 @@ public class RpcServer {
      * methods) in subclasses.
      */
     public byte[] handleCall(byte[] requestBody,
-                             AMQP.BasicProperties replyProperties)
+                             AMQP.BasicProperties.Builder replyPropertiesBuilder)
     {
         return new byte[0];
     }

--- a/src/main/java/com/rabbitmq/client/StringRpcServer.java
+++ b/src/main/java/com/rabbitmq/client/StringRpcServer.java
@@ -37,7 +37,7 @@ public class StringRpcServer extends RpcServer {
      */
     @Override
     @SuppressWarnings("unused")
-    public byte[] handleCall(byte[] requestBody, AMQP.BasicProperties replyProperties)
+    public byte[] handleCall(byte[] requestBody, AMQP.BasicProperties.Builder replyPropertiesBuilder)
     {
         String request;
         try {
@@ -45,7 +45,7 @@ public class StringRpcServer extends RpcServer {
         } catch (IOException _e) {
             request = new String(requestBody);
         }
-        String reply = handleStringCall(request, replyProperties);
+        String reply = handleStringCall(request, replyPropertiesBuilder);
         try {
             return reply.getBytes(STRING_ENCODING);
         } catch (IOException _e) {
@@ -56,7 +56,7 @@ public class StringRpcServer extends RpcServer {
     /**
      * Delegates to handleStringCall(String).
      */
-    public String handleStringCall(String request, AMQP.BasicProperties replyProperties)
+    public String handleStringCall(String request, AMQP.BasicProperties.Builder replyPropertiesBuilder)
     {
         return handleStringCall(request);
     }

--- a/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcServer.java
+++ b/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcServer.java
@@ -98,7 +98,7 @@ public class JsonRpcServer extends StringRpcServer {
      * Override our superclass' method, dispatching to doCall.
      */
     @Override
-    public String handleStringCall(String requestBody, AMQP.BasicProperties replyProperties)
+    public String handleStringCall(String requestBody, AMQP.BasicProperties.Builder replyPropertiesBuilder)
     {
         String replyBody = doCall(requestBody);
         return replyBody;

--- a/src/test/java/com/rabbitmq/client/test/RpcTest.java
+++ b/src/test/java/com/rabbitmq/client/test/RpcTest.java
@@ -78,7 +78,7 @@ public class RpcTest {
         }
 
         @Override
-        public byte[] handleCall(Delivery request, AMQP.BasicProperties replyProperties) {
+        public byte[] handleCall(Delivery request, AMQP.BasicProperties.Builder replyPropertiesBuilder) {
             String input = new String(request.getBody());
             return ("*** " + input + " ***").getBytes();
         }


### PR DESCRIPTION
sometime we need add more information to replyProperties (i.e set headers), so with handleCall function, we need replyPropertiesBuilder not replyProperties argument.