### PR TITLE
e2e binding recovery fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.rabbitmq</groupId>
   <artifactId>amqp-client</artifactId>
-  <version>4.1.1.RC1</version>
+  <version>4.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>RabbitMQ Java Client</name>
@@ -42,7 +42,7 @@
     <url>https://github.com/rabbitmq/rabbitmq-java-client</url>
     <connection>scm:git:git://github.com/rabbitmq/rabbitmq-java-client.git</connection>
     <developerConnection>scm:git:git@github.com:rabbitmq/rabbitmq-java-client.git</developerConnection>
-    <tag>v4.1.1.RC1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.rabbitmq</groupId>
   <artifactId>amqp-client</artifactId>
-  <version>4.1.1-SNAPSHOT</version>
+  <version>4.1.1.RC1</version>
   <packaging>jar</packaging>
 
   <name>RabbitMQ Java Client</name>
@@ -42,7 +42,7 @@
     <url>https://github.com/rabbitmq/rabbitmq-java-client</url>
     <connection>scm:git:git://github.com/rabbitmq/rabbitmq-java-client.git</connection>
     <developerConnection>scm:git:git@github.com:rabbitmq/rabbitmq-java-client.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v4.1.1.RC1</tag>
   </scm>
 
   <organization>

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -805,7 +805,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
                     // last binding where this exchange is the source is gone, remove recorded exchange
                     // if it is auto-deleted. See bug 26364.
                     if((x != null) && x.isAutoDelete()) {
-                        this.recordedExchanges.remove(exchange);
+                        deleteRecordedExchange(exchange);
                     }
                 }
             }


### PR DESCRIPTION
It was possible to have abandoned e2e bindings in the recordedBindings. This caused a channel error during recovery and caused remaining recovery items to fail as well.

Workflow to reproduce:
1) create durable topic exchange -> auto-delete headers exchange -> auto-delete queue -> consumer
2) cancel consumer
3) calls maybeDeleteRecordedAutoDeleteQueue which ends up deleting the recorded queue
4) calls maybeDeleteRecordedAutoDeleteExchange and removes the recorded headers exchange

In that case the e2e binding from the durable topic exchange to the now deleted headers exchange still existed. Calling deleteRecordedExchange() method instead will then clean up the bindings for the exchange.