### PR TITLE
Do not override default client properties when reading from propertie…

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactoryConfigurator.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactoryConfigurator.java
@@ -182,7 +182,8 @@ public class ConnectionFactoryConfigurator {
                 );
             }
         }
-        cf.setClientProperties(clientProperties);
+
+        cf.getClientProperties().putAll(clientProperties);
 
         String automaticRecovery = properties.get(prefix + CONNECTION_RECOVERY_ENABLED);
         if (automaticRecovery != null) {


### PR DESCRIPTION
…s file

## Proposed Changes

On load from a  properties file, if client properties are not specified, there will be no client properties defined.  This results  in default extensions not being enabled whitch breaks, such as cancel notifies from the server. Namely, I  encountered this issue while trying to  use https://www.rabbitmq.com/consumer-cancel.html.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
