### PR TITLE
Add warning for not supported no-local flag

### DIFF
--- a/src/main/java/com/rabbitmq/client/Channel.java
+++ b/src/main/java/com/rabbitmq/client/Channel.java
@@ -1126,8 +1126,8 @@ public interface Channel extends ShutdownNotifier, AutoCloseable {
      * acknowledged once delivered; false if the server should expect
      * explicit acknowledgements
      * @param consumerTag a client-generated consumer tag to establish context
-     * @param noLocal true if the server should not deliver to this consumer
-     * messages published on this channel's connection
+     * @param noLocal True if the server should not deliver to this consumer
+     * messages published on this channel's connection. Note that the RabbitMQ server does not support this flag.
      * @param exclusive true if this is an exclusive consumer
      * @param callback an interface to the consumer object
      * @param arguments a set of arguments for the consume
@@ -1150,8 +1150,8 @@ public interface Channel extends ShutdownNotifier, AutoCloseable {
      * acknowledged once delivered; false if the server should expect
      * explicit acknowledgements
      * @param consumerTag a client-generated consumer tag to establish context
-     * @param noLocal true if the server should not deliver to this consumer
-     * messages published on this channel's connection
+     * @param noLocal True if the server should not deliver to this consumer
+     * messages published on this channel's connection. Note that the RabbitMQ server does not support this flag.
      * @param exclusive true if this is an exclusive consumer
      * @param arguments a set of arguments for the consume
      * @param deliverCallback callback when a message is delivered
@@ -1176,8 +1176,8 @@ public interface Channel extends ShutdownNotifier, AutoCloseable {
      * acknowledged once delivered; false if the server should expect
      * explicit acknowledgements
      * @param consumerTag a client-generated consumer tag to establish context
-     * @param noLocal true if the server should not deliver to this consumer
-     * messages published on this channel's connection
+     * @param noLocal True if the server should not deliver to this consumer
+     * messages published on this channel's connection. Note that the RabbitMQ server does not support this flag.
      * @param exclusive true if this is an exclusive consumer
      * @param arguments a set of arguments for the consume
      * @param deliverCallback callback when a message is delivered
@@ -1202,8 +1202,8 @@ public interface Channel extends ShutdownNotifier, AutoCloseable {
      * acknowledged once delivered; false if the server should expect
      * explicit acknowledgements
      * @param consumerTag a client-generated consumer tag to establish context
-     * @param noLocal true if the server should not deliver to this consumer
-     * messages published on this channel's connection
+     * @param noLocal True if the server should not deliver to this consumer
+     * messages published on this channel's connection. Note that the RabbitMQ server does not support this flag.
      * @param exclusive true if this is an exclusive consumer
      * @param arguments a set of arguments for the consume
      * @param deliverCallback callback when a message is delivered


### PR DESCRIPTION
Add warning to Javadoc that the noLocal flag is not supported by the rabbitmq server.
This is the same as for the immediate flag for publishing.

References #303