### PR TITLE
Add option to ensure RPC reply is for the current request

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -132,7 +132,7 @@ public class ConnectionFactory implements Cloneable {
      * Default is false.
      * @since 4.2.0
      */
-    private boolean channelCheckRpcReplyType = false;
+    private boolean channelShouldCheckRpcResponseType = false;
 
     /** @return the default host to use for connections */
     public String getHost() {
@@ -965,7 +965,7 @@ public class ConnectionFactory implements Cloneable {
         result.setShutdownExecutor(shutdownExecutor);
         result.setHeartbeatExecutor(heartbeatExecutor);
         result.setChannelRpcTimeout(channelRpcTimeout);
-        result.setChannelShouldCheckRpcResponseType(channelCheckRpcReplyType);
+        result.setChannelShouldCheckRpcResponseType(channelShouldCheckRpcResponseType);
         return result;
     }
 
@@ -1136,13 +1136,13 @@ public class ConnectionFactory implements Cloneable {
     /**
      * Set whether or not channels check the reply type of an RPC call.
      * Default is false.
-     * @param channelCheckRpcReplyType
+     * @param channelShouldCheckRpcResponseType
      */
-    public void setChannelCheckRpcReplyType(boolean channelCheckRpcReplyType) {
-        this.channelCheckRpcReplyType = channelCheckRpcReplyType;
+    public void setChannelShouldCheckRpcResponseType(boolean channelShouldCheckRpcResponseType) {
+        this.channelShouldCheckRpcResponseType = channelShouldCheckRpcResponseType;
     }
 
-    public boolean isChannelCheckRpcReplyType() {
-        return channelCheckRpcReplyType;
+    public boolean isChannelShouldCheckRpcResponseType() {
+        return channelShouldCheckRpcResponseType;
     }
 }

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -1134,7 +1134,9 @@ public class ConnectionFactory implements Cloneable {
     }
 
     /**
-     * Set whether or not channels check the reply type of an RPC call.
+     * When set to true, channels will check the response type (e.g. queue.declare
+     * expects a queue.declare-ok response) of RPC calls
+     * and ignore those that do not match.
      * Default is false.
      * @param channelShouldCheckRpcResponseType
      */

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -127,6 +127,13 @@ public class ConnectionFactory implements Cloneable {
      */
     private int channelRpcTimeout = DEFAULT_CHANNEL_RPC_TIMEOUT;
 
+    /**
+     * Whether or not channels check the reply type of an RPC call.
+     * Default is false.
+     * @since 4.2.0
+     */
+    private boolean channelCheckRpcReplyType = false;
+
     /** @return the default host to use for connections */
     public String getHost() {
         return host;
@@ -958,6 +965,7 @@ public class ConnectionFactory implements Cloneable {
         result.setShutdownExecutor(shutdownExecutor);
         result.setHeartbeatExecutor(heartbeatExecutor);
         result.setChannelRpcTimeout(channelRpcTimeout);
+        result.setChannelCheckRpcReplyType(channelCheckRpcReplyType);
         return result;
     }
 
@@ -1123,5 +1131,18 @@ public class ConnectionFactory implements Cloneable {
      */
     public int getChannelRpcTimeout() {
         return channelRpcTimeout;
+    }
+
+    /**
+     * Set whether or not channels check the reply type of an RPC call.
+     * Default is false.
+     * @param channelCheckRpcReplyType
+     */
+    public void setChannelCheckRpcReplyType(boolean channelCheckRpcReplyType) {
+        this.channelCheckRpcReplyType = channelCheckRpcReplyType;
+    }
+
+    public boolean isChannelCheckRpcReplyType() {
+        return channelCheckRpcReplyType;
     }
 }

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -965,7 +965,7 @@ public class ConnectionFactory implements Cloneable {
         result.setShutdownExecutor(shutdownExecutor);
         result.setHeartbeatExecutor(heartbeatExecutor);
         result.setChannelRpcTimeout(channelRpcTimeout);
-        result.setChannelCheckRpcReplyType(channelCheckRpcReplyType);
+        result.setChannelShouldCheckRpcResponseType(channelCheckRpcReplyType);
         return result;
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
@@ -85,7 +85,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
             throw new IllegalArgumentException("Continuation timeout on RPC calls cannot be less than 0");
         }
         this._rpcTimeout = connection.getChannelRpcTimeout();
-        this._checkRpcReplyType = connection.isChannelCheckRpcReplyType();
+        this._checkRpcReplyType = connection.willCheckRpcResponseType();
     }
 
     /**

--- a/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
@@ -20,6 +20,11 @@ import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import com.rabbitmq.client.*;
+import com.rabbitmq.client.AMQP.Basic;
+import com.rabbitmq.client.AMQP.Confirm;
+import com.rabbitmq.client.AMQP.Exchange;
+import com.rabbitmq.client.AMQP.Queue;
+import com.rabbitmq.client.AMQP.Tx;
 import com.rabbitmq.client.Method;
 import com.rabbitmq.utility.BlockingValueOrException;
 import org.slf4j.Logger;
@@ -66,6 +71,8 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     /** Timeout for RPC calls */
     protected final int _rpcTimeout;
 
+    private final boolean _checkRpcReplyType;
+
     /**
      * Construct a channel on the given connection, with the given channel number.
      * @param connection the underlying connection for this channel
@@ -78,6 +85,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
             throw new IllegalArgumentException("Continuation timeout on RPC calls cannot be less than 0");
         }
         this._rpcTimeout = connection.getChannelRpcTimeout();
+        this._checkRpcReplyType = connection.isChannelCheckRpcReplyType();
     }
 
     /**
@@ -154,7 +162,18 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
         if (!processAsync(command)) {
             // The filter decided not to handle/consume the command,
             // so it must be some reply to an earlier RPC.
-            RpcContinuation nextOutstandingRpc = nextOutstandingRpc();
+            if (_checkRpcReplyType) {
+                synchronized (_channelMutex) {
+                    // check if this reply command is intended for the current waiting request before calling nextOutstandingRpc()
+                    if (!_activeRpc.canHandleReply(command)) {
+                        // this reply command is not intended for the current waiting request
+                        // most likely a previous request timed out and this command is the reply for that.
+                        // Throw this reply command away so we don't stop the current request from waiting for its reply
+                        return;
+                    }
+                }
+            }
+            final RpcContinuation nextOutstandingRpc = nextOutstandingRpc();
             // the outstanding RPC can be null when calling Channel#asyncRpc
             if(nextOutstandingRpc != null) {
                 nextOutstandingRpc.handleCommand(command);
@@ -229,7 +248,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     private AMQCommand privateRpc(Method m)
         throws IOException, ShutdownSignalException
     {
-        SimpleBlockingRpcContinuation k = new SimpleBlockingRpcContinuation();
+        SimpleBlockingRpcContinuation k = new SimpleBlockingRpcContinuation(m);
         rpc(m, k);
         // At this point, the request method has been sent, and we
         // should wait for the reply to arrive.
@@ -266,7 +285,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
 
     private AMQCommand privateRpc(Method m, int timeout)
             throws IOException, ShutdownSignalException, TimeoutException {
-        SimpleBlockingRpcContinuation k = new SimpleBlockingRpcContinuation();
+        SimpleBlockingRpcContinuation k = new SimpleBlockingRpcContinuation(m);
         rpc(m, k);
 
         try {
@@ -384,12 +403,24 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
 
     public interface RpcContinuation {
         void handleCommand(AMQCommand command);
+        /** @return true if the reply command can be handled for this request */
+        boolean canHandleReply(AMQCommand command);
         void handleShutdownSignal(ShutdownSignalException signal);
     }
 
     public static abstract class BlockingRpcContinuation<T> implements RpcContinuation {
         public final BlockingValueOrException<T, ShutdownSignalException> _blocker =
             new BlockingValueOrException<T, ShutdownSignalException>();
+
+        protected final Method request;
+
+        public BlockingRpcContinuation() {
+            request = null;
+        }
+
+        public BlockingRpcContinuation(final Method request) {
+            this.request = request;
+        }
 
         @Override
         public void handleCommand(AMQCommand command) {
@@ -412,12 +443,79 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
             return _blocker.uninterruptibleGetValue(timeout);
         }
 
+        @Override
+        public boolean canHandleReply(AMQCommand command) {
+            // make a best effort attempt to ensure the reply was intended for this rpc request
+            // Ideally each rpc request would tag an id on it that could be returned and referenced on its reply.
+            // But because that would be a very large undertaking to add passively this logic at least protects against ClassCastExceptions
+            if (request != null) {
+                final Method reply = command.getMethod();
+                if (request instanceof Basic.Qos) {
+                    return reply instanceof Basic.QosOk;
+                } else if (request instanceof Basic.Get) {
+                    return reply instanceof Basic.GetOk || reply instanceof Basic.GetEmpty;
+                } else if (request instanceof Basic.Consume) {
+                    if (!(reply instanceof Basic.ConsumeOk))
+                        return false;
+                    // can also check the consumer tags match here. handle case where request consumer tag is empty and server-generated.
+                    final String consumerTag = ((Basic.Consume)request).getConsumerTag();
+                    return consumerTag == null || consumerTag.equals("") || consumerTag.equals(((Basic.ConsumeOk)reply).getConsumerTag());
+                } else if (request instanceof Basic.Cancel) {
+                    if (!(reply instanceof Basic.CancelOk))
+                        return false;
+                    // can also check the consumer tags match here
+                    return ((Basic.Cancel)request).getConsumerTag().equals(((Basic.CancelOk)reply).getConsumerTag());
+                } else if (request instanceof Basic.Recover) {
+                    return reply instanceof Basic.RecoverOk;
+                } else if (request instanceof Exchange.Declare) {
+                    return reply instanceof Exchange.DeclareOk;
+                } else if (request instanceof Exchange.Delete) {
+                    return reply instanceof Exchange.DeleteOk;
+                } else if (request instanceof Exchange.Bind) {
+                    return reply instanceof Exchange.BindOk;
+                } else if (request instanceof Exchange.Unbind) {
+                    return reply instanceof Exchange.UnbindOk;
+                } else if (request instanceof Queue.Declare) {
+                    // we cannot check the queue name, as the server can strip some characters
+                    // see QueueLifecycle test and https://github.com/rabbitmq/rabbitmq-server/issues/710
+                    return reply instanceof Queue.DeclareOk;
+                } else if (request instanceof Queue.Delete) {
+                    return reply instanceof Queue.DeleteOk;
+                } else if (request instanceof Queue.Bind) {
+                    return reply instanceof Queue.BindOk;
+                } else if (request instanceof Queue.Unbind) {
+                    return reply instanceof Queue.UnbindOk;
+                } else if (request instanceof Queue.Purge) {
+                    return reply instanceof Queue.PurgeOk;
+                } else if (request instanceof Tx.Select) {
+                    return reply instanceof Tx.SelectOk;
+                } else if (request instanceof Tx.Commit) {
+                    return reply instanceof Tx.CommitOk;
+                } else if (request instanceof Tx.Rollback) {
+                    return reply instanceof Tx.RollbackOk;
+                } else if (request instanceof Confirm.Select) {
+                    return reply instanceof Confirm.SelectOk;
+                }
+            }
+            // for passivity default to true
+            return true;
+        }
+
         public abstract T transformReply(AMQCommand command);
     }
 
     public static class SimpleBlockingRpcContinuation
         extends BlockingRpcContinuation<AMQCommand>
     {
+
+        public SimpleBlockingRpcContinuation() {
+            super();
+        }
+
+        public SimpleBlockingRpcContinuation(final Method method) {
+            super(method);
+        }
+
         @Override
         public AMQCommand transformReply(AMQCommand command) {
             return command;

--- a/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
@@ -71,7 +71,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     /** Timeout for RPC calls */
     protected final int _rpcTimeout;
 
-    private final boolean _checkRpcReplyType;
+    private final boolean _checkRpcResponseType;
 
     /**
      * Construct a channel on the given connection, with the given channel number.
@@ -85,7 +85,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
             throw new IllegalArgumentException("Continuation timeout on RPC calls cannot be less than 0");
         }
         this._rpcTimeout = connection.getChannelRpcTimeout();
-        this._checkRpcReplyType = connection.willCheckRpcResponseType();
+        this._checkRpcResponseType = connection.willCheckRpcResponseType();
     }
 
     /**
@@ -162,7 +162,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
         if (!processAsync(command)) {
             // The filter decided not to handle/consume the command,
             // so it must be some reply to an earlier RPC.
-            if (_checkRpcReplyType) {
+            if (_checkRpcResponseType) {
                 synchronized (_channelMutex) {
                     // check if this reply command is intended for the current waiting request before calling nextOutstandingRpc()
                     if (!_activeRpc.canHandleReply(command)) {

--- a/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
@@ -161,7 +161,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
         // waiting RPC continuation.
         if (!processAsync(command)) {
             // The filter decided not to handle/consume the command,
-            // so it must be some reply to an earlier RPC.
+            // so it must be a response to an earlier RPC.
             if (_checkRpcResponseType) {
                 synchronized (_channelMutex) {
                     // check if this reply command is intended for the current waiting request before calling nextOutstandingRpc()

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -134,6 +134,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     private final Collection<BlockedListener> blockedListeners = new CopyOnWriteArrayList<BlockedListener>();
     protected final MetricsCollector metricsCollector;
     private final int channelRpcTimeout;
+    private final boolean channelCheckRpcReplyType;
 
     /* State modified after start - all volatile */
 
@@ -229,6 +230,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
             throw new IllegalArgumentException("Continuation timeout on RPC calls cannot be less than 0");
         }
         this.channelRpcTimeout = params.getChannelRpcTimeout();
+        this.channelCheckRpcReplyType = params.isChannelCheckRpcReplyType();
 
         this._channel0 = new AMQChannel(this, 0) {
             @Override public boolean processAsync(Command c) throws IOException {
@@ -1055,5 +1057,9 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
 
     public int getChannelRpcTimeout() {
         return channelRpcTimeout;
+    }
+
+    public boolean isChannelCheckRpcReplyType() {
+        return channelCheckRpcReplyType;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -134,7 +134,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     private final Collection<BlockedListener> blockedListeners = new CopyOnWriteArrayList<BlockedListener>();
     protected final MetricsCollector metricsCollector;
     private final int channelRpcTimeout;
-    private final boolean channelCheckRpcReplyType;
+    private final boolean channelShouldCheckRpcResponseType;
 
     /* State modified after start - all volatile */
 
@@ -230,7 +230,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
             throw new IllegalArgumentException("Continuation timeout on RPC calls cannot be less than 0");
         }
         this.channelRpcTimeout = params.getChannelRpcTimeout();
-        this.channelCheckRpcReplyType = params.isChannelCheckRpcReplyType();
+        this.channelShouldCheckRpcResponseType = params.channelShouldCheckRpcResponseType();
 
         this._channel0 = new AMQChannel(this, 0) {
             @Override public boolean processAsync(Command c) throws IOException {
@@ -1059,7 +1059,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         return channelRpcTimeout;
     }
 
-    public boolean isChannelCheckRpcReplyType() {
-        return channelCheckRpcReplyType;
+    public boolean willCheckRpcResponseType() {
+        return channelShouldCheckRpcResponseType;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -40,7 +40,7 @@ public class ConnectionParams {
     private long networkRecoveryInterval;
     private boolean topologyRecovery;
     private int channelRpcTimeout;
-    private boolean channelCheckRpcReplyType;
+    private boolean channelShouldCheckRpcResponseType;
 
     private ExceptionHandler exceptionHandler;
     private ThreadFactory threadFactory;
@@ -115,8 +115,8 @@ public class ConnectionParams {
         return channelRpcTimeout;
     }
 
-    public boolean isChannelCheckRpcReplyType() {
-        return channelCheckRpcReplyType;
+    public boolean channelShouldCheckRpcResponseType() {
+        return channelShouldCheckRpcResponseType;
     }
 
     public void setUsername(String username) {
@@ -195,7 +195,7 @@ public class ConnectionParams {
         this.channelRpcTimeout = channelRpcTimeout;
     }
 
-    public void setChannelCheckRpcReplyType(boolean channelCheckRpcReplyType) {
-        this.channelCheckRpcReplyType = channelCheckRpcReplyType;
+    public void setChannelShouldCheckRpcResponseType(boolean channelShouldCheckRpcResponseType) {
+        this.channelShouldCheckRpcResponseType = channelShouldCheckRpcResponseType;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -40,6 +40,7 @@ public class ConnectionParams {
     private long networkRecoveryInterval;
     private boolean topologyRecovery;
     private int channelRpcTimeout;
+    private boolean channelCheckRpcReplyType;
 
     private ExceptionHandler exceptionHandler;
     private ThreadFactory threadFactory;
@@ -112,6 +113,10 @@ public class ConnectionParams {
 
     public int getChannelRpcTimeout() {
         return channelRpcTimeout;
+    }
+
+    public boolean isChannelCheckRpcReplyType() {
+        return channelCheckRpcReplyType;
     }
 
     public void setUsername(String username) {
@@ -188,5 +193,9 @@ public class ConnectionParams {
 
     public void setChannelRpcTimeout(int channelRpcTimeout) {
         this.channelRpcTimeout = channelRpcTimeout;
+    }
+
+    public void setChannelCheckRpcReplyType(boolean channelCheckRpcReplyType) {
+        this.channelCheckRpcReplyType = channelCheckRpcReplyType;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/nio/HeaderWriteRequest.java
+++ b/src/main/java/com/rabbitmq/client/impl/nio/HeaderWriteRequest.java
@@ -19,8 +19,6 @@ import com.rabbitmq.client.AMQP;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
 
 /**
  *

--- a/src/test/java/com/rabbitmq/client/test/AMQChannelTest.java
+++ b/src/test/java/com/rabbitmq/client/test/AMQChannelTest.java
@@ -107,11 +107,11 @@ public class AMQChannelTest {
     }
 
     @Test
-    public void testRpcTimeout_replyComesDuringNexRpc() throws Exception {
+    public void testRpcTimeoutReplyComesDuringNexRpc() throws Exception {
         int rpcTimeout = 100;
         AMQConnection connection = mock(AMQConnection.class);
         when(connection.getChannelRpcTimeout()).thenReturn(rpcTimeout);
-        when(connection.isChannelCheckRpcReplyType()).thenReturn(Boolean.TRUE);
+        when(connection.willCheckRpcResponseType()).thenReturn(Boolean.TRUE);
 
         final DummyAmqChannel channel = new DummyAmqChannel(connection, 1);
         Method method = new AMQImpl.Queue.Declare.Builder()


### PR DESCRIPTION
During cluster node failovers some TimeoutExceptions during connection recovery
end up causing ClassCastExceptions because the reply for the timed out
RPC request comes in while a 2nd RPC request is waiting.

This commit add the ConnectionFactory#channelCheckRpcReplyType flag that, if enabled,
will make the channel check if a reply is compatible with the outstanding
RPC request. The flag is set to false by default but could be set to true in the future,
when the check logic is proven reliable.

This code was originally contributed by @vikinghawk.

Fixes #290