### PR TITLE
Make SslContext creation more flexible

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -36,7 +36,11 @@ import java.util.concurrent.*;
 import static java.util.concurrent.TimeUnit.*;
 
 /**
- * Convenience "factory" class to facilitate opening a {@link Connection} to an AMQP broker.
+ * Convenience factory class to facilitate opening a {@link Connection} to a RabbitMQ node.
+ *
+ * Most connection and socket settings are configured using this factory.
+ * Some settings that apply to connections can also be configured here
+ * and will apply to all connections produced by this factory.
  */
 
 public class ConnectionFactory implements Cloneable {
@@ -94,7 +98,7 @@ public class ConnectionFactory implements Cloneable {
     private int handshakeTimeout                  = DEFAULT_HANDSHAKE_TIMEOUT;
     private int shutdownTimeout                   = DEFAULT_SHUTDOWN_TIMEOUT;
     private Map<String, Object> _clientProperties = AMQConnection.defaultClientProperties();
-    private SocketFactory factory                 = null;
+    private SocketFactory socketFactory = null;
     private SaslConfig saslConfig                 = DefaultSaslConfig.PLAIN;
     private ExecutorService sharedExecutor;
     private ThreadFactory threadFactory           = Executors.defaultThreadFactory();
@@ -442,19 +446,19 @@ public class ConnectionFactory implements Cloneable {
      * Retrieve the socket factory used to make connections with.
      */
     public SocketFactory getSocketFactory() {
-        return this.factory;
+        return this.socketFactory;
     }
 
     /**
-     * Set the socket factory used to make connections with. Can be
-     * used to enable SSL connections by passing in a
+     * Set the socket factory used to create sockets for new connections. Can be
+     * used to customize TLS-related settings by passing in a
      * javax.net.ssl.SSLSocketFactory instance.
      * Note this applies only to blocking IO, not to
      * NIO, as the NIO API doesn't use the SocketFactory API.
      * @see #useSslProtocol
      */
     public void setSocketFactory(SocketFactory factory) {
-        this.factory = factory;
+        this.socketFactory = factory;
     }
 
     /**
@@ -602,7 +606,7 @@ public class ConnectionFactory implements Cloneable {
     }
 
     /**
-     * Convenience method for setting up an SSL socket factory/engine.
+     * Convenience method for setting up an SSL socket socketFactory/engine.
      * Pass in an initialized SSLContext.
      * The {@link SSLContext} instance will be shared with all
      * the connections created by this connection factory. Use
@@ -682,7 +686,7 @@ public class ConnectionFactory implements Cloneable {
             }
             return this.frameHandlerFactory;
         } else {
-            return new SocketFrameHandlerFactory(connectionTimeout, factory, socketConf, isSSL(), this.shutdownExecutor, sslContextFactory);
+            return new SocketFrameHandlerFactory(connectionTimeout, socketFactory, socketConf, isSSL(), this.shutdownExecutor, sslContextFactory);
         }
 
     }

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -98,7 +98,7 @@ public class ConnectionFactory implements Cloneable {
     private int handshakeTimeout                  = DEFAULT_HANDSHAKE_TIMEOUT;
     private int shutdownTimeout                   = DEFAULT_SHUTDOWN_TIMEOUT;
     private Map<String, Object> _clientProperties = AMQConnection.defaultClientProperties();
-    private SocketFactory socketFactory = null;
+    private SocketFactory socketFactory           = SocketFactory.getDefault();
     private SaslConfig saslConfig                 = DefaultSaslConfig.PLAIN;
     private ExecutorService sharedExecutor;
     private ThreadFactory threadFactory           = Executors.defaultThreadFactory();

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -98,7 +98,7 @@ public class ConnectionFactory implements Cloneable {
     private int handshakeTimeout                  = DEFAULT_HANDSHAKE_TIMEOUT;
     private int shutdownTimeout                   = DEFAULT_SHUTDOWN_TIMEOUT;
     private Map<String, Object> _clientProperties = AMQConnection.defaultClientProperties();
-    private SocketFactory socketFactory           = SocketFactory.getDefault();
+    private SocketFactory socketFactory           = null;
     private SaslConfig saslConfig                 = DefaultSaslConfig.PLAIN;
     private ExecutorService sharedExecutor;
     private ThreadFactory threadFactory           = Executors.defaultThreadFactory();

--- a/src/main/java/com/rabbitmq/client/SslContextFactory.java
+++ b/src/main/java/com/rabbitmq/client/SslContextFactory.java
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * A factory to create {@link SSLContext}s.
+ *
+ * @see ConnectionFactory#setSslContextFactory(SslContextFactory)
+ * @since 5.0.0
+ */
+public interface SslContextFactory {
+
+    /**
+     * Create a {@link SSLContext} for a given name.
+     * The name is typically the name of the connection.
+     * @param name name of the connection the SSLContext is used for
+     * @return the SSLContext for this name
+     * @see ConnectionFactory#newConnection(String)
+     */
+    SSLContext create(String name);
+
+}

--- a/src/main/java/com/rabbitmq/client/impl/FrameHandlerFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/FrameHandlerFactory.java
@@ -9,6 +9,6 @@ import java.io.IOException;
  */
 public interface FrameHandlerFactory {
 
-    FrameHandler create(Address addr) throws IOException;
+    FrameHandler create(Address addr, String connectionName) throws IOException;
 
 }

--- a/src/main/java/com/rabbitmq/client/impl/SocketFrameHandlerFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/SocketFrameHandlerFactory.java
@@ -28,21 +28,24 @@ import java.util.concurrent.ExecutorService;
 
 public class SocketFrameHandlerFactory extends AbstractFrameHandlerFactory {
 
-    private final SocketFactory factory;
+    private final SocketFactory socketFactory;
     private final ExecutorService shutdownExecutor;
     private final SslContextFactory sslContextFactory;
 
-    public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory factory, SocketConfigurator configurator, boolean ssl) {
-        this(connectionTimeout, factory, configurator, ssl, null);
+    public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory socketFactory, SocketConfigurator configurator,
+                                     boolean ssl) {
+        this(connectionTimeout, socketFactory, configurator, ssl, null);
     }
 
-    public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory factory, SocketConfigurator configurator, boolean ssl, ExecutorService shutdownExecutor) {
-        this(connectionTimeout, factory, configurator, ssl, shutdownExecutor, null);
+    public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory socketFactory, SocketConfigurator configurator,
+                                     boolean ssl, ExecutorService shutdownExecutor) {
+        this(connectionTimeout, socketFactory, configurator, ssl, shutdownExecutor, null);
     }
 
-    public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory factory, SocketConfigurator configurator, boolean ssl, ExecutorService shutdownExecutor, SslContextFactory sslContextFactory) {
+    public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory socketFactory, SocketConfigurator configurator,
+                                     boolean ssl, ExecutorService shutdownExecutor, SslContextFactory sslContextFactory) {
         super(connectionTimeout, configurator, ssl);
-        this.factory = factory;
+        this.socketFactory = socketFactory;
         this.shutdownExecutor = shutdownExecutor;
         this.sslContextFactory = sslContextFactory;
     }
@@ -65,8 +68,8 @@ public class SocketFrameHandlerFactory extends AbstractFrameHandlerFactory {
 
     protected Socket createSocket(String connectionName) throws IOException {
         // SocketFactory takes precedence if specified
-        if (factory != null) {
-            return factory.createSocket();
+        if (socketFactory != null) {
+            return socketFactory.createSocket();
         } else {
             if (ssl) {
                 return sslContextFactory.create(connectionName).getSocketFactory().createSocket();

--- a/src/main/java/com/rabbitmq/client/impl/SocketFrameHandlerFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/SocketFrameHandlerFactory.java
@@ -18,6 +18,7 @@ package com.rabbitmq.client.impl;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.SocketConfigurator;
+import com.rabbitmq.client.SslContextFactory;
 
 import javax.net.SocketFactory;
 import java.io.IOException;
@@ -29,23 +30,29 @@ public class SocketFrameHandlerFactory extends AbstractFrameHandlerFactory {
 
     private final SocketFactory factory;
     private final ExecutorService shutdownExecutor;
+    private final SslContextFactory sslContextFactory;
 
     public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory factory, SocketConfigurator configurator, boolean ssl) {
         this(connectionTimeout, factory, configurator, ssl, null);
     }
 
     public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory factory, SocketConfigurator configurator, boolean ssl, ExecutorService shutdownExecutor) {
+        this(connectionTimeout, factory, configurator, ssl, shutdownExecutor, null);
+    }
+
+    public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory factory, SocketConfigurator configurator, boolean ssl, ExecutorService shutdownExecutor, SslContextFactory sslContextFactory) {
         super(connectionTimeout, configurator, ssl);
         this.factory = factory;
         this.shutdownExecutor = shutdownExecutor;
+        this.sslContextFactory = sslContextFactory;
     }
 
-    public FrameHandler create(Address addr) throws IOException {
+    public FrameHandler create(Address addr, String connectionName) throws IOException {
         String hostName = addr.getHost();
         int portNumber = ConnectionFactory.portOrDefault(addr.getPort(), ssl);
         Socket socket = null;
         try {
-            socket = factory.createSocket();
+            socket = createSocket(connectionName);
             configurator.configure(socket);
             socket.connect(new InetSocketAddress(hostName, portNumber),
                     connectionTimeout);
@@ -53,6 +60,19 @@ public class SocketFrameHandlerFactory extends AbstractFrameHandlerFactory {
         } catch (IOException ioe) {
             quietTrySocketClose(socket);
             throw ioe;
+        }
+    }
+
+    protected Socket createSocket(String connectionName) throws IOException {
+        // SocketFactory takes precedence if specified
+        if (factory != null) {
+            return factory.createSocket();
+        } else {
+            if (ssl) {
+                return sslContextFactory.create(connectionName).getSocketFactory().createSocket();
+            } else {
+                return SocketFactory.getDefault().createSocket();
+            }
         }
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnectionFactory.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 public class RecoveryAwareAMQConnectionFactory {
@@ -58,7 +59,7 @@ public class RecoveryAwareAMQConnectionFactory {
 
         for (Address addr : shuffled) {
             try {
-                FrameHandler frameHandler = factory.create(addr);
+                FrameHandler frameHandler = factory.create(addr, connectionName());
                 RecoveryAwareAMQConnection conn = createConnection(params, frameHandler, metricsCollector);
                 conn.start();
                 metricsCollector.newConnection(conn);
@@ -88,5 +89,15 @@ public class RecoveryAwareAMQConnectionFactory {
 
     protected RecoveryAwareAMQConnection createConnection(ConnectionParams params, FrameHandler handler, MetricsCollector metricsCollector) {
         return new RecoveryAwareAMQConnection(params, handler, metricsCollector);
+    }
+
+    private String connectionName() {
+        Map<String, Object> clientProperties = params.getClientProperties();
+        if (clientProperties == null) {
+            return null;
+        } else {
+            Object connectionName = clientProperties.get("connection_name");
+            return connectionName == null ? null : connectionName.toString();
+        }
     }
 }

--- a/src/test/java/com/rabbitmq/client/test/ChannelRpcTimeoutIntegrationTest.java
+++ b/src/test/java/com/rabbitmq/client/test/ChannelRpcTimeoutIntegrationTest.java
@@ -87,7 +87,7 @@ public class ChannelRpcTimeoutIntegrationTest {
     private FrameHandler createFrameHandler() throws IOException {
         SocketFrameHandlerFactory socketFrameHandlerFactory = new SocketFrameHandlerFactory(ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT,
             SocketFactory.getDefault(), new DefaultSocketConfigurator(), false, null);
-        return socketFrameHandlerFactory.create(new Address("localhost"));
+        return socketFrameHandlerFactory.create(new Address("localhost"), null);
     }
 
     static class WaitingChannel extends ChannelN {

--- a/src/test/java/com/rabbitmq/client/test/ClientTests.java
+++ b/src/test/java/com/rabbitmq/client/test/ClientTests.java
@@ -49,6 +49,7 @@ import org.junit.runners.Suite;
     ConnectionFactoryTest.class,
     RecoveryAwareAMQConnectionFactoryTest.class,
     RpcTest.class,
+    SslContextFactoryTest.class,
     LambdaCallbackTest.class
 })
 public class ClientTests {

--- a/src/test/java/com/rabbitmq/client/test/SslContextFactoryTest.java
+++ b/src/test/java/com/rabbitmq/client/test/SslContextFactoryTest.java
@@ -1,0 +1,152 @@
+// Copyright (c) 2007-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.test;
+
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.SslContextFactory;
+import com.rabbitmq.client.TrustEverythingTrustManager;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class SslContextFactoryTest {
+
+    @Test public void setSslContextFactory() throws Exception {
+        doTestSetSslContextFactory(() -> {
+            ConnectionFactory connectionFactory = new ConnectionFactory();
+            connectionFactory.useBlockingIo();
+            connectionFactory.setAutomaticRecoveryEnabled(true);
+            return connectionFactory;
+        });
+        doTestSetSslContextFactory(() -> {
+            ConnectionFactory connectionFactory = new ConnectionFactory();
+            connectionFactory.useNio();
+            connectionFactory.setAutomaticRecoveryEnabled(true);
+            return connectionFactory;
+        });
+        doTestSetSslContextFactory(() -> {
+            ConnectionFactory connectionFactory = new ConnectionFactory();
+            connectionFactory.useBlockingIo();
+            connectionFactory.setAutomaticRecoveryEnabled(false);
+            return connectionFactory;
+        });
+        doTestSetSslContextFactory(() -> {
+            ConnectionFactory connectionFactory = new ConnectionFactory();
+            connectionFactory.useNio();
+            connectionFactory.setAutomaticRecoveryEnabled(false);
+            return connectionFactory;
+        });
+    }
+
+    private void doTestSetSslContextFactory(Supplier<ConnectionFactory> supplier) throws Exception {
+        ConnectionFactory connectionFactory = supplier.get();
+        SslContextFactory sslContextFactory = sslContextFactory();
+        connectionFactory.setSslContextFactory(sslContextFactory);
+
+        Connection connection = connectionFactory.newConnection("connection01");
+        TestUtils.close(connection);
+        try {
+            connectionFactory.newConnection("connection02");
+            fail("The SSL context of this client should not trust the server");
+        } catch (SSLHandshakeException e) {
+            // OK
+        }
+    }
+
+    @Test public void socketFactoryTakesPrecedenceOverSslContextFactoryWithBlockingIo() throws Exception {
+        doTestSocketFactoryTakesPrecedenceOverSslContextFactoryWithBlockingIo(() -> {
+            ConnectionFactory connectionFactory = new ConnectionFactory();
+            connectionFactory.useBlockingIo();
+            connectionFactory.setAutomaticRecoveryEnabled(true);
+            return connectionFactory;
+        });
+        doTestSocketFactoryTakesPrecedenceOverSslContextFactoryWithBlockingIo(() -> {
+            ConnectionFactory connectionFactory = new ConnectionFactory();
+            connectionFactory.useBlockingIo();
+            connectionFactory.setAutomaticRecoveryEnabled(false);
+            return connectionFactory;
+        });
+    }
+
+    private void doTestSocketFactoryTakesPrecedenceOverSslContextFactoryWithBlockingIo(
+                Supplier<ConnectionFactory> supplier
+            ) throws Exception {
+        ConnectionFactory connectionFactory = supplier.get();
+        connectionFactory.useBlockingIo();
+        SslContextFactory sslContextFactory = sslContextFactory();
+        connectionFactory.setSslContextFactory(sslContextFactory);
+
+        SSLContext contextAcceptAll = sslContextFactory.create("connection01");
+        connectionFactory.setSocketFactory(contextAcceptAll.getSocketFactory());
+
+        Connection connection = connectionFactory.newConnection("connection01");
+        TestUtils.close(connection);
+        connection = connectionFactory.newConnection("connection02");
+        TestUtils.close(connection);
+    }
+
+    private SslContextFactory sslContextFactory() throws Exception {
+        SSLContext contextAcceptAll = SSLContext.getInstance(tlsProtocol());
+        contextAcceptAll.init(null, new TrustManager[] { new TrustEverythingTrustManager() }, null);
+
+        SSLContext contextRejectAll = SSLContext.getInstance(tlsProtocol());
+        contextRejectAll.init(null, new TrustManager[] { new TrustNothingTrustManager() }, null);
+
+        Map<String, SSLContext> sslContexts = new HashMap<>();
+        sslContexts.put("connection01", contextAcceptAll);
+        sslContexts.put("connection02", contextRejectAll);
+
+        SslContextFactory sslContextFactory = name -> sslContexts.get(name);
+        return sslContextFactory;
+    }
+
+    private String tlsProtocol() throws NoSuchAlgorithmException {
+        return ConnectionFactory.computeDefaultTlsProcotol(SSLContext.getDefault().getSupportedSSLParameters().getProtocols());
+    }
+
+    private static class TrustNothingTrustManager implements X509TrustManager {
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+            throw new CertificateException("Doesn't trust any server");
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+}

--- a/src/test/java/com/rabbitmq/client/test/functional/ConnectionOpen.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/ConnectionOpen.java
@@ -35,6 +35,8 @@ import com.rabbitmq.client.Method;
 import com.rabbitmq.client.impl.AMQCommand;
 import com.rabbitmq.client.impl.SocketFrameHandler;
 
+import javax.net.SocketFactory;
+
 
 /**
  * Check that protocol negotiation works
@@ -42,7 +44,7 @@ import com.rabbitmq.client.impl.SocketFrameHandler;
 public class ConnectionOpen {
     @Test public void correctProtocolHeader() throws IOException {
         ConnectionFactory factory = TestUtils.connectionFactory();
-        SocketFrameHandler fh = new SocketFrameHandler(factory.getSocketFactory().createSocket("localhost", AMQP.PROTOCOL.PORT));
+        SocketFrameHandler fh = new SocketFrameHandler(SocketFactory.getDefault().createSocket("localhost", AMQP.PROTOCOL.PORT));
         fh.sendHeader();
         AMQCommand command = new AMQCommand();
         while (!command.handleFrame(fh.readFrame())) { }
@@ -60,7 +62,7 @@ public class ConnectionOpen {
     @Test public void crazyProtocolHeader() throws IOException {
         ConnectionFactory factory = TestUtils.connectionFactory();
         // keep the frame handler's socket
-        Socket fhSocket = factory.getSocketFactory().createSocket("localhost", AMQP.PROTOCOL.PORT);
+        Socket fhSocket = SocketFactory.getDefault().createSocket("localhost", AMQP.PROTOCOL.PORT);
         SocketFrameHandler fh = new SocketFrameHandler(fhSocket);
         fh.sendHeader(100, 3); // major, minor
         DataInputStream in = fh.getInputStream();

--- a/src/test/java/com/rabbitmq/client/test/functional/FrameMax.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/FrameMax.java
@@ -179,7 +179,7 @@ public class FrameMax extends BrokerTestCase {
             IOException lastException = null;
             for (Address addr : addrs) {
                 try {
-                    FrameHandler frameHandler = createFrameHandlerFactory().create(addr);
+                    FrameHandler frameHandler = createFrameHandlerFactory().create(addr, null);
                     AMQConnection conn = new GenerousAMQConnection(this, frameHandler, executor);
                     conn.start();
                     return conn;


### PR DESCRIPTION
Introduce the SslContextFactory interface, in use in the ConnectionFactory
to create SslContext instance based on the connection name.
The existing ConnectionFactory#useSslProtocol() methods still work
the same way (they end using a SslContextFactory that returns the
same SslContext, whatever the name of the connection is).
This introduces a breaking change in the FrameHandlerFactory
by adding a new connectionName parameter. It should impact many
users, as this is more an internal API.

Fixes #241