### PR TITLE
Don't blindly overwrite SSLContext when specifying URI

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -226,7 +226,10 @@ public class ConnectionFactory implements Cloneable {
             // nothing special to do
         } else if ("amqps".equals(uri.getScheme().toLowerCase())) {
             setPort(DEFAULT_AMQP_OVER_SSL_PORT);
-            useSslProtocol();
+            // SSL context not set yet, we use the default one
+            if (this.sslContext != null) {
+                useSslProtocol();
+            }
         } else {
             throw new IllegalArgumentException("Wrong scheme in AMQP URI: " +
                                                uri.getScheme());

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -227,7 +227,7 @@ public class ConnectionFactory implements Cloneable {
         } else if ("amqps".equals(uri.getScheme().toLowerCase())) {
             setPort(DEFAULT_AMQP_OVER_SSL_PORT);
             // SSL context not set yet, we use the default one
-            if (this.sslContext != null) {
+            if (this.sslContext == null) {
                 useSslProtocol();
             }
         } else {


### PR DESCRIPTION
ConnectionFactory#setUri always set up the default SSLContext
when a secured AMQP URI is passed in. Now, it only does so
if the sslContext property hasn't been set yet.

Fixes #297