### PR TITLE
Trigger recovery if a socket write fails

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -81,6 +81,9 @@ public class ConnectionFactory implements Cloneable {
     /** The default network recovery interval: 5000 millis */
     public static final long   DEFAULT_NETWORK_RECOVERY_INTERVAL = 5000;
 
+    /** The default timeout for work pool enqueueing: no timeout */
+    public static final int    DEFAULT_WORK_POOL_TIMEOUT = -1;
+
     private static final String PREFERRED_TLS_PROTOCOL = "TLSv1.2";
 
     private static final String FALLBACK_TLS_PROTOCOL = "TLSv1";
@@ -137,6 +140,12 @@ public class ConnectionFactory implements Cloneable {
      * @since 4.2.0
      */
     private boolean channelShouldCheckRpcResponseType = false;
+
+    /**
+     * Timeout in ms for work pool enqueuing.
+     * @since 4.5.0
+     */
+    private int workPoolTimeout = DEFAULT_WORK_POOL_TIMEOUT;
 
     /** @return the default host to use for connections */
     public String getHost() {
@@ -974,6 +983,7 @@ public class ConnectionFactory implements Cloneable {
         result.setHeartbeatExecutor(heartbeatExecutor);
         result.setChannelRpcTimeout(channelRpcTimeout);
         result.setChannelShouldCheckRpcResponseType(channelShouldCheckRpcResponseType);
+        result.setWorkPoolTimeout(workPoolTimeout);
         return result;
     }
 
@@ -1269,5 +1279,26 @@ public class ConnectionFactory implements Cloneable {
 
     public boolean isChannelShouldCheckRpcResponseType() {
         return channelShouldCheckRpcResponseType;
+    }
+
+    /**
+     * Timeout (in ms) for work pool enqueueing.
+     * The {@link WorkPool} dispatches several types of responses
+     * from the broker (e.g. deliveries). A high-traffic
+     * client with slow consumers can exhaust the work pool and
+     * compromise the whole connection (by e.g. letting the broker
+     * saturate the receive TCP buffers). Setting a timeout
+     * would make the connection fail early and avoid hard-to-diagnose
+     * TCP connection failure. Note this shouldn't happen
+     * with clients that set appropriate QoS values.
+     * Default is no timeout.
+     * @param workPoolTimeout timeout in ms
+     */
+    public void setWorkPoolTimeout(int workPoolTimeout) {
+        this.workPoolTimeout = workPoolTimeout;
+    }
+
+    public int getWorkPoolTimeout() {
+        return workPoolTimeout;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -567,8 +567,9 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     public void flush() throws IOException {
         try {
             _frameHandler.flush();
-        } catch (Throwable throwable) {
-            this.errorOnWriteListener.handle(this, throwable);
+        } catch (IOException ioe) {
+            this.errorOnWriteListener.handle(this, ioe);
+            throw ioe;
         }
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -44,6 +44,7 @@ public class ConnectionParams {
     private boolean topologyRecovery;
     private int channelRpcTimeout;
     private boolean channelShouldCheckRpcResponseType;
+    private ErrorOnWriteListener errorOnWriteListener;
 
     private ExceptionHandler exceptionHandler;
     private ThreadFactory threadFactory;
@@ -212,5 +213,13 @@ public class ConnectionParams {
 
     public void setChannelShouldCheckRpcResponseType(boolean channelShouldCheckRpcResponseType) {
         this.channelShouldCheckRpcResponseType = channelShouldCheckRpcResponseType;
+    }
+
+    public void setErrorOnWriteListener(ErrorOnWriteListener errorOnWriteListener) {
+        this.errorOnWriteListener = errorOnWriteListener;
+    }
+
+    public ErrorOnWriteListener getErrorOnWriteListener() {
+        return errorOnWriteListener;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -45,6 +45,7 @@ public class ConnectionParams {
     private int channelRpcTimeout;
     private boolean channelShouldCheckRpcResponseType;
     private ErrorOnWriteListener errorOnWriteListener;
+    private int workPoolTimeout = -1;
 
     private ExceptionHandler exceptionHandler;
     private ThreadFactory threadFactory;
@@ -221,5 +222,13 @@ public class ConnectionParams {
 
     public ErrorOnWriteListener getErrorOnWriteListener() {
         return errorOnWriteListener;
+    }
+
+    public void setWorkPoolTimeout(int workPoolTimeout) {
+        this.workPoolTimeout = workPoolTimeout;
+    }
+
+    public int getWorkPoolTimeout() {
+        return workPoolTimeout;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/ConsumerWorkService.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConsumerWorkService.java
@@ -31,12 +31,16 @@ final public class ConsumerWorkService {
     private final WorkPool<Channel, Runnable> workPool;
     private final int shutdownTimeout;
 
-    public ConsumerWorkService(ExecutorService executor, ThreadFactory threadFactory, int shutdownTimeout) {
+    public ConsumerWorkService(ExecutorService executor, ThreadFactory threadFactory, int queueingTimeout, int shutdownTimeout) {
         this.privateExecutor = (executor == null);
         this.executor = (executor == null) ? Executors.newFixedThreadPool(DEFAULT_NUM_THREADS, threadFactory)
-                                           : executor;
-        this.workPool = new WorkPool<Channel, Runnable>();
+            : executor;
+        this.workPool = new WorkPool<Channel, Runnable>(queueingTimeout);
         this.shutdownTimeout = shutdownTimeout;
+    }
+
+    public ConsumerWorkService(ExecutorService executor, ThreadFactory threadFactory, int shutdownTimeout) {
+        this(executor, threadFactory, -1, shutdownTimeout);
     }
 
     public int getShutdownTimeout() {

--- a/src/main/java/com/rabbitmq/client/impl/ErrorOnWriteListener.java
+++ b/src/main/java/com/rabbitmq/client/impl/ErrorOnWriteListener.java
@@ -17,6 +17,8 @@ package com.rabbitmq.client.impl;
 
 import com.rabbitmq.client.Connection;
 
+import java.io.IOException;
+
 /**
  * Listener called when a connection gets an error trying to write on the socket.
  * This can be used to trigger connection recovery.
@@ -28,6 +30,6 @@ public interface ErrorOnWriteListener {
      * @param connection the owning connection instance
      * @param exception the thrown exception
      */
-    void handle(Connection connection, Throwable exception);
+    void handle(Connection connection, IOException exception) throws IOException;
 
 }

--- a/src/main/java/com/rabbitmq/client/impl/ErrorOnWriteListener.java
+++ b/src/main/java/com/rabbitmq/client/impl/ErrorOnWriteListener.java
@@ -1,0 +1,33 @@
+// Copyright (c) 2018-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import com.rabbitmq.client.Connection;
+
+/**
+ * Listener called when a connection gets an error trying to write on the socket.
+ * This can be used to trigger connection recovery.
+ */
+public interface ErrorOnWriteListener {
+
+    /**
+     * Called when writing to the socket failed
+     * @param connection the owning connection instance
+     * @param exception the thrown exception
+     */
+    void handle(Connection connection, Throwable exception);
+
+}

--- a/src/main/java/com/rabbitmq/client/impl/WorkPoolFullException.java
+++ b/src/main/java/com/rabbitmq/client/impl/WorkPoolFullException.java
@@ -1,8 +1,26 @@
+// Copyright (c) 2018-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
 package com.rabbitmq.client.impl;
 
 /**
- *
+ * Exception thrown when {@link WorkPool} enqueueing times out.
  */
-public class WorkPoolFullException {
+public class WorkPoolFullException extends RuntimeException {
 
+    public WorkPoolFullException(String msg) {
+        super(msg);
+    }
 }

--- a/src/main/java/com/rabbitmq/client/impl/WorkPoolFullException.java
+++ b/src/main/java/com/rabbitmq/client/impl/WorkPoolFullException.java
@@ -1,0 +1,8 @@
+package com.rabbitmq.client.impl;
+
+/**
+ *
+ */
+public class WorkPoolFullException {
+
+}

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -22,13 +22,18 @@ import com.rabbitmq.client.impl.ErrorOnWriteListener;
 import com.rabbitmq.client.impl.FrameHandlerFactory;
 import com.rabbitmq.client.impl.NetworkConnection;
 import com.rabbitmq.utility.Utility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Connection implementation that performs automatic recovery when
@@ -52,6 +57,9 @@ import java.util.concurrent.TimeoutException;
  * @since 3.3.0
  */
 public class AutorecoveringConnection implements RecoverableConnection, NetworkConnection {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AutorecoveringConnection.class);
+
     private final RecoveryAwareAMQConnectionFactory cf;
     private final Map<Integer, AutorecoveringChannel> channels;
     private final ConnectionParams params;
@@ -88,15 +96,37 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
         this.cf = new RecoveryAwareAMQConnectionFactory(params, f, addressResolver, metricsCollector);
         this.params = params;
 
-        this.params.setErrorOnWriteListener(new ErrorOnWriteListener() {
-            @Override
-            public void handle(Connection connection, Throwable exception) {
-                AMQConnection c = (AMQConnection) connection;
-                c.handleIoError(exception);
-            }
-        });
+        setupErrorOnWriteListenerForPotentialRecovery();
 
         this.channels = new ConcurrentHashMap<Integer, AutorecoveringChannel>();
+    }
+
+    private void setupErrorOnWriteListenerForPotentialRecovery() {
+        final ThreadFactory threadFactory = this.params.getThreadFactory();
+        final Lock errorOnWriteLock = new ReentrantLock();
+        this.params.setErrorOnWriteListener(new ErrorOnWriteListener() {
+            @Override
+            public void handle(final Connection connection, final IOException exception) throws IOException {
+                // this is called for any write error
+                // we should trigger the error handling and the recovery only once
+                if (errorOnWriteLock.tryLock()) {
+                    try {
+                        Thread recoveryThread = threadFactory.newThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                AMQConnection c = (AMQConnection) connection;
+                                c.handleIoError(exception);
+                            }
+                        });
+                        recoveryThread.setName("RabbitMQ Error On Write Thread");
+                        recoveryThread.start();
+                    } finally {
+                        errorOnWriteLock.unlock();
+                    }
+                }
+                throw exception;
+            }
+        });
     }
 
     /**
@@ -661,7 +691,9 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
         for (Map.Entry<String, RecordedConsumer> entry : Utility.copy(this.consumers).entrySet()) {
             String tag = entry.getKey();
             RecordedConsumer consumer = entry.getValue();
-
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Recovering consumer {}", consumer);
+            }
             try {
                 String newTag = consumer.recover();
                 // make sure server-generated tags are re-added. MK.
@@ -675,6 +707,9 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
 
                 for(ConsumerRecoveryListener crl : Utility.copy(this.consumerRecoveryListeners)) {
                     crl.consumerRecovered(tag, newTag);
+                }
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Consumer {} has recovered", consumer);
                 }
             } catch (Exception cause) {
                 final String message = "Caught an exception while recovering consumer " + tag +

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -18,6 +18,7 @@ package com.rabbitmq.client.impl.recovery;
 import com.rabbitmq.client.*;
 import com.rabbitmq.client.impl.AMQConnection;
 import com.rabbitmq.client.impl.ConnectionParams;
+import com.rabbitmq.client.impl.ErrorOnWriteListener;
 import com.rabbitmq.client.impl.FrameHandlerFactory;
 import com.rabbitmq.client.impl.NetworkConnection;
 import com.rabbitmq.utility.Utility;
@@ -86,6 +87,14 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
     public AutorecoveringConnection(ConnectionParams params, FrameHandlerFactory f, AddressResolver addressResolver, MetricsCollector metricsCollector) {
         this.cf = new RecoveryAwareAMQConnectionFactory(params, f, addressResolver, metricsCollector);
         this.params = params;
+
+        this.params.setErrorOnWriteListener(new ErrorOnWriteListener() {
+            @Override
+            public void handle(Connection connection, Throwable exception) {
+                AMQConnection c = (AMQConnection) connection;
+                c.handleIoError(exception);
+            }
+        });
 
         this.channels = new ConcurrentHashMap<Integer, AutorecoveringChannel>();
     }

--- a/src/test/java/com/rabbitmq/client/impl/WorkPoolTests.java
+++ b/src/test/java/com/rabbitmq/client/impl/WorkPoolTests.java
@@ -30,7 +30,7 @@ import org.junit.Test;
  */
 public class WorkPoolTests {
 
-    private final WorkPool<String, Object> pool = new WorkPool<String, Object>();
+    private final WorkPool<String, Object> pool = new WorkPool<String, Object>(-1);
 
     /**
      * Test unknown key tolerated silently

--- a/src/test/java/com/rabbitmq/client/test/ClientTests.java
+++ b/src/test/java/com/rabbitmq/client/test/ClientTests.java
@@ -54,7 +54,8 @@ import org.junit.runners.Suite;
     FrameBuilderTest.class,
     PropertyFileInitialisationTest.class,
     ClientVersionTest.class,
-    StrictExceptionHandlerTest.class
+    StrictExceptionHandlerTest.class,
+    NoAutoRecoveryWhenTcpWindowIsFullTest.class
 })
 public class ClientTests {
 

--- a/src/test/java/com/rabbitmq/client/test/NoAutoRecoveryWhenTcpWindowIsFullTest.java
+++ b/src/test/java/com/rabbitmq/client/test/NoAutoRecoveryWhenTcpWindowIsFullTest.java
@@ -1,0 +1,200 @@
+// Copyright (c) 2018-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.test;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.Recoverable;
+import com.rabbitmq.client.RecoveryListener;
+import com.rabbitmq.client.impl.recovery.AutorecoveringChannel;
+import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test to trigger and check the fix of https://github.com/rabbitmq/rabbitmq-java-client/issues/341.
+ * Conditions:
+ *   - client registers consumer and a call QoS after
+ *   - client get many messages and the consumer is slow
+ *   - the work pool queue is full, the reading thread is stuck
+ *   - more messages come from the network and saturates the TCP buffer
+ *   - the connection dies but the client doesn't detect it
+ *   - acks of messages fail
+ *   - connection recovery is never triggered
+ *
+ * The fix consists in triggering connection recovery when writing
+ * to the socket fails. As the socket is dead, the closing
+ * sequence can take some time, hence the setup of the shutdown
+ * listener, which avoids waiting for the socket termination by
+ * the OS (can take 15 minutes on linux).
+ */
+public class NoAutoRecoveryWhenTcpWindowIsFullTest {
+
+    private static final int QOS_PREFETCH = 64;
+    private static final int NUM_MESSAGES_TO_PRODUCE = 100000;
+    private static final int MESSAGE_PROCESSING_TIME_MS = 3000;
+
+    private ExecutorService dispatchingService;
+    private ExecutorService producerService;
+    private ExecutorService shutdownService;
+    private AutorecoveringConnection producingConnection;
+    private AutorecoveringChannel producingChannel;
+    private AutorecoveringConnection consumingConnection;
+    private AutorecoveringChannel consumingChannel;
+
+    private CountDownLatch consumerRecoverOkLatch;
+
+    @Before
+    public void setUp() throws Exception {
+        dispatchingService = Executors.newSingleThreadExecutor();
+        shutdownService = Executors.newSingleThreadExecutor();
+        producerService = Executors.newSingleThreadExecutor();
+        final ConnectionFactory factory = TestUtils.connectionFactory();
+        factory.setAutomaticRecoveryEnabled(true);
+        factory.setTopologyRecoveryEnabled(true);
+        // we try to set the lower values for closing timeouts, etc.
+        // this makes the test execute faster.
+        factory.setShutdownExecutor(shutdownService);
+        factory.setShutdownTimeout(10000);
+        factory.setRequestedHeartbeat(5);
+        factory.setShutdownExecutor(dispatchingService);
+        factory.setNetworkRecoveryInterval(1000);
+
+        producingConnection = (AutorecoveringConnection) factory.newConnection("Producer Connection");
+        producingChannel = (AutorecoveringChannel) producingConnection.createChannel();
+        consumingConnection = (AutorecoveringConnection) factory.newConnection("Consuming Connection");
+        consumingChannel = (AutorecoveringChannel) consumingConnection.createChannel();
+
+        consumerRecoverOkLatch = new CountDownLatch(1);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        dispatchingService.shutdownNow();
+        producerService.shutdownNow();
+        shutdownService.shutdownNow();
+        closeConnectionIfOpen(consumingConnection);
+        closeConnectionIfOpen(producingConnection);
+    }
+
+    @Test
+    public void failureAndRecovery() throws IOException, InterruptedException {
+        final String queue = UUID.randomUUID().toString();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        consumingConnection.addRecoveryListener(new RecoveryListener() {
+
+            @Override
+            public void handleRecovery(Recoverable recoverable) {
+            }
+
+            @Override
+            public void handleRecoveryStarted(Recoverable recoverable) {
+                latch.countDown();
+            }
+        });
+
+        declareQueue(producingChannel, queue);
+        produceMessagesInBackground(producingChannel, queue);
+        startConsumer(queue);
+
+        assertThat(
+            "Connection should have been closed and should have recovered by now",
+            latch.await(60, TimeUnit.SECONDS), is(true)
+        );
+
+        assertThat(
+            "Consumer should have recovered by now",
+            latch.await(5, TimeUnit.SECONDS), is(true)
+        );
+    }
+
+    private void closeConnectionIfOpen(Connection connection) throws IOException {
+        if (connection.isOpen()) {
+            connection.close();
+        }
+    }
+
+    private void declareQueue(final Channel channel, final String queue) throws IOException {
+        final Map<String, Object> queueArguments = new HashMap<String, Object>();
+        channel.queueDeclare(queue, false, false, false, queueArguments);
+    }
+
+    private void produceMessagesInBackground(final Channel channel, final String queue) {
+        final AMQP.BasicProperties properties = new AMQP.BasicProperties.Builder().deliveryMode(1).build();
+        producerService.submit(new Callable<Void>() {
+
+            @Override
+            public Void call() throws Exception {
+                for (int i = 0; i < NUM_MESSAGES_TO_PRODUCE; i++) {
+                    channel.basicPublish("", queue, false, properties, ("MSG NUM" + i).getBytes());
+                }
+                closeConnectionIfOpen(producingConnection);
+                return null;
+            }
+        });
+    }
+
+    private void startConsumer(final String queue) throws IOException {
+        consumingChannel.basicConsume(queue, false, "", false, false, null, new DefaultConsumer(consumingChannel) {
+
+            @Override
+            public void handleRecoverOk(String consumerTag) {
+                consumerRecoverOkLatch.countDown();
+            }
+
+            @Override
+            public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
+                consumerWork();
+                consumingChannel.basicAck(envelope.getDeliveryTag(), false);
+            }
+        });
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        consumingChannel.basicQos(QOS_PREFETCH);
+    }
+
+    private void consumerWork() {
+        try {
+            Thread.sleep(MESSAGE_PROCESSING_TIME_MS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}
+

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
 
-    <root level="warn">
+    <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="warn">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
Detecting connection failure on reading can take a lot of time
(even forever if the reading thread is stuck), so connection
recovery can now be triggered when a write operation fails.
This can make the client more reactive to detect failing connections.

Closes #341.