### PR TITLE
Use default client properties when reading from properties file

### DIFF
--- a/src/test/java/com/rabbitmq/client/test/PropertyFileInitialisationTest.java
+++ b/src/test/java/com/rabbitmq/client/test/PropertyFileInitialisationTest.java
@@ -91,22 +91,34 @@ public class PropertyFileInitialisationTest {
         assertThat(cf.getPort(), is(5673));
     }
 
-    @Test public void propertyInitialisationIncludeDefaultClientProperties() {
+    @Test public void propertyInitialisationIncludeDefaultClientPropertiesByDefault() {
+        cf.load(new HashMap<String, String>());
+        assertThat(cf.getClientProperties().entrySet(), hasSize(defaultClientProperties().size()));
+    }
+
+    @Test public void propertyInitialisationAddCustomClientProperty() {
         cf.load(new HashMap<String, String>() {{
-            put("rabbitmq.use.default.client.properties", "true");
             put("rabbitmq.client.properties.foo", "bar");
         }});
         assertThat(cf.getClientProperties().entrySet(), hasSize(defaultClientProperties().size() + 1));
         assertThat(cf.getClientProperties().get("foo").toString(), is("bar"));
     }
 
-    @Test public void propertyInitialisationDoNotIncludeDefaultClientProperties() {
+    @Test public void propertyInitialisationGetRidOfDefaultClientPropertyWithEmptyValue() {
+        final String key = defaultClientProperties().entrySet().iterator().next().getKey();
         cf.load(new HashMap<String, String>() {{
-            put("rabbitmq.use.default.client.properties", "false");
-            put("rabbitmq.client.properties.foo", "bar");
+            put("rabbitmq.client.properties." + key, "");
         }});
-        assertThat(cf.getClientProperties().entrySet(), hasSize(1));
-        assertThat(cf.getClientProperties().get("foo").toString(), is("bar"));
+        assertThat(cf.getClientProperties().entrySet(), hasSize(defaultClientProperties().size() - 1));
+    }
+
+    @Test public void propertyInitialisationOverrideDefaultClientProperty() {
+        final String key = defaultClientProperties().entrySet().iterator().next().getKey();
+        cf.load(new HashMap<String, String>() {{
+            put("rabbitmq.client.properties." + key, "whatever");
+        }});
+        assertThat(cf.getClientProperties().entrySet(), hasSize(defaultClientProperties().size()));
+        assertThat(cf.getClientProperties().get(key).toString(), is("whatever"));
     }
 
     @Test public void propertyInitialisationDoNotUseNio() throws Exception {


### PR DESCRIPTION
This commit adds the default client properties when reading
connection factory settings from a properties file. Default client properties
can be customized and gotten rid of as well.

Original idea by @dgoetsch contributed in #367.

Fixes #368.