### PR TITLE
ensure rpc reply is for the current request

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/SocketFrameHandlerFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/SocketFrameHandlerFactory.java
@@ -40,6 +40,7 @@ public class SocketFrameHandlerFactory extends AbstractFrameHandlerFactory {
         this.shutdownExecutor = shutdownExecutor;
     }
 
+    @Override
     public FrameHandler create(Address addr) throws IOException {
         String hostName = addr.getHost();
         int portNumber = ConnectionFactory.portOrDefault(addr.getPort(), ssl);

--- a/src/main/java/com/rabbitmq/client/impl/nio/HeaderWriteRequest.java
+++ b/src/main/java/com/rabbitmq/client/impl/nio/HeaderWriteRequest.java
@@ -19,8 +19,6 @@ import com.rabbitmq.client.AMQP;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
 
 /**
  *

--- a/src/test/java/com/rabbitmq/client/test/AMQChannelTest.java
+++ b/src/test/java/com/rabbitmq/client/test/AMQChannelTest.java
@@ -105,6 +105,63 @@ public class AMQChannelTest {
         AMQCommand rpcResponse = channel.rpc(method);
         assertThat(rpcResponse.getMethod(), is(response));
     }
+    
+    @Test
+    public void testRpcTimeout_replyComesDuringNexRpc() throws Exception {
+        int rpcTimeout = 100;
+        AMQConnection connection = mock(AMQConnection.class);
+        when(connection.getChannelRpcTimeout()).thenReturn(rpcTimeout);
+
+        final DummyAmqChannel channel = new DummyAmqChannel(connection, 1);
+        Method method = new AMQImpl.Queue.Declare.Builder()
+            .queue("123")
+            .durable(false)
+            .exclusive(true)
+            .autoDelete(true)
+            .arguments(null)
+            .build();
+
+        try {
+            channel.rpc(method);
+            fail("Should time out and throw an exception");
+        } catch(final ChannelContinuationTimeoutException e) {
+            // OK
+            assertThat((DummyAmqChannel) e.getChannel(), is(channel));
+            assertThat(e.getChannelNumber(), is(channel.getChannelNumber()));
+            assertThat(e.getMethod(), is(method));
+            assertNull("outstanding RPC should have been cleaned", channel.nextOutstandingRpc());
+        }
+        
+        // now do a basic.consume request and have the queue.declareok returned instead
+        method = new AMQImpl.Basic.Consume.Builder()
+                .queue("123")
+                .consumerTag("")
+                .arguments(null)
+                .build();
+        
+        final Method response1 = new AMQImpl.Queue.DeclareOk.Builder()
+                .queue("123")
+                .consumerCount(0)
+                .messageCount(0).build();
+        
+        final Method response2 = new AMQImpl.Basic.ConsumeOk.Builder()
+                .consumerTag("456").build();
+        
+        scheduler.schedule(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                channel.handleCompleteInboundCommand(new AMQCommand(response1));
+                Thread.sleep(10);
+                channel.handleCompleteInboundCommand(new AMQCommand(response2));
+                return null;
+            }
+        }, (long) (rpcTimeout / 2.0), TimeUnit.MILLISECONDS);
+        
+        AMQCommand rpcResponse = channel.rpc(method);
+        assertThat(rpcResponse.getMethod(), is(response2));
+    }
+    
+    
 
     static class DummyAmqChannel extends AMQChannel {
 


### PR DESCRIPTION
This is my proposal for addressing https://github.com/rabbitmq/rabbitmq-java-client/issues/290.

As discussed on the issue, this isn't the ideal solution to the problem but it is an improvement as it prevents classcastexceptions from occurring. Added a unit test as well that helps explain the scenario I was seeing and trying to prevent here.