### PR TITLE
remove e2e bindings for auto-delete exchanges

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -805,7 +805,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
                     // last binding where this exchange is the source is gone, remove recorded exchange
                     // if it is auto-deleted. See bug 26364.
                     if((x != null) && x.isAutoDelete()) {
-                        this.recordedExchanges.remove(exchange);
+                        deleteRecordedExchange(exchange);
                     }
                 }
             }


### PR DESCRIPTION
It was possible to have abandoned e2e bindings in the recordedBindings. This caused a channel error during recovery and caused remaining recovery items to fail as well.

Workflow to reproduce:
1) create durable topic exchange -> auto-delete headers exchange -> auto-delete queue -> consumer
2) cancel consumer
3) calls maybeDeleteRecordedAutoDeleteQueue which ends up deleting the recorded queue
4) calls maybeDeleteRecordedAutoDeleteExchange and removes the recorded headers exchange

In that case the e2e binding from the durable topic exchange to the now deleted headers exchange still existed. Calling deleteRecordedExchange() method instead will then clean up the bindings for the exchange.