### PR TITLE
Multi-threaded topology recovery

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -127,7 +127,7 @@ public class ConnectionFactory implements Cloneable {
 
     private boolean automaticRecovery               = true;
     private boolean topologyRecovery                = true;
-    private int recoveryThreads                     = 1;
+    private int topologyRecoveryThreads             = 1;
     
     // long is used to make sure the users can use both ints
     // and longs safely. It is unlikely that anybody'd need
@@ -714,13 +714,13 @@ public class ConnectionFactory implements Cloneable {
         this.topologyRecovery = topologyRecovery;
     }
     
-    public int getRecoveryThreadCount() {
-        return recoveryThreads;
+    public int getTopologyRecoveryThreadCount() {
+        return topologyRecoveryThreads;
     }
     
     // TODO Document that your exception handler method should be thread safe
-    public void setRecoveryThreadCount(final int recoveryThreads) {
-        this.recoveryThreads = recoveryThreads;
+    public void setTopologyRecoveryThreadCount(final int topologyRecoveryThreads) {
+        this.topologyRecoveryThreads = topologyRecoveryThreads;
     }
 
     public void setMetricsCollector(MetricsCollector metricsCollector) {
@@ -1021,7 +1021,7 @@ public class ConnectionFactory implements Cloneable {
         result.setNetworkRecoveryInterval(networkRecoveryInterval);
         result.setRecoveryDelayHandler(recoveryDelayHandler);
         result.setTopologyRecovery(topologyRecovery);
-        result.setRecoveryThreadCount(recoveryThreads);
+        result.setTopologyRecoveryThreadCount(topologyRecoveryThreads);
         result.setExceptionHandler(exceptionHandler);
         result.setThreadFactory(threadFactory);
         result.setHandshakeTimeout(handshakeTimeout);

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -127,7 +127,8 @@ public class ConnectionFactory implements Cloneable {
 
     private boolean automaticRecovery               = true;
     private boolean topologyRecovery                = true;
-
+    private int topologyRecoveryThreads           = 1;
+    
     // long is used to make sure the users can use both ints
     // and longs safely. It is unlikely that anybody'd need
     // to use recovery intervals > Integer.MAX_VALUE in practice.
@@ -339,7 +340,7 @@ public class ConnectionFactory implements Cloneable {
         setUri(new URI(uriString));
     }
 
-    private String uriDecode(String s) {
+    private static String uriDecode(String s) {
         try {
             // URLDecode decodes '+' to a space, as for
             // form encoding.  So protect plus signs.
@@ -523,7 +524,6 @@ public class ConnectionFactory implements Cloneable {
      *
      * @see #setSocketConfigurator(SocketConfigurator)
      */
-    @SuppressWarnings("unused")
     public SocketConfigurator getSocketConfigurator() {
         return socketConf;
     }
@@ -701,7 +701,6 @@ public class ConnectionFactory implements Cloneable {
      * @return true if topology recovery is enabled, false otherwise
      * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
-    @SuppressWarnings("unused")
     public boolean isTopologyRecoveryEnabled() {
         return topologyRecovery;
     }
@@ -713,6 +712,15 @@ public class ConnectionFactory implements Cloneable {
      */
     public void setTopologyRecoveryEnabled(boolean topologyRecovery) {
         this.topologyRecovery = topologyRecovery;
+    }
+    
+    public int getTopologyRecoveryThreadCount() {
+        return topologyRecoveryThreads;
+    }
+    
+    // TODO Document that your exception handler method should be thread safe
+    public void setTopologyRecoveryThreadCount(final int topologyRecoveryThreads) {
+        this.topologyRecoveryThreads = topologyRecoveryThreads;
     }
 
     public void setMetricsCollector(MetricsCollector metricsCollector) {
@@ -1013,6 +1021,7 @@ public class ConnectionFactory implements Cloneable {
         result.setNetworkRecoveryInterval(networkRecoveryInterval);
         result.setRecoveryDelayHandler(recoveryDelayHandler);
         result.setTopologyRecovery(topologyRecovery);
+        result.setTopologyRecoveryThreadCount(topologyRecoveryThreads);
         result.setExceptionHandler(exceptionHandler);
         result.setThreadFactory(threadFactory);
         result.setHandshakeTimeout(handshakeTimeout);

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -127,7 +127,7 @@ public class ConnectionFactory implements Cloneable {
 
     private boolean automaticRecovery               = true;
     private boolean topologyRecovery                = true;
-    private int topologyRecoveryThreads             = 1;
+    private int recoveryThreads                     = 1;
     
     // long is used to make sure the users can use both ints
     // and longs safely. It is unlikely that anybody'd need
@@ -714,13 +714,13 @@ public class ConnectionFactory implements Cloneable {
         this.topologyRecovery = topologyRecovery;
     }
     
-    public int getTopologyRecoveryThreadCount() {
-        return topologyRecoveryThreads;
+    public int getRecoveryThreadCount() {
+        return recoveryThreads;
     }
     
     // TODO Document that your exception handler method should be thread safe
-    public void setTopologyRecoveryThreadCount(final int topologyRecoveryThreads) {
-        this.topologyRecoveryThreads = topologyRecoveryThreads;
+    public void setRecoveryThreadCount(final int recoveryThreads) {
+        this.recoveryThreads = recoveryThreads;
     }
 
     public void setMetricsCollector(MetricsCollector metricsCollector) {
@@ -1021,7 +1021,7 @@ public class ConnectionFactory implements Cloneable {
         result.setNetworkRecoveryInterval(networkRecoveryInterval);
         result.setRecoveryDelayHandler(recoveryDelayHandler);
         result.setTopologyRecovery(topologyRecovery);
-        result.setTopologyRecoveryThreadCount(topologyRecoveryThreads);
+        result.setRecoveryThreadCount(recoveryThreads);
         result.setExceptionHandler(exceptionHandler);
         result.setThreadFactory(threadFactory);
         result.setHandshakeTimeout(handshakeTimeout);

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -127,7 +127,7 @@ public class ConnectionFactory implements Cloneable {
 
     private boolean automaticRecovery               = true;
     private boolean topologyRecovery                = true;
-    private int topologyRecoveryThreads           = 1;
+    private int topologyRecoveryThreads             = 1;
     
     // long is used to make sure the users can use both ints
     // and longs safely. It is unlikely that anybody'd need

--- a/src/main/java/com/rabbitmq/client/ExceptionHandler.java
+++ b/src/main/java/com/rabbitmq/client/ExceptionHandler.java
@@ -108,7 +108,7 @@ public interface ExceptionHandler {
      * during topology (exchanges, queues, bindings, consumers) recovery
      * that it can't otherwise deal with.
      * @param conn the Connection that caught the exception
-     * @param ch the Channel that caught the exception
+     * @param ch the Channel that caught the exception. May be null.
      * @param exception the exception caught in the driver thread
      */
 

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -41,7 +41,7 @@ public class ConnectionParams {
     private long networkRecoveryInterval;
     private RecoveryDelayHandler recoveryDelayHandler;
     private boolean topologyRecovery;
-    private int recoveryThreads = 1;
+    private int topologyRecoveryThreads = 1;
     private int channelRpcTimeout;
     private boolean channelShouldCheckRpcResponseType;
     private ErrorOnWriteListener errorOnWriteListener;
@@ -116,8 +116,8 @@ public class ConnectionParams {
         return topologyRecovery;
     }
     
-    public int getRecoveryThreadCount() {
-        return recoveryThreads;
+    public int getTopologyRecoveryThreadCount() {
+        return topologyRecoveryThreads;
     }
 
     public ThreadFactory getThreadFactory() {
@@ -180,8 +180,8 @@ public class ConnectionParams {
         this.topologyRecovery = topologyRecovery;
     }
     
-    public void setRecoveryThreadCount(final int recoveryThreads) {
-        this.recoveryThreads = recoveryThreads;
+    public void setTopologyRecoveryThreadCount(final int topologyRecoveryThreads) {
+        this.topologyRecoveryThreads = topologyRecoveryThreads;
     }
 
     public void setExceptionHandler(ExceptionHandler exceptionHandler) {

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -41,7 +41,7 @@ public class ConnectionParams {
     private long networkRecoveryInterval;
     private RecoveryDelayHandler recoveryDelayHandler;
     private boolean topologyRecovery;
-    private int topologyRecoveryThreads = 1;
+    private ExecutorService topologyRecoveryExecutor;
     private int channelRpcTimeout;
     private boolean channelShouldCheckRpcResponseType;
     private ErrorOnWriteListener errorOnWriteListener;
@@ -116,8 +116,12 @@ public class ConnectionParams {
         return topologyRecovery;
     }
     
-    public int getTopologyRecoveryThreadCount() {
-        return topologyRecoveryThreads;
+    /**
+     * Get the topology recovery executor. If null, the main connection thread should be used.
+     * @return executor. May be null.
+     */
+    public ExecutorService getTopologyRecoveryExecutor() {
+        return topologyRecoveryExecutor;
     }
 
     public ThreadFactory getThreadFactory() {
@@ -180,8 +184,8 @@ public class ConnectionParams {
         this.topologyRecovery = topologyRecovery;
     }
     
-    public void setTopologyRecoveryThreadCount(final int topologyRecoveryThreads) {
-        this.topologyRecoveryThreads = topologyRecoveryThreads;
+    public void setTopologyRecoveryExecutor(final ExecutorService topologyRecoveryExecutor) {
+        this.topologyRecoveryExecutor = topologyRecoveryExecutor;
     }
 
     public void setExceptionHandler(ExceptionHandler exceptionHandler) {

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -41,7 +41,7 @@ public class ConnectionParams {
     private long networkRecoveryInterval;
     private RecoveryDelayHandler recoveryDelayHandler;
     private boolean topologyRecovery;
-    private int topologyRecoveryThreads = 1;
+    private int recoveryThreads = 1;
     private int channelRpcTimeout;
     private boolean channelShouldCheckRpcResponseType;
     private ErrorOnWriteListener errorOnWriteListener;
@@ -116,8 +116,8 @@ public class ConnectionParams {
         return topologyRecovery;
     }
     
-    public int getTopologyRecoveryThreadCount() {
-        return topologyRecoveryThreads;
+    public int getRecoveryThreadCount() {
+        return recoveryThreads;
     }
 
     public ThreadFactory getThreadFactory() {
@@ -180,8 +180,8 @@ public class ConnectionParams {
         this.topologyRecovery = topologyRecovery;
     }
     
-    public void setTopologyRecoveryThreadCount(final int topologyRecoveryThreads) {
-        this.topologyRecoveryThreads = topologyRecoveryThreads;
+    public void setRecoveryThreadCount(final int recoveryThreads) {
+        this.recoveryThreads = recoveryThreads;
     }
 
     public void setExceptionHandler(ExceptionHandler exceptionHandler) {

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -41,6 +41,7 @@ public class ConnectionParams {
     private long networkRecoveryInterval;
     private RecoveryDelayHandler recoveryDelayHandler;
     private boolean topologyRecovery;
+    private int topologyRecoveryThreads = 1;
     private int channelRpcTimeout;
     private boolean channelShouldCheckRpcResponseType;
     private ErrorOnWriteListener errorOnWriteListener;
@@ -114,10 +115,14 @@ public class ConnectionParams {
     public boolean isTopologyRecoveryEnabled() {
         return topologyRecovery;
     }
+    
+    public int getTopologyRecoveryThreadCount() {
+        return topologyRecoveryThreads;
+    }
 
     public ThreadFactory getThreadFactory() {
-    return threadFactory;
-  }
+        return threadFactory;
+    }
 
     public int getChannelRpcTimeout() {
         return channelRpcTimeout;
@@ -173,6 +178,10 @@ public class ConnectionParams {
 
     public void setTopologyRecovery(boolean topologyRecovery) {
         this.topologyRecovery = topologyRecovery;
+    }
+    
+    public void setTopologyRecoveryThreadCount(final int topologyRecoveryThreads) {
+        this.topologyRecoveryThreads = topologyRecoveryThreads;
     }
 
     public void setExceptionHandler(ExceptionHandler exceptionHandler) {

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -536,7 +536,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
         if (newConn == null) {
             return;
         }
-
+        LOGGER.debug("Connection {} has recovered", newConn);
         this.addAutomaticRecoveryListener(newConn);
 	    this.recoverShutdownListeners(newConn);
 	    this.recoverBlockedListeners(newConn);
@@ -591,7 +591,6 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
 
     private void recoverChannels(final RecoveryAwareAMQConnection newConn) {
         for (AutorecoveringChannel ch : this.channels.values()) {
-            LOGGER.debug("Recovering channel {}", ch);
             try {
                 ch.automaticallyRecover(this, newConn);
                 LOGGER.debug("Channel {} has recovered", ch);
@@ -652,10 +651,9 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
 
     private void recoverExchange(final RecordedExchange x) {
         // recorded exchanges are guaranteed to be non-predefined (we filter out predefined ones in exchangeDeclare). MK.
-        LOGGER.debug("Recovering exchange {}", x);
         try {
             x.recover();
-            LOGGER.debug("Exchange {} has recovered", x);
+            LOGGER.debug("{} has recovered", x);
         } catch (Exception cause) {
             final String message = "Caught an exception while recovering exchange " + x.getName() +
                     ": " + cause.getMessage();
@@ -665,7 +663,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
     }
 
     private void recoverQueue(final String oldName, final RecordedQueue q) {
-        LOGGER.debug("Recovering queue {}", q);
+        LOGGER.debug("Recovering {}", q);
         try {
             q.recover();
             String newName = q.getName();
@@ -688,7 +686,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
             for (QueueRecoveryListener qrl : Utility.copy(this.queueRecoveryListeners)) {
                 qrl.queueRecovered(oldName, newName);
             }
-            LOGGER.debug("Queue {} has recovered", q);
+            LOGGER.debug("{} has recovered", q);
         } catch (Exception cause) {
             final String message = "Caught an exception while recovering queue " + oldName +
                                            ": " + cause.getMessage();
@@ -698,10 +696,9 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
     }
 
     private void recoverBinding(final RecordedBinding b) {
-        LOGGER.debug("Recovering binding {}", b);
         try {
             b.recover();
-            LOGGER.debug("Binding {} has recovered", b);
+            LOGGER.debug("{} has recovered", b);
         } catch (Exception cause) {
             String message = "Caught an exception while recovering binding between " + b.getSource() +
                                      " and " + b.getDestination() + ": " + cause.getMessage();
@@ -711,7 +708,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
     }
 
     private void recoverConsumer(final String tag, final RecordedConsumer consumer) {
-        LOGGER.debug("Recovering consumer {}", consumer);
+        LOGGER.debug("Recovering {}", consumer);
         try {
             String newTag = consumer.recover();
             // make sure server-generated tags are re-added. MK.
@@ -726,7 +723,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
             for (ConsumerRecoveryListener crl : Utility.copy(this.consumerRecoveryListeners)) {
                 crl.consumerRecovered(tag, newTag);
             }
-            LOGGER.debug("Consumer {} has recovered", consumer);
+            LOGGER.debug("{} has recovered", consumer);
         } catch (Exception cause) {
             final String message = "Caught an exception while recovering consumer " + tag +
                     ": " + cause.getMessage();

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -540,25 +540,12 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
         this.addAutomaticRecoveryListener(newConn);
 	    this.recoverShutdownListeners(newConn);
 	    this.recoverBlockedListeners(newConn);
-	    
-	    // Optionally support recovering channels & entities in parallel for connections that have a lot of channels, queues, bindings, etc.
-	    ExecutorService executor = null;
-        if (params.getRecoveryThreadCount() > 1) {
-            executor = Executors.newFixedThreadPool(params.getRecoveryThreadCount(), delegate.getThreadFactory());
-        }
-        try {
-    	    this.recoverChannels(newConn, executor);
-    	    // don't assign new delegate connection until channel recovery is complete
-    	    this.delegate = newConn;
-    	    // recover topology
-    	    if (this.params.isTopologyRecoveryEnabled()) {
-    	        recoverTopology(executor);
-    	    }
-        } finally {
-            if (executor != null) {
-                executor.shutdownNow();
-            }
-        }
+	    this.recoverChannels(newConn);
+	    // don't assign new delegate connection until channel recovery is complete
+	    this.delegate = newConn;
+	    if (this.params.isTopologyRecoveryEnabled()) {
+	        recoverTopology(params.getTopologyRecoveryThreadCount());
+	    }
 		this.notifyRecoveryListenersComplete();
     }
 
@@ -602,32 +589,14 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
 		return null;
     }
 
-    private void recoverChannels(final RecoveryAwareAMQConnection newConn, final ExecutorService executor) throws InterruptedException {
-        if (executor != null) {
-            final List<Callable<Object>> tasks = new ArrayList<Callable<Object>>();
-            for (final AutorecoveringChannel ch : this.channels.values()) {
-                tasks.add(Executors.callable(new Runnable() {
-                    @Override
-                    public void run() {
-                        recoverChannel(newConn, ch);
-                    }
-                }));
+    private void recoverChannels(final RecoveryAwareAMQConnection newConn) {
+        for (AutorecoveringChannel ch : this.channels.values()) {
+            try {
+                ch.automaticallyRecover(this, newConn);
+                LOGGER.debug("Channel {} has recovered", ch);
+            } catch (Throwable t) {
+                newConn.getExceptionHandler().handleChannelRecoveryException(ch, t);
             }
-            // invokeAll will block until all callables are completed
-            executor.invokeAll(tasks);
-        } else {
-            for (final AutorecoveringChannel ch : this.channels.values()) {
-                recoverChannel(newConn, ch);
-            }
-        }
-    }
-    
-    private void recoverChannel(final RecoveryAwareAMQConnection newConn, final AutorecoveringChannel ch) {
-        try {
-            ch.automaticallyRecover(this, newConn);
-            LOGGER.debug("Channel {} has recovered", ch);
-        } catch (Throwable t) {
-            newConn.getExceptionHandler().handleChannelRecoveryException(ch, t);
         }
     }
 
@@ -643,20 +612,26 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
         }
     }
     
-    private void recoverTopology(final ExecutorService executor) throws InterruptedException {
+    private void recoverTopology(final int recoveryThreads) throws InterruptedException {
         // The recovery sequence is the following:
         // 1. Recover exchanges
         // 2. Recover queues
         // 3. Recover bindings
         // 4. Recover consumers
-        if (executor != null) {
+        if (recoveryThreads > 1) {
+            // Support recovering entities in parallel for connections that have a lot of queues, bindings, & consumers
             // A channel is single threaded, so group things by channel and recover 1 entity at a time per channel
             // We still need to recover 1 type of entity at a time in case channel1 has a binding to a queue that is currently owned and being recovered by channel2 for example
-            // invokeAll will block until all callables are completed
-            executor.invokeAll(groupEntitiesByChannel(Utility.copy(recordedExchanges).values()));
-            executor.invokeAll(groupEntitiesByChannel(Utility.copy(recordedQueues).values()));
-            executor.invokeAll(groupEntitiesByChannel(Utility.copy(recordedBindings)));
-            executor.invokeAll(groupEntitiesByChannel(Utility.copy(consumers).values()));
+            final ExecutorService executor = Executors.newFixedThreadPool(recoveryThreads, delegate.getThreadFactory());
+            try {
+                // invokeAll will block until all callables are completed
+                executor.invokeAll(groupEntitiesByChannel(Utility.copy(recordedExchanges).values()));
+                executor.invokeAll(groupEntitiesByChannel(Utility.copy(recordedQueues).values()));
+                executor.invokeAll(groupEntitiesByChannel(Utility.copy(recordedBindings)));
+                executor.invokeAll(groupEntitiesByChannel(Utility.copy(consumers).values()));
+            } finally {
+                executor.shutdownNow();
+            }
         } else {
             // recover entities in serial on the main connection thread
             for (final RecordedExchange exchange : Utility.copy(recordedExchanges).values()) {
@@ -785,9 +760,9 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
             list.add(entity);
         }
         // now create a runnable per channel
-        final List<Callable<Object>> tasks = new ArrayList<Callable<Object>>();
+        final List<Callable<Object>> callables = new ArrayList<Callable<Object>>();
         for (final List<E> entityList : map.values()) {
-            tasks.add(Executors.callable(new Runnable() {
+            callables.add(Executors.callable(new Runnable() {
                 @Override
                 public void run() {
                     for (final E entity : entityList) {
@@ -806,7 +781,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
                 }
             }));
         }
-        return tasks;
+        return callables;
     }
 
     void recordQueueBinding(AutorecoveringChannel ch,

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedConsumer.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedConsumer.java
@@ -80,6 +80,6 @@ public class RecordedConsumer extends RecordedEntity {
     
     @Override
     public String toString() {
-        return "RecordedConsumer[tag=" + consumerTag + ", queue=" + queue + ", autoAck=" + autoAck + ", exclusive=" + exclusive + ", arguments=" + arguments + ", consumer=" + consumer + ", channel=" + channel;
+        return "RecordedConsumer[tag=" + consumerTag + ", queue=" + queue + ", autoAck=" + autoAck + ", exclusive=" + exclusive + ", arguments=" + arguments + ", consumer=" + consumer + ", channel=" + channel + "]";
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedConsumer.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedConsumer.java
@@ -77,4 +77,9 @@ public class RecordedConsumer extends RecordedEntity {
     public String getConsumerTag() {
         return consumerTag;
     }
+    
+    @Override
+    public String toString() {
+        return "RecordedConsumer[tag=" + consumerTag + ", queue=" + queue + ", autoAck=" + autoAck + ", exclusive=" + exclusive + ", arguments=" + arguments + ", consumer=" + consumer + ", channel=" + channel;
+    }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedExchange.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedExchange.java
@@ -61,6 +61,6 @@ public class RecordedExchange extends RecordedNamedEntity {
     
     @Override
     public String toString() {
-        return "RecordedExchange[name=" + name + ", type=" + type + ", durable=" + durable + ", autoDelete=" + autoDelete + ", arguments=" + arguments + ", channel=" + channel;
+        return "RecordedExchange[name=" + name + ", type=" + type + ", durable=" + durable + ", autoDelete=" + autoDelete + ", arguments=" + arguments + ", channel=" + channel + "]";
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedExchange.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedExchange.java
@@ -58,4 +58,9 @@ public class RecordedExchange extends RecordedNamedEntity {
     public boolean isAutoDelete() {
         return autoDelete;
     }
+    
+    @Override
+    public String toString() {
+        return "RecordedExchange[name=" + name + ", type=" + type + ", durable=" + durable + ", autoDelete=" + autoDelete + ", arguments=" + arguments + ", channel=" + channel;
+    }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedExchangeBinding.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedExchangeBinding.java
@@ -32,6 +32,6 @@ public class RecordedExchangeBinding extends RecordedBinding {
     
     @Override
     public String toString() {
-        return "RecordedExchangeBinding[source=" + source + ", destination=" + destination + ", routingKey=" + routingKey + ", arguments=" + arguments + ", channel=" + channel;
+        return "RecordedExchangeBinding[source=" + source + ", destination=" + destination + ", routingKey=" + routingKey + ", arguments=" + arguments + ", channel=" + channel + "]";
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedExchangeBinding.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedExchangeBinding.java
@@ -29,4 +29,9 @@ public class RecordedExchangeBinding extends RecordedBinding {
     public void recover() throws IOException {
         this.channel.getDelegate().exchangeBind(this.destination, this.source, this.routingKey, this.arguments);
     }
+    
+    @Override
+    public String toString() {
+        return "RecordedExchangeBinding[source=" + source + ", destination=" + destination + ", routingKey=" + routingKey + ", arguments=" + arguments + ", channel=" + channel;
+    }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueue.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueue.java
@@ -82,6 +82,6 @@ public class RecordedQueue extends RecordedNamedEntity {
     
     @Override
     public String toString() {
-        return "RecordedQueue[name=" + name + ", durable=" + durable + ", autoDelete=" + autoDelete + ", exclusive=" + exclusive + ", arguments=" + arguments + "serverNamed=" + serverNamed + ", channel=" + channel;
+        return "RecordedQueue[name=" + name + ", durable=" + durable + ", autoDelete=" + autoDelete + ", exclusive=" + exclusive + ", arguments=" + arguments + "serverNamed=" + serverNamed + ", channel=" + channel + "]";
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueue.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueue.java
@@ -79,4 +79,9 @@ public class RecordedQueue extends RecordedNamedEntity {
         this.arguments = value;
         return this;
     }
+    
+    @Override
+    public String toString() {
+        return "RecordedQueue[name=" + name + ", durable=" + durable + ", autoDelete=" + autoDelete + ", exclusive=" + exclusive + ", arguments=" + arguments + "serverNamed=" + serverNamed + ", channel=" + channel;
+    }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueueBinding.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueueBinding.java
@@ -32,6 +32,6 @@ public class RecordedQueueBinding extends RecordedBinding {
     
     @Override
     public String toString() {
-        return "RecordedQueueBinding[source=" + source + ", destination=" + destination + ", routingKey=" + routingKey + ", arguments=" + arguments + ", channel=" + channel;
+        return "RecordedQueueBinding[source=" + source + ", destination=" + destination + ", routingKey=" + routingKey + ", arguments=" + arguments + ", channel=" + channel + "]";
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueueBinding.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueueBinding.java
@@ -29,4 +29,9 @@ public class RecordedQueueBinding extends RecordedBinding {
     public void recover() throws IOException {
         this.channel.getDelegate().queueBind(this.getDestination(), this.getSource(), this.routingKey, this.arguments);
     }
+    
+    @Override
+    public String toString() {
+        return "RecordedQueueBinding[source=" + source + ", destination=" + destination + ", routingKey=" + routingKey + ", arguments=" + arguments + ", channel=" + channel;
+    }
 }

--- a/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
@@ -16,6 +16,7 @@
 package com.rabbitmq.client.test.functional;
 
 import com.rabbitmq.client.*;
+import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.impl.CredentialsProvider;
 import com.rabbitmq.client.impl.NetworkConnection;
 import com.rabbitmq.client.impl.recovery.*;
@@ -34,7 +35,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -168,11 +168,13 @@ public class ConnectionRecovery extends BrokerTestCase {
         final List<String> events = new CopyOnWriteArrayList<String>();
         final CountDownLatch latch = new CountDownLatch(2); // one when started, another when complete
         connection.addShutdownListener(new ShutdownListener() {
+            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 events.add("shutdown hook 1");
             }
         });
         connection.addShutdownListener(new ShutdownListener() {
+            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 events.add("shutdown hook 2");
             }
@@ -211,6 +213,7 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void shutdownHooksRecoveryOnConnection() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(2);
         connection.addShutdownListener(new ShutdownListener() {
+            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 latch.countDown();
             }
@@ -225,6 +228,7 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void shutdownHooksRecoveryOnChannel() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(3);
         channel.addShutdownListener(new ShutdownListener() {
+            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 latch.countDown();
             }
@@ -241,10 +245,12 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void blockedListenerRecovery() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(2);
         connection.addBlockedListener(new BlockedListener() {
+            @Override
             public void handleBlocked(String reason) throws IOException {
                 latch.countDown();
             }
 
+            @Override
             public void handleUnblocked() throws IOException {
                 latch.countDown();
             }
@@ -270,6 +276,7 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void returnListenerRecovery() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         channel.addReturnListener(new ReturnListener() {
+            @Override
             public void handleReturn(int replyCode, String replyText, String exchange,
                                      String routingKey, AMQP.BasicProperties properties,
                                      byte[] body) throws IOException {
@@ -285,10 +292,12 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void confirmListenerRecovery() throws IOException, InterruptedException, TimeoutException {
         final CountDownLatch latch = new CountDownLatch(1);
         channel.addConfirmListener(new ConfirmListener() {
+            @Override
             public void handleAck(long deliveryTag, boolean multiple) throws IOException {
                 latch.countDown();
             }
 
+            @Override
             public void handleNack(long deliveryTag, boolean multiple) throws IOException {
                 latch.countDown();
             }
@@ -693,9 +702,11 @@ public class ConnectionRecovery extends BrokerTestCase {
         final CountDownLatch latch = new CountDownLatch(2);
         final CountDownLatch startLatch = new CountDownLatch(2);
         final RecoveryListener listener = new RecoveryListener() {
+            @Override
             public void handleRecovery(Recoverable recoverable) {
                 latch.countDown();
             }
+            @Override
             public void handleRecoveryStarted(Recoverable recoverable) {
                 startLatch.countDown();
             }
@@ -792,7 +803,66 @@ public class ConnectionRecovery extends BrokerTestCase {
             closeAndWaitForRecovery((RecoverableConnection) testConnection);
             assertTrue(testConnection.isOpen());
         } finally {
-            connection.close();
+            testConnection.close();
+        }
+    }
+    
+    @Test public void recoveryWithMultipleThreads() throws Exception {
+        // test with 8 recovery threads
+        ConnectionFactory connectionFactory = buildConnectionFactoryWithRecoveryEnabled(false, 8);
+        assertEquals(8, connectionFactory.getRecoveryThreadCount());
+        RecoverableConnection testConnection = (RecoverableConnection) connectionFactory.newConnection();
+        try {
+            final List<Channel> channels = new ArrayList<Channel>();
+            final List<String> exchanges = new ArrayList<String>();
+            final List<String> queues = new ArrayList<String>();
+            // create 16 channels
+            final int channelCount = 16;
+            final int queuesPerChannel = 20;
+            final CountDownLatch latch = new CountDownLatch(channelCount * queuesPerChannel);
+            for (int i=0; i < channelCount; i++) {
+                final Channel testChannel = testConnection.createChannel();
+                String x = "tmp-x-topic-" + i;
+                exchanges.add(x);
+                testChannel.exchangeDeclare(x, "topic");
+                // create 20 queues and bindings per channel
+                for (int j=0; j < queuesPerChannel; j++) {
+                    String q = "tmp-q-" + i + "-" + j;
+                    queues.add(q);
+                    testChannel.queueDeclare(q, false, false, true, null);
+                    testChannel.queueBind(q, x, "tmp-key-" + i + "-" + j);
+                    testChannel.basicConsume(q, new DefaultConsumer(testChannel) {
+                        @Override
+                        public void handleDelivery(String consumerTag, Envelope envelope, BasicProperties properties, byte[] body) throws IOException {
+                            testChannel.basicAck(envelope.getDeliveryTag(), false);
+                            latch.countDown();
+                        }
+                    });
+                }
+            }
+            // now do recovery
+            closeAndWaitForRecovery(testConnection);
+            
+            // verify channels & topology recovered by publishing a message to each
+            for (int i=0; i < channelCount; i++) {
+                Channel ch = channels.get(i);
+                expectChannelRecovery(ch);
+                // publish message to each queue/consumer
+                for (int j=0; j < queuesPerChannel; j++) {
+                    ch.basicPublish("tmp-x-topic-" + i, "tmp-key-" + i + "-" + j, null, "msg".getBytes());
+                }
+            }
+            // verify all queues/consumers got it
+            assertTrue(latch.await(30, TimeUnit.SECONDS));
+            
+            // cleanup
+            Channel cleanupChannel = testConnection.createChannel();
+            for (String q : queues)
+                cleanupChannel.queueDelete(q);
+            for (String x : exchanges)
+                cleanupChannel.exchangeDelete(x);
+        } finally {
+            testConnection.close();
         }
     }
 
@@ -800,28 +870,28 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertEquals(exp, channel.queueDeclarePassive(q).getConsumerCount());
     }
 
-    private AMQP.Queue.DeclareOk declareClientNamedQueue(Channel ch, String q) throws IOException {
+    private static AMQP.Queue.DeclareOk declareClientNamedQueue(Channel ch, String q) throws IOException {
         return ch.queueDeclare(q, true, false, false, null);
     }
 
-    private AMQP.Queue.DeclareOk declareClientNamedAutoDeleteQueue(Channel ch, String q) throws IOException {
+    private static AMQP.Queue.DeclareOk declareClientNamedAutoDeleteQueue(Channel ch, String q) throws IOException {
         return ch.queueDeclare(q, true, false, true, null);
     }
 
 
-    private void declareClientNamedQueueNoWait(Channel ch, String q) throws IOException {
+    private static void declareClientNamedQueueNoWait(Channel ch, String q) throws IOException {
         ch.queueDeclareNoWait(q, true, false, false, null);
     }
 
-    private AMQP.Exchange.DeclareOk declareExchange(Channel ch, String x) throws IOException {
+    private static AMQP.Exchange.DeclareOk declareExchange(Channel ch, String x) throws IOException {
         return ch.exchangeDeclare(x, "fanout", false);
     }
 
-    private void declareExchangeNoWait(Channel ch, String x) throws IOException {
+    private static void declareExchangeNoWait(Channel ch, String x) throws IOException {
         ch.exchangeDeclareNoWait(x, "fanout", false, false, false, null);
     }
 
-    private void expectQueueRecovery(Channel ch, String q) throws IOException, InterruptedException, TimeoutException {
+    private static void expectQueueRecovery(Channel ch, String q) throws IOException, InterruptedException, TimeoutException {
         ch.confirmSelect();
         ch.queuePurge(q);
         AMQP.Queue.DeclareOk ok1 = declareClientNamedQueue(ch, q);
@@ -832,7 +902,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertEquals(1, ok2.getMessageCount());
     }
 
-    private void expectAutoDeleteQueueAndBindingRecovery(Channel ch, String x, String q) throws IOException, InterruptedException,
+    private static void expectAutoDeleteQueueAndBindingRecovery(Channel ch, String x, String q) throws IOException, InterruptedException,
                                                                                     TimeoutException {
         ch.confirmSelect();
         ch.queuePurge(q);
@@ -845,7 +915,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertEquals(1, ok2.getMessageCount());
     }
 
-    private void expectExchangeRecovery(Channel ch, String x) throws IOException, InterruptedException, TimeoutException {
+    private static void expectExchangeRecovery(Channel ch, String x) throws IOException, InterruptedException, TimeoutException {
         ch.confirmSelect();
         String q = ch.queueDeclare().getQueue();
         final String rk = "routing-key";
@@ -855,12 +925,14 @@ public class ConnectionRecovery extends BrokerTestCase {
         ch.exchangeDeclarePassive(x);
     }
 
-    private CountDownLatch prepareForRecovery(Connection conn) {
+    private static CountDownLatch prepareForRecovery(Connection conn) {
         final CountDownLatch latch = new CountDownLatch(1);
         ((AutorecoveringConnection)conn).addRecoveryListener(new RecoveryListener() {
+            @Override
             public void handleRecovery(Recoverable recoverable) {
                 latch.countDown();
             }
+            @Override
             public void handleRecoveryStarted(Recoverable recoverable) {
                 // No-op
             }
@@ -868,9 +940,10 @@ public class ConnectionRecovery extends BrokerTestCase {
         return latch;
     }
 
-    private CountDownLatch prepareForShutdown(Connection conn) throws InterruptedException {
+    private static CountDownLatch prepareForShutdown(Connection conn) {
         final CountDownLatch latch = new CountDownLatch(1);
         conn.addShutdownListener(new ShutdownListener() {
+            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 latch.countDown();
             }
@@ -882,7 +955,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         closeAndWaitForRecovery((AutorecoveringConnection)this.connection);
     }
 
-    private void closeAndWaitForRecovery(RecoverableConnection connection) throws IOException, InterruptedException {
+    private static void closeAndWaitForRecovery(RecoverableConnection connection) throws IOException, InterruptedException {
         CountDownLatch latch = prepareForRecovery(connection);
         Host.closeConnection((NetworkConnection) connection);
         wait(latch);
@@ -900,7 +973,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         wait(latch);
     }
 
-    private void expectChannelRecovery(Channel ch) throws InterruptedException {
+    private static void expectChannelRecovery(Channel ch) {
         assertTrue(ch.isOpen());
     }
 
@@ -909,48 +982,53 @@ public class ConnectionRecovery extends BrokerTestCase {
         return buildConnectionFactoryWithRecoveryEnabled(false);
     }
 
-    private RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery)
+    private static RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
         return (AutorecoveringConnection) cf.newConnection();
     }
 
-    private RecoverableConnection newRecoveringConnection(Address[] addresses)
+    private static RecoverableConnection newRecoveringConnection(Address[] addresses)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(false);
         // specifically use the Address[] overload
         return (AutorecoveringConnection) cf.newConnection(addresses);
     }
 
-    private RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, List<Address> addresses)
+    private static RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, List<Address> addresses)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
         return (AutorecoveringConnection) cf.newConnection(addresses);
     }
 
-    private RecoverableConnection newRecoveringConnection(List<Address> addresses)
+    private static RecoverableConnection newRecoveringConnection(List<Address> addresses)
             throws IOException, TimeoutException {
         return newRecoveringConnection(false, addresses);
     }
 
-    private RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, String connectionName)
+    private static RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, String connectionName)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
         return (RecoverableConnection) cf.newConnection(connectionName);
     }
 
-    private RecoverableConnection newRecoveringConnection(String connectionName)
+    private static RecoverableConnection newRecoveringConnection(String connectionName)
             throws IOException, TimeoutException {
         return newRecoveringConnection(false, connectionName);
     }
+    
+    private static ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery) {
+        return buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery, 1);
+    }
 
-    private ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery) {
+    private static ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery, final int recoveryThreads) {
         ConnectionFactory cf = TestUtils.connectionFactory();
         cf.setNetworkRecoveryInterval(RECOVERY_INTERVAL);
         cf.setAutomaticRecoveryEnabled(true);
         if (disableTopologyRecovery) {
             cf.setTopologyRecoveryEnabled(false);
         }
+        cf.setRecoveryThreadCount(recoveryThreads);
         return cf;
     }
 
@@ -960,15 +1038,15 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertTrue(latch.await(90, TimeUnit.SECONDS));
     }
 
-    private void waitForConfirms(Channel ch) throws InterruptedException, TimeoutException {
+    private static void waitForConfirms(Channel ch) throws InterruptedException, TimeoutException {
         ch.waitForConfirms(30 * 60 * 1000);
     }
 
-    private void assertRecordedQueues(Connection conn, int size) {
+    private static void assertRecordedQueues(Connection conn, int size) {
         assertEquals(size, ((AutorecoveringConnection)conn).getRecordedQueues().size());
     }
 
-    private void assertRecordedExchanges(Connection conn, int size) {
+    private static void assertRecordedExchanges(Connection conn, int size) {
         assertEquals(size, ((AutorecoveringConnection)conn).getRecordedExchanges().size());
     }
 }

--- a/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
@@ -16,7 +16,6 @@
 package com.rabbitmq.client.test.functional;
 
 import com.rabbitmq.client.*;
-import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.impl.CredentialsProvider;
 import com.rabbitmq.client.impl.NetworkConnection;
 import com.rabbitmq.client.impl.recovery.*;
@@ -35,6 +34,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -168,13 +168,11 @@ public class ConnectionRecovery extends BrokerTestCase {
         final List<String> events = new CopyOnWriteArrayList<String>();
         final CountDownLatch latch = new CountDownLatch(2); // one when started, another when complete
         connection.addShutdownListener(new ShutdownListener() {
-            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 events.add("shutdown hook 1");
             }
         });
         connection.addShutdownListener(new ShutdownListener() {
-            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 events.add("shutdown hook 2");
             }
@@ -213,7 +211,6 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void shutdownHooksRecoveryOnConnection() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(2);
         connection.addShutdownListener(new ShutdownListener() {
-            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 latch.countDown();
             }
@@ -228,7 +225,6 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void shutdownHooksRecoveryOnChannel() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(3);
         channel.addShutdownListener(new ShutdownListener() {
-            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 latch.countDown();
             }
@@ -245,12 +241,10 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void blockedListenerRecovery() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(2);
         connection.addBlockedListener(new BlockedListener() {
-            @Override
             public void handleBlocked(String reason) throws IOException {
                 latch.countDown();
             }
 
-            @Override
             public void handleUnblocked() throws IOException {
                 latch.countDown();
             }
@@ -276,7 +270,6 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void returnListenerRecovery() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         channel.addReturnListener(new ReturnListener() {
-            @Override
             public void handleReturn(int replyCode, String replyText, String exchange,
                                      String routingKey, AMQP.BasicProperties properties,
                                      byte[] body) throws IOException {
@@ -292,12 +285,10 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void confirmListenerRecovery() throws IOException, InterruptedException, TimeoutException {
         final CountDownLatch latch = new CountDownLatch(1);
         channel.addConfirmListener(new ConfirmListener() {
-            @Override
             public void handleAck(long deliveryTag, boolean multiple) throws IOException {
                 latch.countDown();
             }
 
-            @Override
             public void handleNack(long deliveryTag, boolean multiple) throws IOException {
                 latch.countDown();
             }
@@ -702,11 +693,9 @@ public class ConnectionRecovery extends BrokerTestCase {
         final CountDownLatch latch = new CountDownLatch(2);
         final CountDownLatch startLatch = new CountDownLatch(2);
         final RecoveryListener listener = new RecoveryListener() {
-            @Override
             public void handleRecovery(Recoverable recoverable) {
                 latch.countDown();
             }
-            @Override
             public void handleRecoveryStarted(Recoverable recoverable) {
                 startLatch.countDown();
             }
@@ -803,66 +792,7 @@ public class ConnectionRecovery extends BrokerTestCase {
             closeAndWaitForRecovery((RecoverableConnection) testConnection);
             assertTrue(testConnection.isOpen());
         } finally {
-            testConnection.close();
-        }
-    }
-    
-    @Test public void recoveryWithMultipleThreads() throws Exception {
-        // test with 8 recovery threads
-        ConnectionFactory connectionFactory = buildConnectionFactoryWithRecoveryEnabled(false, 8);
-        assertEquals(8, connectionFactory.getRecoveryThreadCount());
-        RecoverableConnection testConnection = (RecoverableConnection) connectionFactory.newConnection();
-        try {
-            final List<Channel> channels = new ArrayList<Channel>();
-            final List<String> exchanges = new ArrayList<String>();
-            final List<String> queues = new ArrayList<String>();
-            // create 16 channels
-            final int channelCount = 16;
-            final int queuesPerChannel = 20;
-            final CountDownLatch latch = new CountDownLatch(channelCount * queuesPerChannel);
-            for (int i=0; i < channelCount; i++) {
-                final Channel testChannel = testConnection.createChannel();
-                String x = "tmp-x-topic-" + i;
-                exchanges.add(x);
-                testChannel.exchangeDeclare(x, "topic");
-                // create 20 queues and bindings per channel
-                for (int j=0; j < queuesPerChannel; j++) {
-                    String q = "tmp-q-" + i + "-" + j;
-                    queues.add(q);
-                    testChannel.queueDeclare(q, false, false, true, null);
-                    testChannel.queueBind(q, x, "tmp-key-" + i + "-" + j);
-                    testChannel.basicConsume(q, new DefaultConsumer(testChannel) {
-                        @Override
-                        public void handleDelivery(String consumerTag, Envelope envelope, BasicProperties properties, byte[] body) throws IOException {
-                            testChannel.basicAck(envelope.getDeliveryTag(), false);
-                            latch.countDown();
-                        }
-                    });
-                }
-            }
-            // now do recovery
-            closeAndWaitForRecovery(testConnection);
-            
-            // verify channels & topology recovered by publishing a message to each
-            for (int i=0; i < channelCount; i++) {
-                Channel ch = channels.get(i);
-                expectChannelRecovery(ch);
-                // publish message to each queue/consumer
-                for (int j=0; j < queuesPerChannel; j++) {
-                    ch.basicPublish("tmp-x-topic-" + i, "tmp-key-" + i + "-" + j, null, "msg".getBytes());
-                }
-            }
-            // verify all queues/consumers got it
-            assertTrue(latch.await(30, TimeUnit.SECONDS));
-            
-            // cleanup
-            Channel cleanupChannel = testConnection.createChannel();
-            for (String q : queues)
-                cleanupChannel.queueDelete(q);
-            for (String x : exchanges)
-                cleanupChannel.exchangeDelete(x);
-        } finally {
-            testConnection.close();
+            connection.close();
         }
     }
 
@@ -870,28 +800,28 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertEquals(exp, channel.queueDeclarePassive(q).getConsumerCount());
     }
 
-    private static AMQP.Queue.DeclareOk declareClientNamedQueue(Channel ch, String q) throws IOException {
+    private AMQP.Queue.DeclareOk declareClientNamedQueue(Channel ch, String q) throws IOException {
         return ch.queueDeclare(q, true, false, false, null);
     }
 
-    private static AMQP.Queue.DeclareOk declareClientNamedAutoDeleteQueue(Channel ch, String q) throws IOException {
+    private AMQP.Queue.DeclareOk declareClientNamedAutoDeleteQueue(Channel ch, String q) throws IOException {
         return ch.queueDeclare(q, true, false, true, null);
     }
 
 
-    private static void declareClientNamedQueueNoWait(Channel ch, String q) throws IOException {
+    private void declareClientNamedQueueNoWait(Channel ch, String q) throws IOException {
         ch.queueDeclareNoWait(q, true, false, false, null);
     }
 
-    private static AMQP.Exchange.DeclareOk declareExchange(Channel ch, String x) throws IOException {
+    private AMQP.Exchange.DeclareOk declareExchange(Channel ch, String x) throws IOException {
         return ch.exchangeDeclare(x, "fanout", false);
     }
 
-    private static void declareExchangeNoWait(Channel ch, String x) throws IOException {
+    private void declareExchangeNoWait(Channel ch, String x) throws IOException {
         ch.exchangeDeclareNoWait(x, "fanout", false, false, false, null);
     }
 
-    private static void expectQueueRecovery(Channel ch, String q) throws IOException, InterruptedException, TimeoutException {
+    private void expectQueueRecovery(Channel ch, String q) throws IOException, InterruptedException, TimeoutException {
         ch.confirmSelect();
         ch.queuePurge(q);
         AMQP.Queue.DeclareOk ok1 = declareClientNamedQueue(ch, q);
@@ -902,7 +832,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertEquals(1, ok2.getMessageCount());
     }
 
-    private static void expectAutoDeleteQueueAndBindingRecovery(Channel ch, String x, String q) throws IOException, InterruptedException,
+    private void expectAutoDeleteQueueAndBindingRecovery(Channel ch, String x, String q) throws IOException, InterruptedException,
                                                                                     TimeoutException {
         ch.confirmSelect();
         ch.queuePurge(q);
@@ -915,7 +845,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertEquals(1, ok2.getMessageCount());
     }
 
-    private static void expectExchangeRecovery(Channel ch, String x) throws IOException, InterruptedException, TimeoutException {
+    private void expectExchangeRecovery(Channel ch, String x) throws IOException, InterruptedException, TimeoutException {
         ch.confirmSelect();
         String q = ch.queueDeclare().getQueue();
         final String rk = "routing-key";
@@ -925,14 +855,12 @@ public class ConnectionRecovery extends BrokerTestCase {
         ch.exchangeDeclarePassive(x);
     }
 
-    private static CountDownLatch prepareForRecovery(Connection conn) {
+    private CountDownLatch prepareForRecovery(Connection conn) {
         final CountDownLatch latch = new CountDownLatch(1);
         ((AutorecoveringConnection)conn).addRecoveryListener(new RecoveryListener() {
-            @Override
             public void handleRecovery(Recoverable recoverable) {
                 latch.countDown();
             }
-            @Override
             public void handleRecoveryStarted(Recoverable recoverable) {
                 // No-op
             }
@@ -940,10 +868,9 @@ public class ConnectionRecovery extends BrokerTestCase {
         return latch;
     }
 
-    private static CountDownLatch prepareForShutdown(Connection conn) {
+    private CountDownLatch prepareForShutdown(Connection conn) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         conn.addShutdownListener(new ShutdownListener() {
-            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 latch.countDown();
             }
@@ -955,7 +882,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         closeAndWaitForRecovery((AutorecoveringConnection)this.connection);
     }
 
-    private static void closeAndWaitForRecovery(RecoverableConnection connection) throws IOException, InterruptedException {
+    private void closeAndWaitForRecovery(RecoverableConnection connection) throws IOException, InterruptedException {
         CountDownLatch latch = prepareForRecovery(connection);
         Host.closeConnection((NetworkConnection) connection);
         wait(latch);
@@ -973,7 +900,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         wait(latch);
     }
 
-    private static void expectChannelRecovery(Channel ch) {
+    private void expectChannelRecovery(Channel ch) throws InterruptedException {
         assertTrue(ch.isOpen());
     }
 
@@ -982,53 +909,48 @@ public class ConnectionRecovery extends BrokerTestCase {
         return buildConnectionFactoryWithRecoveryEnabled(false);
     }
 
-    private static RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery)
+    private RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
         return (AutorecoveringConnection) cf.newConnection();
     }
 
-    private static RecoverableConnection newRecoveringConnection(Address[] addresses)
+    private RecoverableConnection newRecoveringConnection(Address[] addresses)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(false);
         // specifically use the Address[] overload
         return (AutorecoveringConnection) cf.newConnection(addresses);
     }
 
-    private static RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, List<Address> addresses)
+    private RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, List<Address> addresses)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
         return (AutorecoveringConnection) cf.newConnection(addresses);
     }
 
-    private static RecoverableConnection newRecoveringConnection(List<Address> addresses)
+    private RecoverableConnection newRecoveringConnection(List<Address> addresses)
             throws IOException, TimeoutException {
         return newRecoveringConnection(false, addresses);
     }
 
-    private static RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, String connectionName)
+    private RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, String connectionName)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
         return (RecoverableConnection) cf.newConnection(connectionName);
     }
 
-    private static RecoverableConnection newRecoveringConnection(String connectionName)
+    private RecoverableConnection newRecoveringConnection(String connectionName)
             throws IOException, TimeoutException {
         return newRecoveringConnection(false, connectionName);
     }
-    
-    private static ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery) {
-        return buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery, 1);
-    }
 
-    private static ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery, final int recoveryThreads) {
+    private ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery) {
         ConnectionFactory cf = TestUtils.connectionFactory();
         cf.setNetworkRecoveryInterval(RECOVERY_INTERVAL);
         cf.setAutomaticRecoveryEnabled(true);
         if (disableTopologyRecovery) {
             cf.setTopologyRecoveryEnabled(false);
         }
-        cf.setRecoveryThreadCount(recoveryThreads);
         return cf;
     }
 
@@ -1038,15 +960,15 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertTrue(latch.await(90, TimeUnit.SECONDS));
     }
 
-    private static void waitForConfirms(Channel ch) throws InterruptedException, TimeoutException {
+    private void waitForConfirms(Channel ch) throws InterruptedException, TimeoutException {
         ch.waitForConfirms(30 * 60 * 1000);
     }
 
-    private static void assertRecordedQueues(Connection conn, int size) {
+    private void assertRecordedQueues(Connection conn, int size) {
         assertEquals(size, ((AutorecoveringConnection)conn).getRecordedQueues().size());
     }
 
-    private static void assertRecordedExchanges(Connection conn, int size) {
+    private void assertRecordedExchanges(Connection conn, int size) {
         assertEquals(size, ((AutorecoveringConnection)conn).getRecordedExchanges().size());
     }
 }

--- a/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
@@ -16,6 +16,7 @@
 package com.rabbitmq.client.test.functional;
 
 import com.rabbitmq.client.*;
+import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.impl.CredentialsProvider;
 import com.rabbitmq.client.impl.NetworkConnection;
 import com.rabbitmq.client.impl.recovery.*;
@@ -34,7 +35,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -168,11 +168,13 @@ public class ConnectionRecovery extends BrokerTestCase {
         final List<String> events = new CopyOnWriteArrayList<String>();
         final CountDownLatch latch = new CountDownLatch(2); // one when started, another when complete
         connection.addShutdownListener(new ShutdownListener() {
+            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 events.add("shutdown hook 1");
             }
         });
         connection.addShutdownListener(new ShutdownListener() {
+            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 events.add("shutdown hook 2");
             }
@@ -211,6 +213,7 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void shutdownHooksRecoveryOnConnection() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(2);
         connection.addShutdownListener(new ShutdownListener() {
+            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 latch.countDown();
             }
@@ -225,6 +228,7 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void shutdownHooksRecoveryOnChannel() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(3);
         channel.addShutdownListener(new ShutdownListener() {
+            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 latch.countDown();
             }
@@ -241,10 +245,12 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void blockedListenerRecovery() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(2);
         connection.addBlockedListener(new BlockedListener() {
+            @Override
             public void handleBlocked(String reason) throws IOException {
                 latch.countDown();
             }
 
+            @Override
             public void handleUnblocked() throws IOException {
                 latch.countDown();
             }
@@ -270,6 +276,7 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void returnListenerRecovery() throws IOException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         channel.addReturnListener(new ReturnListener() {
+            @Override
             public void handleReturn(int replyCode, String replyText, String exchange,
                                      String routingKey, AMQP.BasicProperties properties,
                                      byte[] body) throws IOException {
@@ -285,10 +292,12 @@ public class ConnectionRecovery extends BrokerTestCase {
     @Test public void confirmListenerRecovery() throws IOException, InterruptedException, TimeoutException {
         final CountDownLatch latch = new CountDownLatch(1);
         channel.addConfirmListener(new ConfirmListener() {
+            @Override
             public void handleAck(long deliveryTag, boolean multiple) throws IOException {
                 latch.countDown();
             }
 
+            @Override
             public void handleNack(long deliveryTag, boolean multiple) throws IOException {
                 latch.countDown();
             }
@@ -693,9 +702,11 @@ public class ConnectionRecovery extends BrokerTestCase {
         final CountDownLatch latch = new CountDownLatch(2);
         final CountDownLatch startLatch = new CountDownLatch(2);
         final RecoveryListener listener = new RecoveryListener() {
+            @Override
             public void handleRecovery(Recoverable recoverable) {
                 latch.countDown();
             }
+            @Override
             public void handleRecoveryStarted(Recoverable recoverable) {
                 startLatch.countDown();
             }
@@ -795,33 +806,93 @@ public class ConnectionRecovery extends BrokerTestCase {
             connection.close();
         }
     }
+    
+    @Test public void recoveryWithMultipleThreads() throws Exception {
+        // test with 8 recovery threads
+        ConnectionFactory connectionFactory = buildConnectionFactoryWithRecoveryEnabled(false, 8);
+        assertEquals(8, connectionFactory.getTopologyRecoveryThreadCount());
+        RecoverableConnection testConnection = (RecoverableConnection) connectionFactory.newConnection();
+        try {
+            final List<Channel> channels = new ArrayList<Channel>();
+            final List<String> exchanges = new ArrayList<String>();
+            final List<String> queues = new ArrayList<String>();
+            // create 16 channels
+            final int channelCount = 16;
+            final int queuesPerChannel = 20;
+            final CountDownLatch latch = new CountDownLatch(channelCount * queuesPerChannel);
+            for (int i=0; i < channelCount; i++) {
+                final Channel testChannel = testConnection.createChannel();
+                String x = "tmp-x-topic-" + i;
+                exchanges.add(x);
+                testChannel.exchangeDeclare(x, "topic");
+                // create 20 queues and bindings per channel
+                for (int j=0; j < queuesPerChannel; j++) {
+                    String q = "tmp-q-" + i + "-" + j;
+                    queues.add(q);
+                    testChannel.queueDeclare(q, false, false, true, null);
+                    testChannel.queueBind(q, x, "tmp-key-" + i + "-" + j);
+                    testChannel.basicConsume(q, new DefaultConsumer(testChannel) {
+                        @Override
+                        public void handleDelivery(String consumerTag, Envelope envelope, BasicProperties properties, byte[] body)
+                                throws IOException {
+                            testChannel.basicAck(envelope.getDeliveryTag(), false);
+                            latch.countDown();
+                        }
+                    }); 
+                }
+            }
+            // now do recovery
+            closeAndWaitForRecovery(testConnection);
+            
+            // verify channels & topology recovered by publishing a message to each
+            for (int i=0; i < channelCount; i++) {
+                Channel ch = channels.get(i);
+                expectChannelRecovery(ch);
+                // publish message to each queue/consumer
+                for (int j=0; j < queuesPerChannel; j++) {
+                    ch.basicPublish("tmp-x-topic-" + i, "tmp-key-" + i + "-" + j, null, "msg".getBytes());
+                }
+            }
+            // verify all queues/consumers got it
+            assertTrue(latch.await(30, TimeUnit.SECONDS));
+            
+            // cleanup
+            Channel cleanupChannel = testConnection.createChannel();
+            for (String q : queues)
+                cleanupChannel.queueDelete(q);
+            for (String x : exchanges)
+                cleanupChannel.exchangeDelete(x);
+        } finally {
+            testConnection.close();
+        }
+    }
 
     private void assertConsumerCount(int exp, String q) throws IOException {
         assertEquals(exp, channel.queueDeclarePassive(q).getConsumerCount());
     }
 
-    private AMQP.Queue.DeclareOk declareClientNamedQueue(Channel ch, String q) throws IOException {
+    private static AMQP.Queue.DeclareOk declareClientNamedQueue(Channel ch, String q) throws IOException {
         return ch.queueDeclare(q, true, false, false, null);
     }
 
-    private AMQP.Queue.DeclareOk declareClientNamedAutoDeleteQueue(Channel ch, String q) throws IOException {
+    private static AMQP.Queue.DeclareOk declareClientNamedAutoDeleteQueue(Channel ch, String q) throws IOException {
         return ch.queueDeclare(q, true, false, true, null);
     }
 
 
-    private void declareClientNamedQueueNoWait(Channel ch, String q) throws IOException {
+    private static void declareClientNamedQueueNoWait(Channel ch, String q) throws IOException {
         ch.queueDeclareNoWait(q, true, false, false, null);
     }
 
-    private AMQP.Exchange.DeclareOk declareExchange(Channel ch, String x) throws IOException {
+    private static AMQP.Exchange.DeclareOk declareExchange(Channel ch, String x) throws IOException {
         return ch.exchangeDeclare(x, "fanout", false);
     }
 
-    private void declareExchangeNoWait(Channel ch, String x) throws IOException {
+    private static void declareExchangeNoWait(Channel ch, String x) throws IOException {
         ch.exchangeDeclareNoWait(x, "fanout", false, false, false, null);
     }
 
-    private void expectQueueRecovery(Channel ch, String q) throws IOException, InterruptedException, TimeoutException {
+    private static void expectQueueRecovery(Channel ch, String q) throws IOException, InterruptedException, TimeoutException {
         ch.confirmSelect();
         ch.queuePurge(q);
         AMQP.Queue.DeclareOk ok1 = declareClientNamedQueue(ch, q);
@@ -832,7 +903,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertEquals(1, ok2.getMessageCount());
     }
 
-    private void expectAutoDeleteQueueAndBindingRecovery(Channel ch, String x, String q) throws IOException, InterruptedException,
+    private static void expectAutoDeleteQueueAndBindingRecovery(Channel ch, String x, String q) throws IOException, InterruptedException,
                                                                                     TimeoutException {
         ch.confirmSelect();
         ch.queuePurge(q);
@@ -845,7 +916,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertEquals(1, ok2.getMessageCount());
     }
 
-    private void expectExchangeRecovery(Channel ch, String x) throws IOException, InterruptedException, TimeoutException {
+    private static void expectExchangeRecovery(Channel ch, String x) throws IOException, InterruptedException, TimeoutException {
         ch.confirmSelect();
         String q = ch.queueDeclare().getQueue();
         final String rk = "routing-key";
@@ -855,12 +926,14 @@ public class ConnectionRecovery extends BrokerTestCase {
         ch.exchangeDeclarePassive(x);
     }
 
-    private CountDownLatch prepareForRecovery(Connection conn) {
+    private static CountDownLatch prepareForRecovery(Connection conn) {
         final CountDownLatch latch = new CountDownLatch(1);
         ((AutorecoveringConnection)conn).addRecoveryListener(new RecoveryListener() {
+            @Override
             public void handleRecovery(Recoverable recoverable) {
                 latch.countDown();
             }
+            @Override
             public void handleRecoveryStarted(Recoverable recoverable) {
                 // No-op
             }
@@ -868,9 +941,10 @@ public class ConnectionRecovery extends BrokerTestCase {
         return latch;
     }
 
-    private CountDownLatch prepareForShutdown(Connection conn) throws InterruptedException {
+    private static CountDownLatch prepareForShutdown(Connection conn) {
         final CountDownLatch latch = new CountDownLatch(1);
         conn.addShutdownListener(new ShutdownListener() {
+            @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
                 latch.countDown();
             }
@@ -882,7 +956,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         closeAndWaitForRecovery((AutorecoveringConnection)this.connection);
     }
 
-    private void closeAndWaitForRecovery(RecoverableConnection connection) throws IOException, InterruptedException {
+    private static void closeAndWaitForRecovery(RecoverableConnection connection) throws IOException, InterruptedException {
         CountDownLatch latch = prepareForRecovery(connection);
         Host.closeConnection((NetworkConnection) connection);
         wait(latch);
@@ -900,7 +974,7 @@ public class ConnectionRecovery extends BrokerTestCase {
         wait(latch);
     }
 
-    private void expectChannelRecovery(Channel ch) throws InterruptedException {
+    private static void expectChannelRecovery(Channel ch) {
         assertTrue(ch.isOpen());
     }
 
@@ -909,48 +983,53 @@ public class ConnectionRecovery extends BrokerTestCase {
         return buildConnectionFactoryWithRecoveryEnabled(false);
     }
 
-    private RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery)
+    private static RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
         return (AutorecoveringConnection) cf.newConnection();
     }
 
-    private RecoverableConnection newRecoveringConnection(Address[] addresses)
+    private static RecoverableConnection newRecoveringConnection(Address[] addresses)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(false);
         // specifically use the Address[] overload
         return (AutorecoveringConnection) cf.newConnection(addresses);
     }
 
-    private RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, List<Address> addresses)
+    private static RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, List<Address> addresses)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
         return (AutorecoveringConnection) cf.newConnection(addresses);
     }
 
-    private RecoverableConnection newRecoveringConnection(List<Address> addresses)
+    private static RecoverableConnection newRecoveringConnection(List<Address> addresses)
             throws IOException, TimeoutException {
         return newRecoveringConnection(false, addresses);
     }
 
-    private RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, String connectionName)
+    private static RecoverableConnection newRecoveringConnection(boolean disableTopologyRecovery, String connectionName)
             throws IOException, TimeoutException {
         ConnectionFactory cf = buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery);
         return (RecoverableConnection) cf.newConnection(connectionName);
     }
 
-    private RecoverableConnection newRecoveringConnection(String connectionName)
+    private static RecoverableConnection newRecoveringConnection(String connectionName)
             throws IOException, TimeoutException {
         return newRecoveringConnection(false, connectionName);
     }
+    
+    private static ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery) {
+        return buildConnectionFactoryWithRecoveryEnabled(disableTopologyRecovery, 1);
+    }
 
-    private ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery) {
+    private static ConnectionFactory buildConnectionFactoryWithRecoveryEnabled(boolean disableTopologyRecovery, final int recoveryThreads) {
         ConnectionFactory cf = TestUtils.connectionFactory();
         cf.setNetworkRecoveryInterval(RECOVERY_INTERVAL);
         cf.setAutomaticRecoveryEnabled(true);
         if (disableTopologyRecovery) {
             cf.setTopologyRecoveryEnabled(false);
         }
+        cf.setTopologyRecoveryThreadCount(recoveryThreads);
         return cf;
     }
 
@@ -960,15 +1039,15 @@ public class ConnectionRecovery extends BrokerTestCase {
         assertTrue(latch.await(90, TimeUnit.SECONDS));
     }
 
-    private void waitForConfirms(Channel ch) throws InterruptedException, TimeoutException {
+    private static void waitForConfirms(Channel ch) throws InterruptedException, TimeoutException {
         ch.waitForConfirms(30 * 60 * 1000);
     }
 
-    private void assertRecordedQueues(Connection conn, int size) {
+    private static void assertRecordedQueues(Connection conn, int size) {
         assertEquals(size, ((AutorecoveringConnection)conn).getRecordedQueues().size());
     }
 
-    private void assertRecordedExchanges(Connection conn, int size) {
+    private static void assertRecordedExchanges(Connection conn, int size) {
         assertEquals(size, ((AutorecoveringConnection)conn).getRecordedExchanges().size());
     }
 }


### PR DESCRIPTION
## Proposed Changes

Decrease recovery time for connections that have lots of queues and bindings by recovering entities (exchanges, queues, bindings, and consumers) in parallel using multiple threads. One of our applications has 100s of channels and 1000s of queues and bindings on a single connection. This PR makes it configurable and opt-in to use multiple threads. Default is still single threaded on the main connection thread. I can add javadoc and clean it up a bit if the team is interested in pulling this in.

In my testing with our workflow I have found recovery time to improve by about 5x using 8 threads vs 1. More than 8 threads seems to have diminishing returns (could be related to the VM i was testing from which only had 2 cores). In one case recovery time went from 26 seconds to 5 seconds and from 119 seconds to 25 in another.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

