### PR TITLE
Allow pluggable means of acquiring the username and password for authentication

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -1080,7 +1080,9 @@ public class ConnectionFactory implements Cloneable {
 
     @Override public ConnectionFactory clone(){
         try {
-            return (ConnectionFactory)super.clone();
+            ConnectionFactory clone = (ConnectionFactory)super.clone();
+            clone.credentialsProv = (CredentialsProvider)clone.credentialsProv.clone();
+            return clone;
         } catch (CloneNotSupportedException e) {
             throw new Error(e);
         }

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -129,8 +129,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     private final int requestedFrameMax;
     private final int handshakeTimeout;
     private final int shutdownTimeout;
-    private final String username;
-    private final String password;
+    private final CredentialsProvider credentialsProvider;
     private final Collection<BlockedListener> blockedListeners = new CopyOnWriteArrayList<BlockedListener>();
     protected final MetricsCollector metricsCollector;
     private final int channelRpcTimeout;
@@ -209,8 +208,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     public AMQConnection(ConnectionParams params, FrameHandler frameHandler, MetricsCollector metricsCollector)
     {
         checkPreconditions();
-        this.username = params.getUsername();
-        this.password = params.getPassword();
+        this.credentialsProvider = params.getCredentialsProvider();
         this._frameHandler = frameHandler;
         this._virtualHost = params.getVirtualHost();
         this._exceptionHandler = params.getExceptionHandler();
@@ -323,8 +321,10 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
                                               "server offered [" + connStart.getMechanisms() + "]");
             }
 
+            String username = credentialsProvider.getUsername();
+            String password = credentialsProvider.getPassword();
             LongString challenge = null;
-            LongString response = sm.handleChallenge(null, this.username, this.password);
+            LongString response = sm.handleChallenge(null, username, password);
 
             do {
                 Method method = (challenge == null)
@@ -341,7 +341,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
                         connTune = (AMQP.Connection.Tune) serverResponse;
                     } else {
                         challenge = ((AMQP.Connection.Secure) serverResponse).getChallenge();
-                        response = sm.handleChallenge(challenge, this.username, this.password);
+                        response = sm.handleChallenge(challenge, username, password);
                     }
                 } catch (ShutdownSignalException e) {
                     Method shutdownMethod = e.getReason();
@@ -1021,7 +1021,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
 
     @Override public String toString() {
         final String virtualHost = "/".equals(_virtualHost) ? _virtualHost : "/" + _virtualHost;
-        return "amqp://" + this.username + "@" + getHostAddress() + ":" + getPort() + virtualHost;
+        return "amqp://" + credentialsProvider.getUsername() + "@" + getHostAddress() + ":" + getPort() + virtualHost;
     }
 
     private String getHostAddress() {

--- a/src/main/java/com/rabbitmq/client/impl/AbstractCredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/AbstractCredentialsProvider.java
@@ -35,5 +35,14 @@ public abstract class AbstractCredentialsProvider implements CredentialsProvider
     public void setPassword(String password) {
         throw new UnsupportedOperationException();
     }
+    
+    /**
+     * Default clone() behavior is to call Object's clone() method. If you need more custom
+     * behavior, override clone().
+     */
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
 
 }

--- a/src/main/java/com/rabbitmq/client/impl/AbstractCredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/AbstractCredentialsProvider.java
@@ -1,0 +1,39 @@
+package com.rabbitmq.client.impl;
+
+/**
+ * Base class for extending to implement a concrete CredentialsProvider, used
+ * when creating connections to the broker or reconnecting during recovery.
+ */
+public abstract class AbstractCredentialsProvider implements CredentialsProvider {
+
+    /* (non-Javadoc)
+     * @see com.rabbitmq.client.impl.CredentialsProvider#getUsername()
+     */
+    @Override
+    public abstract String getUsername();
+
+    /* (non-Javadoc)
+     * @see com.rabbitmq.client.impl.CredentialsProvider#getPassword()
+     */
+    @Override
+    public abstract String getPassword();
+
+    /** 
+     * Default implementation throws UnsupportedOperationException() but can be overridden for 
+     * classes which support setting a static username.
+     */
+    @Override
+    public void setUsername(String username) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** 
+     * Default implementation throws UnsupportedOperationException() but can be overridden for
+     * classes which support setting a static password.
+     */
+    @Override
+    public void setPassword(String password) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -26,8 +26,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 
 public class ConnectionParams {
-    private String username;
-    private String password;
+    private CredentialsProvider credentialsProvider;
     private ExecutorService consumerWorkServiceExecutor;
     private ScheduledExecutorService heartbeatExecutor;
     private ExecutorService shutdownExecutor;
@@ -50,12 +49,8 @@ public class ConnectionParams {
 
     public ConnectionParams() {}
 
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPassword() {
-        return password;
+    public CredentialsProvider getCredentialsProvider() {
+        return credentialsProvider;
     }
 
     public ExecutorService getConsumerWorkServiceExecutor() {
@@ -130,12 +125,8 @@ public class ConnectionParams {
         return channelShouldCheckRpcResponseType;
     }
 
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
+    public void setCredentialsProvider(CredentialsProvider credentialsProvider) {
+        this.credentialsProvider = credentialsProvider;
     }
 
     public void setConsumerWorkServiceExecutor(ExecutorService consumerWorkServiceExecutor) {

--- a/src/main/java/com/rabbitmq/client/impl/CredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/CredentialsProvider.java
@@ -4,8 +4,10 @@ package com.rabbitmq.client.impl;
  * Provider interface for establishing credentials for connecting to the broker. Especially useful
  * for situations where credentials might change before a recovery takes place or where it is 
  * convenient to plug in an outside custom implementation.
+ * 
+ * @see com.rabbitmq.client.impl.AbstractCredentialsProvider
  */
-public interface CredentialsProvider {
+public interface CredentialsProvider extends Cloneable {
 
     String getUsername();
 
@@ -15,4 +17,6 @@ public interface CredentialsProvider {
 
     void setPassword(String password);
 
+    Object clone() throws CloneNotSupportedException;
+    
 }

--- a/src/main/java/com/rabbitmq/client/impl/CredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/CredentialsProvider.java
@@ -1,0 +1,18 @@
+package com.rabbitmq.client.impl;
+
+/**
+ * Provider interface for establishing credentials for connecting to the broker. Especially useful
+ * for situations where credentials might change before a recovery takes place or where it is 
+ * convenient to plug in an outside custom implementation.
+ */
+public interface CredentialsProvider {
+
+    String getUsername();
+
+    String getPassword();
+
+    void setUsername(String username);
+
+    void setPassword(String password);
+
+}

--- a/src/main/java/com/rabbitmq/client/impl/DefaultCredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/DefaultCredentialsProvider.java
@@ -1,0 +1,32 @@
+package com.rabbitmq.client.impl;
+
+/**
+ * Default implementation of a CredentialsProvider which simply holds a static
+ * username and password.
+ */
+public class DefaultCredentialsProvider extends AbstractCredentialsProvider {
+
+    protected String username;
+    protected String password;
+    
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+    
+    @Override
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    @Override
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+}

--- a/src/main/java/com/rabbitmq/client/impl/DefaultCredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/DefaultCredentialsProvider.java
@@ -28,5 +28,5 @@ public class DefaultCredentialsProvider extends AbstractCredentialsProvider {
     public void setPassword(String password) {
         this.password = password;
     }
-
+    
 }


### PR DESCRIPTION
Use a CredentialsProvider to pass usernames & passwords into AMQConnection with default
implementation that simply tracks a static username and password. Useful
for reconnect scenarios where the username or password might have
changed between the connect & reconnect.  Doesn't break the existing API,
which uses the DefaultCredentialsProvider unless otherwise configured
with setCredentialsProvider.

## Proposed Changes

Rationale: in some customized AuthC/AuthZ scenarios, especially where someone may be using  auth_backend_http, a username or a password might change between the time it was first used and the time it was needed to reconnect for a connection recovery.

By passing a CredentialsProvider (in a ConnectionParameters) to AMQConnection instead of a static username and password, and by requesting the username and password of the CredentialsProvider just prior to using them to connect, it is possible to provide a custom instance which knows how to go and fetch new credentials if necessary prior to making the connection.

So for example, if a custom token-based oauth scheme is used, and the token is short-lived, this custom implementation could request a new oauth token to be provided as the 'password', which then gets validated on the other side of the request by auth_backend_http.

Without some mechanism to refresh credentials, a recovery would continue to use the original token, which may no longer be valid.

It's also conceivable that it may be useful in some cases to have a username provided to a dumb client by some API call in a manner which is semi-random or at least changeable.  That, too, would be supportable by a custom CredentialsProvider (and then again handled by a custom server with auth_backend_http).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

I'm still finding my way around in the test infrastructure, but I will try to add some tests for a custom CredentialsProvider as well once I figure it out.  Existing tests with the new DefaultCredentialsProvider are working in my local environment, so I'm reasonably confident.

Apologies for hitting cmd-shift-O (force of habit) once in ConnectionFactory and creating some spurious differences where Eclipse did an "organize imports".  I can try to revert that if it's important.

I selfishly made these changes on the 4.4 branch because we're stuck with 4.4 until we can end our Java 7 support in the wild.