### PR TITLE
Proposal: Add method to remove a queue from recovery without deleting it

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -761,6 +761,28 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
             this.maybeDeleteRecordedAutoDeleteExchange(b.getSource());
         }
     }
+    
+    /**
+     * Remove the queue from list of recorded queues to recover after connection failure.
+     * Intended to be used in usecases where you want to remove the queue from this connection's recovery list but don't want to delete the queue from the server.
+     * 
+     * @param queue queue name to remove from recorded recovery queues
+     * @param ifUnused if true, the RecordedQueue will only be removed if no more consumers from this connection are using it.
+     */
+    public void removeRecordedQueue(final String queue, final boolean ifUnused) {
+        if (ifUnused) {
+            // Note: This is basically the same as maybeDeleteRecordedAutoDeleteQueue except it works for non auto-delete queues as well.
+            synchronized (this.consumers) {
+                synchronized (this.recordedQueues) {
+                    if (!hasMoreConsumersOnQueue(this.consumers.values(), queue)) {
+                        deleteRecordedQueue(queue);
+                    }
+                }
+            }
+        } else {
+            deleteRecordedQueue(queue);
+        }
+    }
 
     void recordExchange(String exchange, RecordedExchange x) {
         this.recordedExchanges.put(exchange, x);
@@ -789,7 +811,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
                     RecordedQueue q = this.recordedQueues.get(queue);
                     // last consumer on this connection is gone, remove recorded queue
                     // if it is auto-deleted. See bug 26364.
-                    if((q != null) && q.isAutoDelete()) {
+                    if(q != null && q.isAutoDelete()) {
                         deleteRecordedQueue(queue);
                     }
                 }
@@ -804,7 +826,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
                     RecordedExchange x = this.recordedExchanges.get(exchange);
                     // last binding where this exchange is the source is gone, remove recorded exchange
                     // if it is auto-deleted. See bug 26364.
-                    if((x != null) && x.isAutoDelete()) {
+                    if(x != null && x.isAutoDelete()) {
                         deleteRecordedExchange(exchange);
                     }
                 }


### PR DESCRIPTION
## Proposed Changes
This is a proposal to add a new method to address the following usecase:
1. Connection A declares a durable, shared,non-autodelete queue "ABC"
2. Connection A consumes from the queue
3. Connection B re-declares the same queue "ABC" as it does not know or care whether it already exists from Connection A
4. Connection B consume from the queue
5. Connection A cancels its queue consumers
6. Connection A does not want to delete the queue because it may still be in use by others, but it would like to remove the queue from its list of recovery items because it is no longer actively using it.

This adds a public method to AutorecoveringConnection to allow for removal of a queue from recorded queues (and its related bindings) without having to call Channel.queueDelete().

Let me know if this is something you guys would be willing to pull in. I was originally looking at using reflections to get to the necessary methods/variables to do this. But obviously that is fragile for me to maintain and there may be others in the community with a similar usecase that could benefit.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
