### PR TITLE
fix PRECONDITION_FAILED error after channel recovery

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
@@ -600,8 +600,8 @@ public class AutorecoveringChannel implements RecoverableChannel {
         final RecoveryAwareChannelN newChannel = (RecoveryAwareChannelN) connDelegate.createChannel(this.getChannelNumber());
         if (newChannel == null)
             throw new IOException("Failed to create new channel for channel number=" + this.getChannelNumber() + " during recovery");
+        newChannel.inheritOffsetFrom(defunctChannel);
         this.delegate = newChannel;
-        this.delegate.inheritOffsetFrom(defunctChannel);
 
         this.notifyRecoveryListenersStarted();
         this.recoverShutdownListeners();


### PR DESCRIPTION
## Proposed Changes

We encountered recovery errors during a brief network outage for a slow consumer that was under heavy load. When attempting to acknowledge a delivery the channel was closed with "reply-code=406,
 * reply-text=PRECONDITION_FAILED - unknown delivery tag 0, class-id=60, method-id=80)" and messages stopped being delivered.

I was able to create a test app to easily recreate the issue. After these changes I could not recreate.

Changes are:
1. Don't allow sending an ack with tag=0 unless multiple=true
2. Fix potential timing issue by inheriting the offset on the new channel before setting delegate=newChannel.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
