### PR TITLE
It provides the user the flexibility to set consumer worker thread count.

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -85,6 +85,9 @@ public class ConnectionFactory implements Cloneable {
     private static final String PREFERRED_TLS_PROTOCOL = "TLSv1.2";
 
     private static final String FALLBACK_TLS_PROTOCOL = "TLSv1";
+    
+    /** Default consumer worker count per connection */ 
+    public static final int DEFAULT_CONSUMER_WORKER_COUNT = Runtime.getRuntime().availableProcessors() * 2;
 
     private String username                       = DEFAULT_USER;
     private String password                       = DEFAULT_PASS;
@@ -97,6 +100,7 @@ public class ConnectionFactory implements Cloneable {
     private int connectionTimeout                 = DEFAULT_CONNECTION_TIMEOUT;
     private int handshakeTimeout                  = DEFAULT_HANDSHAKE_TIMEOUT;
     private int shutdownTimeout                   = DEFAULT_SHUTDOWN_TIMEOUT;
+    private int consumerWorkerCount   	  		  = DEFAULT_CONSUMER_WORKER_COUNT;
     private Map<String, Object> _clientProperties = AMQConnection.defaultClientProperties();
     private SocketFactory socketFactory           = null;
     private SaslConfig saslConfig                 = DefaultSaslConfig.PLAIN;
@@ -992,6 +996,7 @@ public class ConnectionFactory implements Cloneable {
         result.setHeartbeatExecutor(heartbeatExecutor);
         result.setChannelRpcTimeout(channelRpcTimeout);
         result.setChannelShouldCheckRpcResponseType(channelShouldCheckRpcResponseType);
+        result.setConsumerWorkerCount(consumerWorkerCount);
         return result;
     }
 
@@ -1191,4 +1196,22 @@ public class ConnectionFactory implements Cloneable {
     public boolean isChannelShouldCheckRpcResponseType() {
         return channelShouldCheckRpcResponseType;
     }
+
+    /**
+     * @return
+     */
+	public int getConsumerWorkerCount() {
+		return consumerWorkerCount;
+	}
+	
+	/**
+	 * Set the number of consumer worker thread count 
+	 * It provides the flexibility to control the number of worker per AMQP connection  
+	 * Default is {@link #DEFAULT_CONSUMER_WORKER_COUNT} 
+	 * @param consumerWorkerCount
+	 */
+	public void setConsumerWorkerCount(int consumerWorkerCount) {
+		this.consumerWorkerCount = consumerWorkerCount;
+	}
+    
 }

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -56,6 +56,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     private final ExecutorService shutdownExecutor;
     private Thread mainLoopThread;
     private ThreadFactory threadFactory = Executors.defaultThreadFactory();
+    private final int consumerWorkerCount;
     private String id;
 
     private final List<RecoveryCanBeginListener> recoveryCanBeginListeners =
@@ -231,7 +232,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         }
         this.channelRpcTimeout = params.getChannelRpcTimeout();
         this.channelShouldCheckRpcResponseType = params.channelShouldCheckRpcResponseType();
-
+        
         this._channel0 = new AMQChannel(this, 0) {
             @Override public boolean processAsync(Command c) throws IOException {
                 return getConnection().processControlCommand(c);
@@ -245,10 +246,12 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         this._inConnectionNegotiation = true; // we start out waiting for the first protocol response
 
         this.metricsCollector = metricsCollector;
+        
+        this.consumerWorkerCount = params.getConsumerWorkerCount();
     }
 
     private void initializeConsumerWorkService() {
-        this._workService  = new ConsumerWorkService(consumerWorkServiceExecutor, threadFactory, shutdownTimeout);
+        this._workService  = new ConsumerWorkService(consumerWorkServiceExecutor, consumerWorkerCount, threadFactory, shutdownTimeout);
     }
 
     private void initializeHeartbeatSender() {

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -41,6 +41,7 @@ public class ConnectionParams {
     private boolean topologyRecovery;
     private int channelRpcTimeout;
     private boolean channelShouldCheckRpcResponseType;
+    private int consumerWorkerCount;
 
     private ExceptionHandler exceptionHandler;
     private ThreadFactory threadFactory;
@@ -198,4 +199,13 @@ public class ConnectionParams {
     public void setChannelShouldCheckRpcResponseType(boolean channelShouldCheckRpcResponseType) {
         this.channelShouldCheckRpcResponseType = channelShouldCheckRpcResponseType;
     }
+
+	public int getConsumerWorkerCount() {
+		return consumerWorkerCount;
+	}
+
+	public void setConsumerWorkerCount(int consumerWorkerCount) {
+		this.consumerWorkerCount = consumerWorkerCount;
+	}
+    
 }

--- a/src/main/java/com/rabbitmq/client/impl/ConsumerWorkService.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConsumerWorkService.java
@@ -24,16 +24,22 @@ import java.util.concurrent.ThreadFactory;
 import com.rabbitmq.client.Channel;
 
 final public class ConsumerWorkService {
-    private static final int MAX_RUNNABLE_BLOCK_SIZE = 16;
-    private static final int DEFAULT_NUM_THREADS = Runtime.getRuntime().availableProcessors() * 2;
+	
+    private static final int MAX_RUNNABLE_BLOCK_SIZE = 16;    
     private final ExecutorService executor;
     private final boolean privateExecutor;
     private final WorkPool<Channel, Runnable> workPool;
     private final int shutdownTimeout;
 
-    public ConsumerWorkService(ExecutorService executor, ThreadFactory threadFactory, int shutdownTimeout) {
+    /**
+     * @param executor
+     * @param consumerWorkerCount
+     * @param threadFactory
+     * @param shutdownTimeout
+     */
+    public ConsumerWorkService(ExecutorService executor, int consumerWorkerCount, ThreadFactory threadFactory, int shutdownTimeout) {
         this.privateExecutor = (executor == null);
-        this.executor = (executor == null) ? Executors.newFixedThreadPool(DEFAULT_NUM_THREADS, threadFactory)
+        this.executor = (executor == null) ? Executors.newFixedThreadPool(consumerWorkerCount, threadFactory)
                                            : executor;
         this.workPool = new WorkPool<Channel, Runnable>();
         this.shutdownTimeout = shutdownTimeout;


### PR DESCRIPTION
The default remains the same which is availableProcessors * 2


Background - I am using this rabbitMq java client and then found out that for each connection I have 24 worker thread and after debugging found that is availableProcessors * 2 but there is no parameters to set. 
so created this variable consumerWorkerCount by which the user will have the flexibility to control the number of worker threads. 