### PR TITLE
basicCancel and basicConsume honor rpc timeout.

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
@@ -39,7 +39,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AMQChannel.class);
 
-    private static final int NO_RPC_TIMEOUT = 0;
+    protected static final int NO_RPC_TIMEOUT = 0;
 
     /**
      * Protected; used instead of synchronizing on the channel itself,
@@ -64,7 +64,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     public volatile boolean _blockContent = false;
 
     /** Timeout for RPC calls */
-    private final int _rpcTimeout;
+    protected final int _rpcTimeout;
 
     /**
      * Construct a channel on the given connection, with the given channel number.
@@ -243,16 +243,25 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
             try {
                 return k.getReply(_rpcTimeout);
             } catch (TimeoutException e) {
-                try {
-                    // clean RPC channel state
-                    nextOutstandingRpc();
-                    markRpcFinished();
-                } catch(Exception ex) {
-                    LOGGER.warn("Error while cleaning timed out channel RPC: {}", ex.getMessage());
-                }
-                throw new ChannelContinuationTimeoutException(e, this, this._channelNumber, m);
+                throw wrapTimeoutException(m, e);
             }
         }
+    }
+    
+    private void cleanRpcChannelState() {
+        try {
+            // clean RPC channel state
+            nextOutstandingRpc();
+            markRpcFinished();
+        } catch (Exception ex) {
+            LOGGER.warn("Error while cleaning timed out channel RPC: {}", ex.getMessage());
+        }
+    }
+    
+    /** Cleans RPC channel state after a timeout and wraps the TimeoutException in a ChannelContinuationTimeoutException */
+    protected ChannelContinuationTimeoutException wrapTimeoutException(final Method m, final TimeoutException e)  {
+        cleanRpcChannelState();
+        return new ChannelContinuationTimeoutException(e, this, this._channelNumber, m);
     }
 
     private AMQCommand privateRpc(Method m, int timeout)
@@ -260,7 +269,12 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
         SimpleBlockingRpcContinuation k = new SimpleBlockingRpcContinuation();
         rpc(m, k);
 
-        return k.getReply(timeout);
+        try {
+            return k.getReply(timeout);
+        } catch (TimeoutException e) {
+            cleanRpcChannelState();
+            throw e;
+        }
     }
 
     public void rpc(Method m, RpcContinuation k)

--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -1280,7 +1280,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
             @Override
             public Consumer transformReply(AMQCommand replyCommand) {
                 if (!(replyCommand.getMethod() instanceof Basic.CancelOk))
-                    LOGGER.warn("Received reply was not of expected method Basic.CancelOk");
+                    LOGGER.warn("Received reply {} was not of expected method Basic.CancelOk", replyCommand.getMethod());
                 _consumers.remove(consumerTag); //may already have been removed
                 dispatcher.handleCancelOk(originalConsumer, consumerTag);
                 return originalConsumer;

--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -37,6 +37,9 @@ import com.rabbitmq.client.impl.AMQImpl.Queue;
 import com.rabbitmq.client.impl.AMQImpl.Tx;
 import com.rabbitmq.utility.Utility;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Main interface to AMQP protocol functionality. Public API -
  * Implementation of all AMQChannels except channel zero.
@@ -49,6 +52,7 @@ import com.rabbitmq.utility.Utility;
  */
 public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel {
     private static final String UNSPECIFIED_OUT_OF_BAND = "";
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChannelN.class);
 
     /** Map from consumer tag to {@link Consumer} instance.
      * <p/>
@@ -1275,7 +1279,8 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
         BlockingRpcContinuation<Consumer> k = new BlockingRpcContinuation<Consumer>() {
             @Override
             public Consumer transformReply(AMQCommand replyCommand) {
-                ((Basic.CancelOk) replyCommand.getMethod()).getConsumerTag(); // just to make sure its the method expected
+                if (!(replyCommand.getMethod() instanceof Basic.CancelOk))
+                    LOGGER.warn("Received reply was not of expected method Basic.CancelOk");
                 _consumers.remove(consumerTag); //may already have been removed
                 dispatcher.handleCancelOk(originalConsumer, consumerTag);
                 return originalConsumer;

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -805,7 +805,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
                     // last binding where this exchange is the source is gone, remove recorded exchange
                     // if it is auto-deleted. See bug 26364.
                     if((x != null) && x.isAutoDelete()) {
-                        this.recordedExchanges.remove(exchange);
+                        deleteRecordedExchange(exchange);
                     }
                 }
             }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -805,7 +805,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
                     // last binding where this exchange is the source is gone, remove recorded exchange
                     // if it is auto-deleted. See bug 26364.
                     if((x != null) && x.isAutoDelete()) {
-                        deleteRecordedExchange(exchange);
+                        this.recordedExchanges.remove(exchange);
                     }
                 }
             }


### PR DESCRIPTION
Also make sure to remove other e2e bindings for autodeleted exchanges.

See https://groups.google.com/forum/#!topic/rabbitmq-users/pQ46aq6Tf_o for more details related to this PR.