### PR TITLE
Fix RpcClient potential memory leak if timeout occurs

### DIFF
--- a/src/main/java/com/rabbitmq/client/RpcClient.java
+++ b/src/main/java/com/rabbitmq/client/RpcClient.java
@@ -192,10 +192,10 @@ public class RpcClient {
                     String replyId = properties.getCorrelationId();
                     BlockingCell<Object> blocker =_continuationMap.remove(replyId);
                     if (blocker != null) {
-	                    blocker.set(new Response(consumerTag, envelope, properties, body));
+                        blocker.set(new Response(consumerTag, envelope, properties, body));
                     } else {
-						// Not an error. Entry will have been removed if request timed out.
-					}
+                        // Not an error. Entry will have been removed if request timed out.
+                    }
                 }
             }
         };
@@ -218,7 +218,7 @@ public class RpcClient {
         throws IOException, ShutdownSignalException, TimeoutException {
         checkConsumer();
         BlockingCell<Object> k = new BlockingCell<Object>();
-		String replyId;
+        String replyId;
         synchronized (_continuationMap) {
             _correlationId++;
             replyId = "" + _correlationId;
@@ -227,14 +227,14 @@ public class RpcClient {
             _continuationMap.put(replyId, k);
         }
         publish(props, message);
-		Object reply;
+        Object reply;
         try {
-			reply = k.uninterruptibleGet(timeout);
-		} catch (TimeoutException ex) {
-			// Avoid potential leak.  This entry is no longer needed by caller.
-			_continuationMap.remove(replyId);
-			throw ex;
-		}
+            reply = k.uninterruptibleGet(timeout);
+        } catch (TimeoutException ex) {
+            // Avoid potential leak.  This entry is no longer needed by caller.
+            _continuationMap.remove(replyId);
+            throw ex;
+        }
         if (reply instanceof ShutdownSignalException) {
             ShutdownSignalException sig = (ShutdownSignalException) reply;
             ShutdownSignalException wrapper =

--- a/src/main/java/com/rabbitmq/client/RpcClient.java
+++ b/src/main/java/com/rabbitmq/client/RpcClient.java
@@ -191,10 +191,11 @@ public class RpcClient {
                 synchronized (_continuationMap) {
                     String replyId = properties.getCorrelationId();
                     BlockingCell<Object> blocker =_continuationMap.remove(replyId);
-                    if (blocker == null) {
-                        throw new IllegalStateException("No outstanding request for correlation ID " + replyId);
-                    }
-                    blocker.set(new Response(consumerTag, envelope, properties, body));
+                    if (blocker != null) {
+	                    blocker.set(new Response(consumerTag, envelope, properties, body));
+                    } else {
+						// Not an error. Entry will have been removed if request timed out.
+					}
                 }
             }
         };
@@ -217,15 +218,23 @@ public class RpcClient {
         throws IOException, ShutdownSignalException, TimeoutException {
         checkConsumer();
         BlockingCell<Object> k = new BlockingCell<Object>();
+		String replyId;
         synchronized (_continuationMap) {
             _correlationId++;
-            String replyId = "" + _correlationId;
+            replyId = "" + _correlationId;
             props = ((props==null) ? new AMQP.BasicProperties.Builder() : props.builder())
                 .correlationId(replyId).replyTo(_replyTo).build();
             _continuationMap.put(replyId, k);
         }
         publish(props, message);
-        Object reply = k.uninterruptibleGet(timeout);
+		Object reply;
+        try {
+			reply = k.uninterruptibleGet(timeout);
+		} catch (TimeoutException ex) {
+			// Avoid potential leak.  This entry is no longer needed by caller.
+			_continuationMap.remove(replyId);
+			throw ex;
+		}
         if (reply instanceof ShutdownSignalException) {
             ShutdownSignalException sig = (ShutdownSignalException) reply;
             ShutdownSignalException wrapper =


### PR DESCRIPTION
## Proposed Changes

The RpcClient can time out if no response is received within the time window. If this happens, it doesn't necessarily leak, but it *will* leak if the response is *never* received. This change recognizes that once a timeout happens, the entry in the _continuationMap serves no purpose and can be safely removed, since the client cannot wait again on the same request.

## Types of Changes

- [X] Bugfix (non-breaking change which fixes issue #375)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- I was not able to add a test because of trouble building.  However I did run a local test program (see https://github.com/wheezil/rabbitmq-rpc-example) to confirm that that a client (a) times out and removes the entry (b) causes no later issues when the reply arrives
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in related repositories

## Further Comments

Around line 197, I allow for the entry to have already been removed when the reply finally arrives  and ignore its absence instead of throwing IllegalStateException.  I don't *think* this runs afoul of any assumptions, but it would be good if another pair of eyes looked this over.