### PR TITLE
Add optional retry logic to topology recovery

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -29,6 +29,7 @@ import com.rabbitmq.client.impl.SocketFrameHandlerFactory;
 import com.rabbitmq.client.impl.nio.NioParams;
 import com.rabbitmq.client.impl.nio.SocketChannelFrameHandlerFactory;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
+import com.rabbitmq.client.impl.recovery.RetryHandler;
 import com.rabbitmq.client.impl.recovery.TopologyRecoveryFilter;
 
 import java.io.IOException;
@@ -191,6 +192,13 @@ public class ConnectionFactory implements Cloneable {
      * @since 5.4.0
      */
     private Predicate<ShutdownSignalException> connectionRecoveryTriggeringCondition;
+
+    /**
+     * Retry handler for topology recovery.
+     * Default is no retry.
+     * @since 5.4.0
+     */
+    private RetryHandler topologyRecoveryRetryHandler;
 
     /** @return the default host to use for connections */
     public String getHost() {
@@ -1087,6 +1095,7 @@ public class ConnectionFactory implements Cloneable {
         result.setErrorOnWriteListener(errorOnWriteListener);
         result.setTopologyRecoveryFilter(topologyRecoveryFilter);
         result.setConnectionRecoveryTriggeringCondition(connectionRecoveryTriggeringCondition);
+        result.setTopologyRecoveryRetryHandler(topologyRecoveryRetryHandler);
         return result;
     }
 
@@ -1454,4 +1463,13 @@ public class ConnectionFactory implements Cloneable {
         this.connectionRecoveryTriggeringCondition = connectionRecoveryTriggeringCondition;
     }
 
+    /**
+     * Set retry handler for topology recovery.
+     * Default is no retry.
+     * @param topologyRecoveryRetryHandler
+     * @since 5.4.0
+     */
+    public void setTopologyRecoveryRetryHandler(RetryHandler topologyRecoveryRetryHandler) {
+        this.topologyRecoveryRetryHandler = topologyRecoveryRetryHandler;
+    }
 }

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -20,6 +20,7 @@ import com.rabbitmq.client.RecoveryDelayHandler;
 import com.rabbitmq.client.RecoveryDelayHandler.DefaultRecoveryDelayHandler;
 import com.rabbitmq.client.SaslConfig;
 import com.rabbitmq.client.ShutdownSignalException;
+import com.rabbitmq.client.impl.recovery.RetryHandler;
 import com.rabbitmq.client.impl.recovery.TopologyRecoveryFilter;
 
 import java.util.Map;
@@ -51,6 +52,7 @@ public class ConnectionParams {
     private int workPoolTimeout = -1;
     private TopologyRecoveryFilter topologyRecoveryFilter;
     private Predicate<ShutdownSignalException> connectionRecoveryTriggeringCondition;
+    private RetryHandler topologyRecoveryRetryHandler;
 
     private ExceptionHandler exceptionHandler;
     private ThreadFactory threadFactory;
@@ -257,4 +259,11 @@ public class ConnectionParams {
         return connectionRecoveryTriggeringCondition;
     }
 
+    public void setTopologyRecoveryRetryHandler(RetryHandler topologyRecoveryRetryHandler) {
+        this.topologyRecoveryRetryHandler = topologyRecoveryRetryHandler;
+    }
+
+    public RetryHandler getTopologyRecoveryRetryHandler() {
+        return topologyRecoveryRetryHandler;
+    }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/BackoffPolicy.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/BackoffPolicy.java
@@ -1,0 +1,34 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl.recovery;
+
+/**
+ * Backoff policy for topology recovery retry attempts.
+ *
+ * @see DefaultRetryHandler
+ * @see TopologyRecoveryRetryHandlerBuilder
+ * @since 5.4.0
+ */
+@FunctionalInterface
+public interface BackoffPolicy {
+
+    /**
+     * Wait depending on the current attempt number (1, 2, 3, etc)
+     * @param attemptNumber current attempt number
+     * @throws InterruptedException
+     */
+    void backoff(int attemptNumber) throws InterruptedException;
+}

--- a/src/main/java/com/rabbitmq/client/impl/recovery/DefaultRetryHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/DefaultRetryHandler.java
@@ -1,0 +1,131 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl.recovery;
+
+import java.util.Objects;
+import java.util.function.BiPredicate;
+
+/**
+ * Composable topology recovery retry handler.
+ * This retry handler implementations let the user choose the condition
+ * to trigger retry and the retry operation for each type of recoverable
+ * entities. The number of attempts and the backoff policy (time to wait
+ * between retries) are also configurable.
+ * <p>
+ * See also {@link TopologyRecoveryRetryHandlerBuilder} to easily create
+ * instances and {@link TopologyRecoveryRetryLogic} for ready-to-use
+ * conditions and operations.
+ *
+ * @see TopologyRecoveryRetryHandlerBuilder
+ * @see TopologyRecoveryRetryLogic
+ * @since 5.4.0
+ */
+public class DefaultRetryHandler implements RetryHandler {
+
+    private final BiPredicate<RecordedQueue, Exception> queueRecoveryRetryCondition;
+    private final BiPredicate<RecordedExchange, Exception> exchangeRecoveryRetryCondition;
+    private final BiPredicate<RecordedBinding, Exception> bindingRecoveryRetryCondition;
+    private final BiPredicate<RecordedConsumer, Exception> consumerRecoveryRetryCondition;
+
+    private final RetryOperation<?> queueRecoveryRetryOperation;
+    private final RetryOperation<?> exchangeRecoveryRetryOperation;
+    private final RetryOperation<?> bindingRecoveryRetryOperation;
+    private final RetryOperation<?> consumerRecoveryRetryOperation;
+
+    private final int retryAttempts;
+
+    private final BackoffPolicy backoffPolicy;
+
+    public DefaultRetryHandler(BiPredicate<RecordedQueue, Exception> queueRecoveryRetryCondition,
+        BiPredicate<RecordedExchange, Exception> exchangeRecoveryRetryCondition,
+        BiPredicate<RecordedBinding, Exception> bindingRecoveryRetryCondition,
+        BiPredicate<RecordedConsumer, Exception> consumerRecoveryRetryCondition,
+        RetryOperation<?> queueRecoveryRetryOperation,
+        RetryOperation<?> exchangeRecoveryRetryOperation,
+        RetryOperation<?> bindingRecoveryRetryOperation,
+        RetryOperation<?> consumerRecoveryRetryOperation, int retryAttempts, BackoffPolicy backoffPolicy) {
+        this.queueRecoveryRetryCondition = queueRecoveryRetryCondition;
+        this.exchangeRecoveryRetryCondition = exchangeRecoveryRetryCondition;
+        this.bindingRecoveryRetryCondition = bindingRecoveryRetryCondition;
+        this.consumerRecoveryRetryCondition = consumerRecoveryRetryCondition;
+        this.queueRecoveryRetryOperation = queueRecoveryRetryOperation;
+        this.exchangeRecoveryRetryOperation = exchangeRecoveryRetryOperation;
+        this.bindingRecoveryRetryOperation = bindingRecoveryRetryOperation;
+        this.consumerRecoveryRetryOperation = consumerRecoveryRetryOperation;
+        this.backoffPolicy = backoffPolicy;
+        if (retryAttempts <= 0) {
+            throw new IllegalArgumentException("Number of retry attempts must be greater than 0");
+        }
+        this.retryAttempts = retryAttempts;
+    }
+
+    @Override
+    public RetryResult retryQueueRecovery(RetryContext context) throws Exception {
+        return doRetry(queueRecoveryRetryCondition, queueRecoveryRetryOperation, context.queue(), context);
+    }
+
+    @Override
+    public RetryResult retryExchangeRecovery(RetryContext context) throws Exception {
+        return doRetry(exchangeRecoveryRetryCondition, exchangeRecoveryRetryOperation, context.exchange(), context);
+    }
+
+    @Override
+    public RetryResult retryBindingRecovery(RetryContext context) throws Exception {
+        return doRetry(bindingRecoveryRetryCondition, bindingRecoveryRetryOperation, context.binding(), context);
+    }
+
+    @Override
+    public RetryResult retryConsumerRecovery(RetryContext context) throws Exception {
+        return doRetry(consumerRecoveryRetryCondition, consumerRecoveryRetryOperation, context.consumer(), context);
+    }
+
+    protected <T extends RecordedEntity> RetryResult doRetry(BiPredicate<T, Exception> condition, RetryOperation<?> operation, T entity, RetryContext context)
+        throws Exception {
+        int attempts = 0;
+        Exception exception = context.exception();
+        while (attempts < retryAttempts) {
+            if (condition.test(entity, exception)) {
+                backoffPolicy.backoff(attempts + 1);
+                try {
+                    Object result = operation.call(context);
+                    return new RetryResult(
+                        entity, result == null ? null : result.toString()
+                    );
+                } catch (Exception e) {
+                    exception = e;
+                    attempts++;
+                    continue;
+                }
+            } else {
+                throw exception;
+            }
+        }
+        throw context.exception();
+    }
+
+    public interface RetryOperation<T> {
+
+        T call(RetryContext context) throws Exception;
+
+        default <V> RetryOperation<V> andThen(RetryOperation<V> after) {
+            Objects.requireNonNull(after);
+            return (context) -> {
+                call(context);
+                return after.call(context);
+            };
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RetryContext.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RetryContext.java
@@ -1,0 +1,99 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl.recovery;
+
+/**
+ * The context of a topology recovery retry operation.
+ *
+ * @since 5.4.0
+ */
+public class RetryContext {
+
+    private final RecordedEntity entity;
+
+    private final Exception exception;
+
+    private final AutorecoveringConnection connection;
+
+    public RetryContext(RecordedEntity entity, Exception exception, AutorecoveringConnection connection) {
+        this.entity = entity;
+        this.exception = exception;
+        this.connection = connection;
+    }
+
+    /**
+     * The underlying connection.
+     *
+     * @return
+     */
+    public AutorecoveringConnection connection() {
+        return connection;
+    }
+
+    /**
+     * The exception that triggered the retry attempt.
+     *
+     * @return
+     */
+    public Exception exception() {
+        return exception;
+    }
+
+    /**
+     * The to-be-recovered entity.
+     *
+     * @return
+     */
+    public RecordedEntity entity() {
+        return entity;
+    }
+
+    /**
+     * The to-be-recovered entity as a queue.
+     *
+     * @return
+     */
+    public RecordedQueue queue() {
+        return (RecordedQueue) entity;
+    }
+
+    /**
+     * The to-be-recovered entity as an exchange.
+     *
+     * @return
+     */
+    public RecordedExchange exchange() {
+        return (RecordedExchange) entity;
+    }
+
+    /**
+     * The to-be-recovered entity as a binding.
+     *
+     * @return
+     */
+    public RecordedBinding binding() {
+        return (RecordedBinding) entity;
+    }
+
+    /**
+     * The to-be-recovered entity as a consumer.
+     *
+     * @return
+     */
+    public RecordedConsumer consumer() {
+        return (RecordedConsumer) entity;
+    }
+}

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RetryHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RetryHandler.java
@@ -1,0 +1,62 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl.recovery;
+
+/**
+ * Contract to retry failed operations during topology recovery.
+ * Not all operations have to be retried, it's a decision of the
+ * underlying implementation.
+ *
+ * @since 5.4.0
+ */
+public interface RetryHandler {
+
+    /**
+     * Retry a failed queue recovery operation.
+     *
+     * @param context the context of the retry
+     * @return the result of the retry attempt
+     * @throws Exception if the retry fails
+     */
+    RetryResult retryQueueRecovery(RetryContext context) throws Exception;
+
+    /**
+     * Retry a failed exchange recovery operation.
+     *
+     * @param context the context of the retry
+     * @return the result of the retry attempt
+     * @throws Exception if the retry fails
+     */
+    RetryResult retryExchangeRecovery(RetryContext context) throws Exception;
+
+    /**
+     * Retry a failed binding recovery operation.
+     *
+     * @param context the context of the retry
+     * @return the result of the retry attempt
+     * @throws Exception if the retry fails
+     */
+    RetryResult retryBindingRecovery(RetryContext context) throws Exception;
+
+    /**
+     * Retry a failed consumer recovery operation.
+     *
+     * @param context the context of the retry
+     * @return the result of the retry attempt
+     * @throws Exception if the retry fails
+     */
+    RetryResult retryConsumerRecovery(RetryContext context) throws Exception;
+}

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RetryResult.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RetryResult.java
@@ -1,0 +1,57 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl.recovery;
+
+/**
+ * The retry of a retried topology recovery operation.
+ *
+ * @since 5.4.0
+ */
+public class RetryResult {
+
+    /**
+     * The entity to recover.
+     */
+    private final RecordedEntity recordedEntity;
+
+    /**
+     * The result of the recovery operation.
+     * E.g. a consumer tag when recovering a consumer.
+     */
+    private final Object result;
+
+    public RetryResult(RecordedEntity recordedEntity, Object result) {
+        this.recordedEntity = recordedEntity;
+        this.result = result;
+    }
+
+    /**
+     * The entity to recover.
+     *
+     * @return
+     */
+    public RecordedEntity getRecordedEntity() {
+        return recordedEntity;
+    }
+
+    /**
+     * The result of the recovery operation.
+     * E.g. a consumer tag when recovering a consumer.
+     */
+    public Object getResult() {
+        return result;
+    }
+}

--- a/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryHandlerBuilder.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryHandlerBuilder.java
@@ -1,0 +1,115 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl.recovery;
+
+import java.util.function.BiPredicate;
+
+/**
+ * Builder to ease creation of {@link DefaultRetryHandler} instances.
+ * <p>
+ * Just override what you need. By default, retry conditions don't trigger retry,
+ * retry operations are no-op, the number of retry attempts is 1, and the backoff
+ * policy doesn't wait at all.
+ *
+ * @see DefaultRetryHandler
+ * @see TopologyRecoveryRetryLogic
+ * @since 5.4.0
+ */
+public class TopologyRecoveryRetryHandlerBuilder {
+
+    private BiPredicate<RecordedQueue, Exception> queueRecoveryRetryCondition = (q, e) -> false;
+    private BiPredicate<RecordedExchange, Exception> exchangeRecoveryRetryCondition = (ex, e) -> false;
+    private BiPredicate<RecordedBinding, Exception> bindingRecoveryRetryCondition = (b, e) -> false;
+    private BiPredicate<RecordedConsumer, Exception> consumerRecoveryRetryCondition = (c, e) -> false;
+
+    private DefaultRetryHandler.RetryOperation<?> queueRecoveryRetryOperation = context -> null;
+    private DefaultRetryHandler.RetryOperation<?> exchangeRecoveryRetryOperation = context -> null;
+    private DefaultRetryHandler.RetryOperation<?> bindingRecoveryRetryOperation = context -> null;
+    private DefaultRetryHandler.RetryOperation<?> consumerRecoveryRetryOperation = context -> null;
+
+    private int retryAttempts = 1;
+
+    private BackoffPolicy backoffPolicy = nbAttempts -> {
+    };
+
+    public static TopologyRecoveryRetryHandlerBuilder builder() {
+        return new TopologyRecoveryRetryHandlerBuilder();
+    }
+
+    public TopologyRecoveryRetryHandlerBuilder queueRecoveryRetryCondition(
+        BiPredicate<RecordedQueue, Exception> queueRecoveryRetryCondition) {
+        this.queueRecoveryRetryCondition = queueRecoveryRetryCondition;
+        return this;
+    }
+
+    public TopologyRecoveryRetryHandlerBuilder exchangeRecoveryRetryCondition(
+        BiPredicate<RecordedExchange, Exception> exchangeRecoveryRetryCondition) {
+        this.exchangeRecoveryRetryCondition = exchangeRecoveryRetryCondition;
+        return this;
+    }
+
+    public TopologyRecoveryRetryHandlerBuilder bindingRecoveryRetryCondition(
+        BiPredicate<RecordedBinding, Exception> bindingRecoveryRetryCondition) {
+        this.bindingRecoveryRetryCondition = bindingRecoveryRetryCondition;
+        return this;
+    }
+
+    public TopologyRecoveryRetryHandlerBuilder consumerRecoveryRetryCondition(
+        BiPredicate<RecordedConsumer, Exception> consumerRecoveryRetryCondition) {
+        this.consumerRecoveryRetryCondition = consumerRecoveryRetryCondition;
+        return this;
+    }
+
+    public TopologyRecoveryRetryHandlerBuilder queueRecoveryRetryOperation(DefaultRetryHandler.RetryOperation<?> queueRecoveryRetryOperation) {
+        this.queueRecoveryRetryOperation = queueRecoveryRetryOperation;
+        return this;
+    }
+
+    public TopologyRecoveryRetryHandlerBuilder exchangeRecoveryRetryOperation(DefaultRetryHandler.RetryOperation<?> exchangeRecoveryRetryOperation) {
+        this.exchangeRecoveryRetryOperation = exchangeRecoveryRetryOperation;
+        return this;
+    }
+
+    public TopologyRecoveryRetryHandlerBuilder bindingRecoveryRetryOperation(DefaultRetryHandler.RetryOperation<?> bindingRecoveryRetryOperation) {
+        this.bindingRecoveryRetryOperation = bindingRecoveryRetryOperation;
+        return this;
+    }
+
+    public TopologyRecoveryRetryHandlerBuilder consumerRecoveryRetryOperation(DefaultRetryHandler.RetryOperation<?> consumerRecoveryRetryOperation) {
+        this.consumerRecoveryRetryOperation = consumerRecoveryRetryOperation;
+        return this;
+    }
+
+    public TopologyRecoveryRetryHandlerBuilder backoffPolicy(BackoffPolicy backoffPolicy) {
+        this.backoffPolicy = backoffPolicy;
+        return this;
+    }
+
+    public TopologyRecoveryRetryHandlerBuilder retryAttempts(int retryAttempts) {
+        this.retryAttempts = retryAttempts;
+        return this;
+    }
+
+    public RetryHandler build() {
+        return new DefaultRetryHandler(
+            queueRecoveryRetryCondition, exchangeRecoveryRetryCondition,
+            bindingRecoveryRetryCondition, consumerRecoveryRetryCondition,
+            queueRecoveryRetryOperation, exchangeRecoveryRetryOperation,
+            bindingRecoveryRetryOperation, consumerRecoveryRetryOperation,
+            retryAttempts,
+            backoffPolicy);
+    }
+}

--- a/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryLogic.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryLogic.java
@@ -1,0 +1,85 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl.recovery;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.ShutdownSignalException;
+
+import java.util.function.Predicate;
+
+/**
+ * Useful ready-to-use conditions and operations for {@link DefaultRetryHandler}.
+ * They're composed and used with the {@link TopologyRecoveryRetryHandlerBuilder}.
+ *
+ * @see DefaultRetryHandler
+ * @see RetryHandler
+ * @see TopologyRecoveryRetryHandlerBuilder
+ * @since 5.4.0
+ */
+public abstract class TopologyRecoveryRetryLogic {
+
+    public static final Predicate<Exception> CHANNEL_CLOSED_NOT_FOUND = e -> {
+        if (e.getCause() instanceof ShutdownSignalException) {
+            ShutdownSignalException cause = (ShutdownSignalException) e.getCause();
+            if (cause.getReason() instanceof AMQP.Channel.Close) {
+                return ((AMQP.Channel.Close) cause.getReason()).getReplyCode() == 404;
+            }
+        }
+        return false;
+    };
+
+    public static final DefaultRetryHandler.RetryOperation<Void> RECOVER_CHANNEL = context -> {
+        if (!context.entity().getChannel().isOpen()) {
+            context.connection().recoverChannel(context.entity().getChannel());
+        }
+        return null;
+    };
+
+    public static final DefaultRetryHandler.RetryOperation<Void> RECOVER_BINDING_QUEUE = context -> {
+        if (context.entity() instanceof RecordedQueueBinding) {
+            RecordedBinding binding = context.binding();
+            AutorecoveringConnection connection = context.connection();
+            RecordedQueue recordedQueue = connection.getRecordedQueues().get(binding.getDestination());
+            if (recordedQueue != null) {
+                connection.recoverQueue(
+                    recordedQueue.getName(), recordedQueue, false
+                );
+            }
+        }
+        return null;
+    };
+
+    public static final DefaultRetryHandler.RetryOperation<Void> RECOVER_BINDING = context -> {
+        context.binding().recover();
+        return null;
+    };
+
+    public static final DefaultRetryHandler.RetryOperation<Void> RECOVER_CONSUMER_QUEUE = context -> {
+        if (context.entity() instanceof RecordedConsumer) {
+            RecordedConsumer consumer = context.consumer();
+            AutorecoveringConnection connection = context.connection();
+            RecordedQueue recordedQueue = connection.getRecordedQueues().get(consumer.getQueue());
+            if (recordedQueue != null) {
+                connection.recoverQueue(
+                    recordedQueue.getName(), recordedQueue, false
+                );
+            }
+        }
+        return null;
+    };
+
+    public static final DefaultRetryHandler.RetryOperation<String> RECOVER_CONSUMER = context -> context.consumer().recover();
+}

--- a/src/test/java/com/rabbitmq/client/test/ClientTests.java
+++ b/src/test/java/com/rabbitmq/client/test/ClientTests.java
@@ -62,7 +62,8 @@ import org.junit.runners.Suite;
     StrictExceptionHandlerTest.class,
     NoAutoRecoveryWhenTcpWindowIsFullTest.class,
     JsonRpcTest.class,
-    AddressTest.class
+    AddressTest.class,
+    DefaultRetryHandlerTest.class
 })
 public class ClientTests {
 

--- a/src/test/java/com/rabbitmq/client/test/DefaultRetryHandlerTest.java
+++ b/src/test/java/com/rabbitmq/client/test/DefaultRetryHandlerTest.java
@@ -1,0 +1,257 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.test;
+
+import com.rabbitmq.client.impl.recovery.BackoffPolicy;
+import com.rabbitmq.client.impl.recovery.DefaultRetryHandler;
+import com.rabbitmq.client.impl.recovery.RecordedBinding;
+import com.rabbitmq.client.impl.recovery.RecordedConsumer;
+import com.rabbitmq.client.impl.recovery.RecordedExchange;
+import com.rabbitmq.client.impl.recovery.RecordedQueue;
+import com.rabbitmq.client.impl.recovery.RetryContext;
+import com.rabbitmq.client.impl.recovery.RetryHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.verification.VerificationMode;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiPredicate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.intThat;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ *
+ */
+public class DefaultRetryHandlerTest {
+
+    RetryHandler handler;
+
+    @Mock
+    BiPredicate<RecordedQueue, Exception> queueRecoveryRetryCondition;
+    @Mock
+    BiPredicate<RecordedExchange, Exception> exchangeRecoveryRetryCondition;
+    @Mock
+    BiPredicate<RecordedBinding, Exception> bindingRecoveryRetryCondition;
+    @Mock
+    BiPredicate<RecordedConsumer, Exception> consumerRecoveryRetryCondition;
+
+    @Mock
+    DefaultRetryHandler.RetryOperation queueRecoveryRetryOperation;
+    @Mock
+    DefaultRetryHandler.RetryOperation exchangeRecoveryRetryOperation;
+    @Mock
+    DefaultRetryHandler.RetryOperation bindingRecoveryRetryOperation;
+    @Mock
+    DefaultRetryHandler.RetryOperation consumerRecoveryRetryOperation;
+
+    @Mock
+    BackoffPolicy backoffPolicy;
+
+    @Before
+    public void init() {
+        initMocks(this);
+    }
+
+    @Test
+    public void shouldNotRetryWhenConditionReturnsFalse() throws Exception {
+        conditionsReturn(false);
+        handler = handler();
+        assertExceptionIsThrown(
+            "No retry, initial exception should have been re-thrown",
+            () -> handler.retryQueueRecovery(retryContext())
+        );
+        assertExceptionIsThrown(
+            "No retry, initial exception should have been re-thrown",
+            () -> handler.retryExchangeRecovery(retryContext())
+        );
+        assertExceptionIsThrown(
+            "No retry, initial exception should have been re-thrown",
+            () -> handler.retryBindingRecovery(retryContext())
+        );
+        assertExceptionIsThrown(
+            "No retry, initial exception should have been re-thrown",
+            () -> handler.retryConsumerRecovery(retryContext())
+        );
+        verifyConditionsInvocation(times(1));
+        verifyOperationsInvocation(never());
+        verify(backoffPolicy, never()).backoff(anyInt());
+    }
+
+    @Test
+    public void shouldReturnOperationResultInRetryResultWhenRetrying() throws Exception {
+        conditionsReturn(true);
+        when(queueRecoveryRetryOperation.call(any(RetryContext.class))).thenReturn("queue");
+        when(exchangeRecoveryRetryOperation.call(any(RetryContext.class))).thenReturn("exchange");
+        when(bindingRecoveryRetryOperation.call(any(RetryContext.class))).thenReturn("binding");
+        when(consumerRecoveryRetryOperation.call(any(RetryContext.class))).thenReturn("consumer");
+        handler = handler();
+        assertEquals(
+            "queue",
+            handler.retryQueueRecovery(retryContext()).getResult()
+        );
+        assertEquals(
+            "exchange",
+            handler.retryExchangeRecovery(retryContext()).getResult()
+        );
+        assertEquals(
+            "binding",
+            handler.retryBindingRecovery(retryContext()).getResult()
+        );
+        assertEquals(
+            "consumer",
+            handler.retryConsumerRecovery(retryContext()).getResult()
+        );
+        verifyConditionsInvocation(times(1));
+        verifyOperationsInvocation(times(1));
+        verify(backoffPolicy, times(1 * 4)).backoff(1);
+    }
+
+    @Test
+    public void shouldRetryWhenOperationFailsAndConditionIsTrue() throws Exception {
+        conditionsReturn(true);
+        when(queueRecoveryRetryOperation.call(any(RetryContext.class)))
+            .thenThrow(new Exception()).thenReturn("queue");
+        when(exchangeRecoveryRetryOperation.call(any(RetryContext.class)))
+            .thenThrow(new Exception()).thenReturn("exchange");
+        when(bindingRecoveryRetryOperation.call(any(RetryContext.class)))
+            .thenThrow(new Exception()).thenReturn("binding");
+        when(consumerRecoveryRetryOperation.call(any(RetryContext.class)))
+            .thenThrow(new Exception()).thenReturn("consumer");
+        handler = handler(2);
+        assertEquals(
+            "queue",
+            handler.retryQueueRecovery(retryContext()).getResult()
+        );
+        assertEquals(
+            "exchange",
+            handler.retryExchangeRecovery(retryContext()).getResult()
+        );
+        assertEquals(
+            "binding",
+            handler.retryBindingRecovery(retryContext()).getResult()
+        );
+        assertEquals(
+            "consumer",
+            handler.retryConsumerRecovery(retryContext()).getResult()
+        );
+        verifyConditionsInvocation(times(2));
+        verifyOperationsInvocation(times(2));
+        checkBackoffSequence(1, 2, 1, 2, 1, 2, 1, 2);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenRetryAttemptsIsExceeded() throws Exception {
+        conditionsReturn(true);
+        when(queueRecoveryRetryOperation.call(any(RetryContext.class)))
+            .thenThrow(new Exception());
+        when(exchangeRecoveryRetryOperation.call(any(RetryContext.class)))
+            .thenThrow(new Exception());
+        when(bindingRecoveryRetryOperation.call(any(RetryContext.class)))
+            .thenThrow(new Exception());
+        when(consumerRecoveryRetryOperation.call(any(RetryContext.class)))
+            .thenThrow(new Exception());
+        handler = handler(3);
+        assertExceptionIsThrown(
+            "Retry exhausted, an exception should have been thrown",
+            () -> handler.retryQueueRecovery(retryContext())
+        );
+        assertExceptionIsThrown(
+            "Retry exhausted, an exception should have been thrown",
+            () -> handler.retryExchangeRecovery(retryContext())
+        );
+        assertExceptionIsThrown(
+            "Retry exhausted, an exception should have been thrown",
+            () -> handler.retryBindingRecovery(retryContext())
+        );
+        assertExceptionIsThrown(
+            "Retry exhausted, an exception should have been thrown",
+            () -> handler.retryConsumerRecovery(retryContext())
+        );
+        verifyConditionsInvocation(times(3));
+        verifyOperationsInvocation(times(3));
+        checkBackoffSequence(1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3);
+    }
+
+    private void assertExceptionIsThrown(String message, Callable<?> action) {
+        try {
+            action.call();
+            fail(message);
+        } catch (Exception e) {
+        }
+    }
+
+    private void conditionsReturn(boolean shouldRetry) {
+        when(queueRecoveryRetryCondition.test(nullable(RecordedQueue.class), nullable(Exception.class)))
+            .thenReturn(shouldRetry);
+        when(exchangeRecoveryRetryCondition.test(nullable(RecordedExchange.class), nullable(Exception.class)))
+            .thenReturn(shouldRetry);
+        when(bindingRecoveryRetryCondition.test(nullable(RecordedBinding.class), nullable(Exception.class)))
+            .thenReturn(shouldRetry);
+        when(consumerRecoveryRetryCondition.test(nullable(RecordedConsumer.class), nullable(Exception.class)))
+            .thenReturn(shouldRetry);
+    }
+
+    private void verifyConditionsInvocation(VerificationMode mode) {
+        verify(queueRecoveryRetryCondition, mode).test(nullable(RecordedQueue.class), any(Exception.class));
+        verify(exchangeRecoveryRetryCondition, mode).test(nullable(RecordedExchange.class), any(Exception.class));
+        verify(bindingRecoveryRetryCondition, mode).test(nullable(RecordedBinding.class), any(Exception.class));
+        verify(consumerRecoveryRetryCondition, mode).test(nullable(RecordedConsumer.class), any(Exception.class));
+    }
+
+    private void verifyOperationsInvocation(VerificationMode mode) throws Exception {
+        verify(queueRecoveryRetryOperation, mode).call(any(RetryContext.class));
+        verify(exchangeRecoveryRetryOperation, mode).call(any(RetryContext.class));
+        verify(bindingRecoveryRetryOperation, mode).call(any(RetryContext.class));
+        verify(consumerRecoveryRetryOperation, mode).call(any(RetryContext.class));
+    }
+
+    private RetryHandler handler() {
+        return handler(1);
+    }
+
+    private RetryHandler handler(int retryAttempts) {
+        return new DefaultRetryHandler(
+            queueRecoveryRetryCondition, exchangeRecoveryRetryCondition,
+            bindingRecoveryRetryCondition, consumerRecoveryRetryCondition,
+            queueRecoveryRetryOperation, exchangeRecoveryRetryOperation,
+            bindingRecoveryRetryOperation, consumerRecoveryRetryOperation,
+            retryAttempts,
+            backoffPolicy);
+    }
+
+    private RetryContext retryContext() {
+        return new RetryContext(null, new Exception(), null);
+    }
+
+    private void checkBackoffSequence(int... sequence) throws InterruptedException {
+        AtomicInteger count = new AtomicInteger(0);
+        verify(backoffPolicy, times(sequence.length))
+            // for some reason Mockito calls the matchers twice as many times as the target method
+            .backoff(intThat(i -> i == sequence[count.getAndIncrement() % sequence.length]));
+    }
+}

--- a/src/test/java/com/rabbitmq/client/test/functional/FunctionalTests.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/FunctionalTests.java
@@ -78,7 +78,8 @@ import org.junit.runners.Suite;
 	Nack.class,
 	ExceptionMessages.class,
 	Metrics.class,
-	TopologyRecoveryFiltering.class
+	TopologyRecoveryFiltering.class,
+	TopologyRecoveryRetry.class
 })
 public class FunctionalTests {
 

--- a/src/test/java/com/rabbitmq/client/test/functional/TopologyRecoveryFiltering.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/TopologyRecoveryFiltering.java
@@ -21,12 +21,7 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
-import com.rabbitmq.client.Recoverable;
 import com.rabbitmq.client.RecoverableConnection;
-import com.rabbitmq.client.RecoveryListener;
-import com.rabbitmq.client.ShutdownSignalException;
-import com.rabbitmq.client.impl.NetworkConnection;
-import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 import com.rabbitmq.client.impl.recovery.RecordedBinding;
 import com.rabbitmq.client.impl.recovery.RecordedConsumer;
 import com.rabbitmq.client.impl.recovery.RecordedExchange;
@@ -34,16 +29,18 @@ import com.rabbitmq.client.impl.recovery.RecordedQueue;
 import com.rabbitmq.client.impl.recovery.TopologyRecoveryFilter;
 import com.rabbitmq.client.test.BrokerTestCase;
 import com.rabbitmq.client.test.TestUtils;
-import com.rabbitmq.tools.Host;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.rabbitmq.client.test.TestUtils.closeAndWaitForRecovery;
+import static com.rabbitmq.client.test.TestUtils.exchangeExists;
+import static com.rabbitmq.client.test.TestUtils.queueExists;
+import static com.rabbitmq.client.test.TestUtils.sendAndConsumeMessage;
 import static org.awaitility.Awaitility.waitAtMost;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -61,98 +58,6 @@ public class TopologyRecoveryFiltering extends BrokerTestCase {
         "topology.recovery.queue.1", "topology.recovery.queue.2"
     };
     Connection c;
-
-    private static boolean sendAndConsumeMessage(String exchange, String routingKey, String queue, Connection c)
-        throws IOException, TimeoutException, InterruptedException {
-        Channel ch = c.createChannel();
-        try {
-            ch.confirmSelect();
-            final CountDownLatch latch = new CountDownLatch(1);
-            ch.basicConsume(queue, true, new DefaultConsumer(ch) {
-
-                @Override
-                public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
-                    latch.countDown();
-                }
-            });
-            ch.basicPublish(exchange, routingKey, null, "".getBytes());
-            ch.waitForConfirmsOrDie(5000);
-            return latch.await(5, TimeUnit.SECONDS);
-        } finally {
-            if (ch != null && ch.isOpen()) {
-                ch.close();
-            }
-        }
-    }
-
-    private static boolean resourceExists(Callable<Channel> callback) throws Exception {
-        Channel declarePassiveChannel = null;
-        try {
-            declarePassiveChannel = callback.call();
-            return true;
-        } catch (IOException e) {
-            if (e.getCause() instanceof ShutdownSignalException) {
-                ShutdownSignalException cause = (ShutdownSignalException) e.getCause();
-                if (cause.getReason() instanceof AMQP.Channel.Close) {
-                    if (((AMQP.Channel.Close) cause.getReason()).getReplyCode() == 404) {
-                        return false;
-                    } else {
-                        throw e;
-                    }
-                }
-                return false;
-            } else {
-                throw e;
-            }
-        } finally {
-            if (declarePassiveChannel != null && declarePassiveChannel.isOpen()) {
-                declarePassiveChannel.close();
-            }
-        }
-    }
-
-    private static boolean queueExists(final String queue, final Connection connection) throws Exception {
-        return resourceExists(() -> {
-            Channel channel = connection.createChannel();
-            channel.queueDeclarePassive(queue);
-            return channel;
-        });
-    }
-
-    private static boolean exchangeExists(final String exchange, final Connection connection) throws Exception {
-        return resourceExists(() -> {
-            Channel channel = connection.createChannel();
-            channel.exchangeDeclarePassive(exchange);
-            return channel;
-        });
-    }
-
-    private static void closeAndWaitForRecovery(RecoverableConnection connection) throws IOException, InterruptedException {
-        CountDownLatch latch = prepareForRecovery(connection);
-        Host.closeConnection((NetworkConnection) connection);
-        wait(latch);
-    }
-
-    private static CountDownLatch prepareForRecovery(Connection conn) {
-        final CountDownLatch latch = new CountDownLatch(1);
-        ((AutorecoveringConnection) conn).addRecoveryListener(new RecoveryListener() {
-
-            @Override
-            public void handleRecovery(Recoverable recoverable) {
-                latch.countDown();
-            }
-
-            @Override
-            public void handleRecoveryStarted(Recoverable recoverable) {
-                // No-op
-            }
-        });
-        return latch;
-    }
-
-    private static void wait(CountDownLatch latch) throws InterruptedException {
-        assertTrue(latch.await(20, TimeUnit.SECONDS));
-    }
 
     @Override
     protected ConnectionFactory newConnectionFactory() {

--- a/src/test/java/com/rabbitmq/client/test/functional/TopologyRecoveryRetry.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/TopologyRecoveryRetry.java
@@ -1,0 +1,70 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.test.functional;
+
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.test.BrokerTestCase;
+import com.rabbitmq.client.test.TestUtils;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryHandlerBuilder.builder;
+import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryLogic.CHANNEL_CLOSED_NOT_FOUND;
+import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryLogic.RECOVER_BINDING;
+import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryLogic.RECOVER_BINDING_QUEUE;
+import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryLogic.RECOVER_CHANNEL;
+import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryLogic.RECOVER_CONSUMER;
+import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryLogic.RECOVER_CONSUMER_QUEUE;
+import static com.rabbitmq.client.test.TestUtils.closeAllConnectionsAndWaitForRecovery;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+public class TopologyRecoveryRetry extends BrokerTestCase {
+
+    @Test
+    public void topologyRecoveryRetry() throws Exception {
+        int nbQueues = 2000;
+        String prefix = "topology-recovery-retry-" + System.currentTimeMillis();
+        for (int i = 0; i < nbQueues; i++) {
+            String queue = prefix + i;
+            channel.queueDeclare(queue, false, false, true, new HashMap<>());
+            channel.queueBind(queue, "amq.direct", queue);
+            channel.basicConsume(queue, true, new DefaultConsumer(channel));
+        }
+
+        closeAllConnectionsAndWaitForRecovery(this.connection);
+
+        assertTrue(channel.isOpen());
+    }
+
+    @Override
+    protected ConnectionFactory newConnectionFactory() {
+        ConnectionFactory connectionFactory = TestUtils.connectionFactory();
+        connectionFactory.setTopologyRecoveryRetryHandler(
+            builder().bindingRecoveryRetryCondition((b, e) -> CHANNEL_CLOSED_NOT_FOUND.test(e))
+                .consumerRecoveryRetryCondition((b, e) -> CHANNEL_CLOSED_NOT_FOUND.test(e))
+                .bindingRecoveryRetryOperation(RECOVER_CHANNEL.andThen(RECOVER_BINDING_QUEUE).andThen(RECOVER_BINDING))
+                .consumerRecoveryRetryOperation(RECOVER_CHANNEL.andThen(RECOVER_CONSUMER_QUEUE.andThen(RECOVER_CONSUMER)))
+                .build()
+        );
+        connectionFactory.setNetworkRecoveryInterval(1000);
+        return connectionFactory;
+    }
+}

--- a/src/test/java/com/rabbitmq/tools/Host.java
+++ b/src/test/java/com/rabbitmq/tools/Host.java
@@ -169,6 +169,10 @@ public class Host {
         rabbitmqctl("close_connection '" + pid + "' 'Closed via rabbitmqctl'");
     }
 
+    public static void closeAllConnections() throws IOException {
+        rabbitmqctl("close_all_connections 'Closed via rabbitmqctl'");
+    }
+
     public static void closeConnection(NetworkConnection c) throws IOException {
         Host.ConnectionInfo ci = findConnectionInfoFor(Host.listConnections(), c);
         closeConnection(ci.getPid());


### PR DESCRIPTION
There's no topology recovery retry by default. The default
implementation is composable: not all have the recoverable entities have
to retry and the retry operations don't have to be only the
corresponding entity recovery, but also other operations, like
recovering the corresponding channel.

Fixes #387