### PR TITLE
Makes Channel extend AutoCloseable

### DIFF
--- a/src/main/java/com/rabbitmq/client/Channel.java
+++ b/src/main/java/com/rabbitmq/client/Channel.java
@@ -54,7 +54,7 @@ import com.rabbitmq.client.AMQP.Confirm;
  * @see <a href="http://www.rabbitmq.com/getstarted.html">RabbitMQ tutorials</a>
  * @see <a href="http://www.rabbitmq.com/api-guide.html">RabbitMQ Java Client User Guide</a>
  */
-public interface Channel extends ShutdownNotifier {
+public interface Channel extends ShutdownNotifier, AutoCloseable {
     /**
      * Retrieve this channel's channel number.
      * @return the channel number
@@ -73,6 +73,7 @@ public interface Channel extends ShutdownNotifier {
      *
      * @throws java.io.IOException if an error is encountered
      */
+    @Override
     void close() throws IOException, TimeoutException;
 
     /**


### PR DESCRIPTION
This PR makes the `Channel` class extend `AutoCloseable`. Note that `Channel` cannot extend `Closeable` due to the `throws TimedOutException` declaration on `Channel#close()`. See #258 for additional details.

Please review and merge. I've signed and mailed the CLA.

Closes #258.

Thanks,
Venil