### PR TITLE
Handle realTag = 0 in RecoveryAwareChannelN

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareChannelN.java
@@ -84,21 +84,27 @@ public class RecoveryAwareChannelN extends ChannelN {
     @Override
     public void basicAck(long deliveryTag, boolean multiple) throws IOException {
         long realTag = deliveryTag - activeDeliveryTagOffset;
-        // 0 tag means ack all when multiple is set
-        if (realTag > 0 || (multiple && realTag == 0)) {
-            transmit(new Basic.Ack(realTag, multiple));
-            metricsCollector.basicAck(this, deliveryTag, multiple);
+        if(multiple && deliveryTag == 0) {
+            // 0 tag means ack all when multiple is set
+            realTag = 0;
+        } else if(realTag <= 0) {
+            return;
         }
+        transmit(new Basic.Ack(realTag, multiple));
+        metricsCollector.basicAck(this, deliveryTag, multiple);
     }
 
     @Override
     public void basicNack(long deliveryTag, boolean multiple, boolean requeue) throws IOException {
         long realTag = deliveryTag - activeDeliveryTagOffset;
-        // 0 tag means nack all when multiple is set
-        if (realTag > 0 || (multiple && realTag == 0)) {
-            transmit(new Basic.Nack(realTag, multiple, requeue));
-            metricsCollector.basicNack(this, deliveryTag);
+        if(multiple && deliveryTag == 0) {
+            // 0 tag means nack all when multiple is set
+            realTag = 0;
+        } else if(realTag <= 0) {
+            return;
         }
+        transmit(new Basic.Nack(realTag, multiple, requeue));
+        metricsCollector.basicNack(this, deliveryTag);
     }
 
     @Override


### PR DESCRIPTION
## Proposed Changes
See https://github.com/rabbitmq/rabbitmq-java-client/issues/395

When a connection is lost and recovered, and the last message from the previous connection is acked with multi=true, the result is a basicAck with tag=0 and multi=1, this will ack every outstanding message. 

This is a problem if there are messages that should be nacked. For example when the rabbit connection is lost, it would seem reasonable that other systems are also unreachable (like a database).
If it somehow happens that the last few messages in the previous connection are successful and acked with multi ack. Then the other unhandled messages will be acked as well.

This change makes sure that this does not happen and only sends a ack with multi=true and tag=0 when that is actually what is requested.

I did not create or run any tests because I am having trouble installing all the required dependencies.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #395)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories


