### PR TITLE
Add opt-in to enable server hostname verification

### DIFF
--- a/src/main/java/com/rabbitmq/client/SocketChannelConfigurator.java
+++ b/src/main/java/com/rabbitmq/client/SocketChannelConfigurator.java
@@ -17,7 +17,9 @@ package com.rabbitmq.client;
 
 import java.io.IOException;
 import java.nio.channels.SocketChannel;
+import java.util.Objects;
 
+@FunctionalInterface
 public interface SocketChannelConfigurator {
 
     /**
@@ -25,5 +27,19 @@ public interface SocketChannelConfigurator {
      * used to connect to an AMQP server before they connect.
      */
     void configure(SocketChannel socketChannel) throws IOException;
+
+    /**
+     * Returns a composed configurator that performs, in sequence, this
+     * operation followed by the {@code after} operation.
+     *
+     * @param after the operation to perform after this operation
+     * @return a composed configurator that performs in sequence this
+     * operation followed by the {@code after} operation
+     * @throws NullPointerException if {@code after} is null
+     */
+    default SocketChannelConfigurator andThen(SocketChannelConfigurator after) {
+        Objects.requireNonNull(after);
+        return t -> { configure(t); after.configure(t); };
+    }
 
 }

--- a/src/main/java/com/rabbitmq/client/SocketChannelConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SocketChannelConfigurators.java
@@ -1,0 +1,111 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client;
+
+/**
+ * Ready-to-use instances and builder for {@link SocketChannelConfigurator}.
+ * <p>
+ * Note {@link SocketChannelConfigurator}s can be combined with
+ * {@link SocketChannelConfigurator#andThen(SocketChannelConfigurator)}.
+ *
+ * @since 5.5.0
+ */
+public abstract class SocketChannelConfigurators {
+
+    /**
+     * Disable Nagle's algorithm.
+     */
+    public static final SocketChannelConfigurator DISABLE_NAGLE_ALGORITHM =
+        socketChannel -> SocketConfigurators.DISABLE_NAGLE_ALGORITHM.configure(socketChannel.socket());
+
+    /**
+     * Default {@link SocketChannelConfigurator} that disables Nagle's algorithm.
+     */
+    public static final SocketChannelConfigurator DEFAULT = DISABLE_NAGLE_ALGORITHM;
+
+    /**
+     * The default {@link SocketChannelConfigurator} that disables Nagle's algorithm.
+     *
+     * @return
+     */
+    public static SocketChannelConfigurator defaultConfigurator() {
+        return DEFAULT;
+    }
+
+    /**
+     * {@link SocketChannelConfigurator} that disables Nagle's algorithm.
+     *
+     * @return
+     */
+    public static SocketChannelConfigurator disableNagleAlgorithm() {
+        return DISABLE_NAGLE_ALGORITHM;
+    }
+
+    /**
+     * Builder to configure and creates a {@link SocketChannelConfigurator} instance.
+     *
+     * @return
+     */
+    public static SocketChannelConfigurators.Builder builder() {
+        return new SocketChannelConfigurators.Builder();
+    }
+
+    public static class Builder {
+
+        private SocketChannelConfigurator configurator = channel -> {
+        };
+
+        /**
+         * Set default configuration.
+         *
+         * @return
+         */
+        public Builder defaultConfigurator() {
+            configurator = configurator.andThen(DEFAULT);
+            return this;
+        }
+
+        /**
+         * Disable Nagle's Algorithm.
+         *
+         * @return
+         */
+        public Builder disableNagleAlgorithm() {
+            configurator = configurator.andThen(DISABLE_NAGLE_ALGORITHM);
+            return this;
+        }
+
+        /**
+         * Add an extra configuration step.
+         *
+         * @param extraConfiguration
+         * @return
+         */
+        public Builder add(SocketChannelConfigurator extraConfiguration) {
+            configurator = configurator.andThen(extraConfiguration);
+            return this;
+        }
+
+        /**
+         * Return the configured {@link SocketConfigurator}.
+         *
+         * @return
+         */
+        public SocketChannelConfigurator build() {
+            return configurator;
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/client/SocketChannelConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SocketChannelConfigurators.java
@@ -21,7 +21,7 @@ package com.rabbitmq.client;
  * Note {@link SocketChannelConfigurator}s can be combined with
  * {@link SocketChannelConfigurator#andThen(SocketChannelConfigurator)}.
  *
- * @since 5.5.0
+ * @since 5.4.0
  */
 public abstract class SocketChannelConfigurators {
 

--- a/src/main/java/com/rabbitmq/client/SocketConfigurator.java
+++ b/src/main/java/com/rabbitmq/client/SocketConfigurator.java
@@ -17,11 +17,31 @@ package com.rabbitmq.client;
 
 import java.io.IOException;
 import java.net.Socket;
+import java.util.Objects;
 
+@FunctionalInterface
 public interface SocketConfigurator {
+
     /**
      * Provides a hook to insert custom configuration of the sockets
      * used to connect to an AMQP server before they connect.
      */
     void configure(Socket socket) throws IOException;
+
+    /**
+     * Returns a composed configurator that performs, in sequence, this
+     * operation followed by the {@code after} operation.
+     *
+     * @param after the operation to perform after this operation
+     * @return a composed configurator that performs in sequence this
+     * operation followed by the {@code after} operation
+     * @throws NullPointerException if {@code after} is null
+     */
+    default SocketConfigurator andThen(SocketConfigurator after) {
+        Objects.requireNonNull(after);
+        return t -> {
+            configure(t);
+            after.configure(t);
+        };
+    }
 }

--- a/src/main/java/com/rabbitmq/client/SocketConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SocketConfigurators.java
@@ -1,0 +1,153 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client;
+
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+
+/**
+ * Ready-to-use instances and builder for {@link SocketConfigurator}.
+ * <p>
+ * Note {@link SocketConfigurator}s can be combined with
+ * {@link SocketConfigurator#andThen(SocketConfigurator)}.
+ *
+ * @since 5.5.0
+ */
+public abstract class SocketConfigurators {
+
+    /**
+     * Disable Nagle's algorithm.
+     */
+    public static final SocketConfigurator DISABLE_NAGLE_ALGORITHM = socket -> socket.setTcpNoDelay(true);
+
+    /**
+     * Default {@link SocketConfigurator} that disables Nagle's algorithm.
+     */
+    public static final SocketConfigurator DEFAULT = DISABLE_NAGLE_ALGORITHM;
+
+    /**
+     * Enable server hostname validation for TLS connections.
+     */
+    public static final SocketConfigurator ENABLE_HOSTNAME_VERIFICATION = socket -> {
+        if (socket instanceof SSLSocket) {
+            SSLSocket sslSocket = (SSLSocket) socket;
+            SSLParameters sslParameters = enableHostnameVerification(sslSocket.getSSLParameters());
+            sslSocket.setSSLParameters(sslParameters);
+        }
+    };
+
+    static final SSLParameters enableHostnameVerification(SSLParameters sslParameters) {
+        if (sslParameters == null) {
+            sslParameters = new SSLParameters();
+        }
+        // It says HTTPS but works also for any TCP connection.
+        // It checks SAN (Subject Alternative Name) as well as CN.
+        sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+        return sslParameters;
+    }
+
+    /**
+     * The default {@link SocketConfigurator} that disables Nagle's algorithm.
+     *
+     * @return
+     */
+    public static SocketConfigurator defaultConfigurator() {
+        return DEFAULT;
+    }
+
+    /**
+     * {@link SocketConfigurator} that disables Nagle's algorithm.
+     *
+     * @return
+     */
+    public static SocketConfigurator disableNagleAlgorithm() {
+        return DISABLE_NAGLE_ALGORITHM;
+    }
+
+    /**
+     * {@link SocketConfigurator} that enable server hostname verification for TLS connections.
+     *
+     * @return
+     */
+    public static SocketConfigurator enableHostnameVerification() {
+        return ENABLE_HOSTNAME_VERIFICATION;
+    }
+
+    /**
+     * Builder to configure and creates a {@link SocketConfigurator} instance.
+     *
+     * @return
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private SocketConfigurator configurator = socket -> {
+        };
+
+        /**
+         * Set default configuration.
+         *
+         * @return
+         */
+        public Builder defaultConfigurator() {
+            configurator = configurator.andThen(DEFAULT);
+            return this;
+        }
+
+        /**
+         * Disable Nagle's Algorithm.
+         *
+         * @return
+         */
+        public Builder disableNagleAlgorithm() {
+            configurator = configurator.andThen(DISABLE_NAGLE_ALGORITHM);
+            return this;
+        }
+
+        /**
+         * Enable server hostname verification for TLS connections.
+         *
+         * @return
+         */
+        public Builder enableHostnameVerification() {
+            configurator = configurator.andThen(ENABLE_HOSTNAME_VERIFICATION);
+            return this;
+        }
+
+        /**
+         * Add an extra configuration step.
+         *
+         * @param extraConfiguration
+         * @return
+         */
+        public Builder add(SocketConfigurator extraConfiguration) {
+            configurator = configurator.andThen(extraConfiguration);
+            return this;
+        }
+
+        /**
+         * Return the configured {@link SocketConfigurator}.
+         *
+         * @return
+         */
+        public SocketConfigurator build() {
+            return configurator;
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/client/SocketConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SocketConfigurators.java
@@ -24,7 +24,7 @@ import javax.net.ssl.SSLSocket;
  * Note {@link SocketConfigurator}s can be combined with
  * {@link SocketConfigurator#andThen(SocketConfigurator)}.
  *
- * @since 5.5.0
+ * @since 5.4.0
  */
 public abstract class SocketConfigurators {
 

--- a/src/main/java/com/rabbitmq/client/SslEngineConfigurator.java
+++ b/src/main/java/com/rabbitmq/client/SslEngineConfigurator.java
@@ -17,7 +17,9 @@ package com.rabbitmq.client;
 
 import javax.net.ssl.SSLEngine;
 import java.io.IOException;
+import java.util.Objects;
 
+@FunctionalInterface
 public interface SslEngineConfigurator {
 
     /**
@@ -26,5 +28,19 @@ public interface SslEngineConfigurator {
      * Note this is used only when NIO are in use.
      */
     void configure(SSLEngine sslEngine) throws IOException;
+
+    /**
+     * Returns a composed configurator that performs, in sequence, this
+     * operation followed by the {@code after} operation.
+     *
+     * @param after the operation to perform after this operation
+     * @return a composed configurator that performs in sequence this
+     * operation followed by the {@code after} operation
+     * @throws NullPointerException if {@code after} is null
+     */
+    default SslEngineConfigurator andThen(SslEngineConfigurator after) {
+        Objects.requireNonNull(after);
+        return t -> { configure(t); after.configure(t); };
+    }
 
 }

--- a/src/main/java/com/rabbitmq/client/SslEngineConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SslEngineConfigurators.java
@@ -23,7 +23,7 @@ import javax.net.ssl.SSLParameters;
  * Note {@link SslEngineConfigurator}s can be combined with
  * {@link SslEngineConfigurator#andThen(SslEngineConfigurator)}.
  *
- * @since 5.5.0
+ * @since 5.4.0
  */
 public abstract class SslEngineConfigurators {
 

--- a/src/main/java/com/rabbitmq/client/SslEngineConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SslEngineConfigurators.java
@@ -1,0 +1,116 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client;
+
+import javax.net.ssl.SSLParameters;
+
+/**
+ * Ready-to-use instances and builder for {@link SslEngineConfigurator}s.
+ * <p>
+ * Note {@link SslEngineConfigurator}s can be combined with
+ * {@link SslEngineConfigurator#andThen(SslEngineConfigurator)}.
+ *
+ * @since 5.5.0
+ */
+public abstract class SslEngineConfigurators {
+
+    /**
+     * Default {@link SslEngineConfigurator}, does nothing.
+     */
+    public static SslEngineConfigurator DEFAULT = sslEngine -> {
+    };
+
+    /**
+     * {@link SslEngineConfigurator} that enables server hostname verification.
+     */
+    public static SslEngineConfigurator ENABLE_HOSTNAME_VERIFICATION = sslEngine -> {
+        SSLParameters sslParameters = SocketConfigurators.enableHostnameVerification(sslEngine.getSSLParameters());
+        sslEngine.setSSLParameters(sslParameters);
+    };
+
+    /**
+     * Default {@link SslEngineConfigurator}, does nothing.
+     *
+     * @return
+     */
+    public static SslEngineConfigurator defaultConfigurator() {
+        return DEFAULT;
+    }
+
+    /**
+     * {@link SslEngineConfigurator} that enables server hostname verification.
+     *
+     * @return
+     */
+    public static SslEngineConfigurator enableHostnameVerification() {
+        return ENABLE_HOSTNAME_VERIFICATION;
+    }
+
+    /**
+     * Builder to configure and creates a {@link SslEngineConfigurator} instance.
+     *
+     * @return
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private SslEngineConfigurator configurator = channel -> {
+        };
+
+        /**
+         * Set default configuration (no op).
+         *
+         * @return
+         */
+        public Builder defaultConfigurator() {
+            configurator = configurator.andThen(DEFAULT);
+            return this;
+        }
+
+        /**
+         * Enables server hostname verification.
+         *
+         * @return
+         */
+        public Builder enableHostnameVerification() {
+            configurator = configurator.andThen(ENABLE_HOSTNAME_VERIFICATION);
+            return this;
+        }
+
+        /**
+         * Add extra configuration step.
+         *
+         * @param extraConfiguration
+         * @return
+         */
+        public Builder add(SslEngineConfigurator extraConfiguration) {
+            configurator = configurator.andThen(extraConfiguration);
+            return this;
+        }
+
+        /**
+         * Return the configured {@link SslEngineConfigurator}.
+         *
+         * @return
+         */
+        public SslEngineConfigurator build() {
+            return configurator;
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/client/impl/nio/NioParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/nio/NioParams.java
@@ -15,13 +15,15 @@
 
 package com.rabbitmq.client.impl.nio;
 
-import com.rabbitmq.client.DefaultSocketChannelConfigurator;
 import com.rabbitmq.client.SocketChannelConfigurator;
+import com.rabbitmq.client.SocketChannelConfigurators;
 import com.rabbitmq.client.SslEngineConfigurator;
 
 import javax.net.ssl.SSLEngine;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
+
+import static com.rabbitmq.client.SslEngineConfigurators.ENABLE_HOSTNAME_VERIFICATION;
 
 /**
  * Parameters used to configure the NIO mode of a {@link com.rabbitmq.client.ConnectionFactory}.
@@ -68,7 +70,7 @@ public class NioParams {
     /**
      * the hook to configure the socket channel before it's open
      */
-    private SocketChannelConfigurator socketChannelConfigurator = new DefaultSocketChannelConfigurator();
+    private SocketChannelConfigurator socketChannelConfigurator = SocketChannelConfigurators.defaultConfigurator();
 
     /**
      * the hook to configure the SSL engine before the connection is open
@@ -94,8 +96,25 @@ public class NioParams {
         setWriteQueueCapacity(nioParams.getWriteQueueCapacity());
         setNioExecutor(nioParams.getNioExecutor());
         setThreadFactory(nioParams.getThreadFactory());
+        setSocketChannelConfigurator(nioParams.getSocketChannelConfigurator());
         setSslEngineConfigurator(nioParams.getSslEngineConfigurator());
         setConnectionShutdownExecutor(nioParams.getConnectionShutdownExecutor());
+    }
+
+    /**
+     * Enable server hostname verification for TLS connections.
+     *
+     * @return this {@link NioParams} instance
+     * @see NioParams#setSslEngineConfigurator(SslEngineConfigurator)
+     * @see com.rabbitmq.client.SslEngineConfigurators#ENABLE_HOSTNAME_VERIFICATION
+     */
+    public NioParams enableHostnameVerification() {
+        if (this.sslEngineConfigurator == null) {
+            this.sslEngineConfigurator = ENABLE_HOSTNAME_VERIFICATION;
+        } else {
+            this.sslEngineConfigurator = this.sslEngineConfigurator.andThen(ENABLE_HOSTNAME_VERIFICATION);
+        }
+        return this;
     }
 
     public int getReadByteBufferSize() {

--- a/src/test/java/com/rabbitmq/client/test/BrokerTestCase.java
+++ b/src/test/java/com/rabbitmq/client/test/BrokerTestCase.java
@@ -352,18 +352,6 @@ public class BrokerTestCase {
     }
 
     protected SSLContext getSSLContext() throws NoSuchAlgorithmException {
-        SSLContext c = null;
-
-        // pick the first protocol available, preferring TLSv1.2, then TLSv1,
-        // falling back to SSLv3 if running on an ancient/crippled JDK
-        for(String proto : Arrays.asList("TLSv1.2", "TLSv1", "SSLv3")) {
-            try {
-                c = SSLContext.getInstance(proto);
-                return c;
-            } catch (NoSuchAlgorithmException x) {
-                // keep trying
-            }
-        }
-        throw new NoSuchAlgorithmException();
+        return TestUtils.getSSLContext();
     }
 }

--- a/src/test/java/com/rabbitmq/client/test/ChannelRpcTimeoutIntegrationTest.java
+++ b/src/test/java/com/rabbitmq/client/test/ChannelRpcTimeoutIntegrationTest.java
@@ -84,7 +84,7 @@ public class ChannelRpcTimeoutIntegrationTest {
 
     private FrameHandler createFrameHandler() throws IOException {
         SocketFrameHandlerFactory socketFrameHandlerFactory = new SocketFrameHandlerFactory(ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT,
-            SocketFactory.getDefault(), new DefaultSocketConfigurator(), false, null);
+            SocketFactory.getDefault(), SocketConfigurators.defaultConfigurator(), false, null);
         return socketFrameHandlerFactory.create(new Address("localhost"), null);
     }
 

--- a/src/test/java/com/rabbitmq/client/test/TestUtils.java
+++ b/src/test/java/com/rabbitmq/client/test/TestUtils.java
@@ -30,7 +30,10 @@ import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 import com.rabbitmq.tools.Host;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.Callable;
@@ -62,6 +65,22 @@ public class TestUtils {
                 throw new RuntimeException(e);
             }
         }
+    }
+
+    public static SSLContext getSSLContext() throws NoSuchAlgorithmException {
+        SSLContext c = null;
+
+        // pick the first protocol available, preferring TLSv1.2, then TLSv1,
+        // falling back to SSLv3 if running on an ancient/crippled JDK
+        for(String proto : Arrays.asList("TLSv1.2", "TLSv1", "SSLv3")) {
+            try {
+                c = SSLContext.getInstance(proto);
+                return c;
+            } catch (NoSuchAlgorithmException x) {
+                // keep trying
+            }
+        }
+        throw new NoSuchAlgorithmException();
     }
 
     public static boolean isVersion37orLater(Connection connection) {

--- a/src/test/java/com/rabbitmq/client/test/functional/UnexpectedFrames.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/UnexpectedFrames.java
@@ -18,6 +18,7 @@ package com.rabbitmq.client.test.functional;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultSocketConfigurator;
+import com.rabbitmq.client.SocketConfigurators;
 import com.rabbitmq.client.impl.*;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 import com.rabbitmq.client.test.BrokerTestCase;
@@ -85,7 +86,7 @@ public class UnexpectedFrames extends BrokerTestCase {
 
     private static class ConfusedFrameHandlerFactory extends SocketFrameHandlerFactory {
         private ConfusedFrameHandlerFactory() {
-            super(1000, SocketFactory.getDefault(), new DefaultSocketConfigurator(), false);
+            super(1000, SocketFactory.getDefault(), SocketConfigurators.defaultConfigurator(), false);
         }
 
         @Override public FrameHandler create(Socket sock) throws IOException {

--- a/src/test/java/com/rabbitmq/client/test/ssl/HostnameVerification.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/HostnameVerification.java
@@ -15,9 +15,15 @@
 
 package com.rabbitmq.client.test.ssl;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import com.rabbitmq.client.Address;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.test.TestUtils;
+import org.junit.Test;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.TrustManagerFactory;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.KeyManagementException;
@@ -28,28 +34,20 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.concurrent.TimeoutException;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManagerFactory;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
-import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.test.TestUtils;
-import org.slf4j.LoggerFactory;
-
-/**
- * Test for bug 19356 - SSL Support in rabbitmq
- *
- */
-public class VerifiedConnection extends UnverifiedConnection {
+public class HostnameVerification extends UnverifiedConnection {
 
     public void openConnection()
-            throws IOException, TimeoutException {
+        throws IOException, TimeoutException {
         try {
             String keystorePath = System.getProperty("test-keystore.ca");
             assertNotNull(keystorePath);
             String keystorePasswd = System.getProperty("test-keystore.password");
             assertNotNull(keystorePasswd);
-            char [] keystorePassword = keystorePasswd.toCharArray();
+            char[] keystorePassword = keystorePasswd.toCharArray();
 
             KeyStore tks = KeyStore.getInstance("JKS");
             tks.load(new FileInputStream(keystorePath), keystorePassword);
@@ -62,7 +60,7 @@ public class VerifiedConnection extends UnverifiedConnection {
             String p12Passwd = System.getProperty("test-client-cert.password");
             assertNotNull(p12Passwd);
             KeyStore ks = KeyStore.getInstance("PKCS12");
-            char [] p12Password = p12Passwd.toCharArray();
+            char[] p12Password = p12Passwd.toCharArray();
             ks.load(new FileInputStream(p12Path), p12Password);
 
             KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
@@ -70,9 +68,11 @@ public class VerifiedConnection extends UnverifiedConnection {
 
             SSLContext c = getSSLContext();
             c.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+            c.init(null, tmf.getTrustManagers(), null);
 
             connectionFactory = TestUtils.connectionFactory();
             connectionFactory.useSslProtocol(c);
+            connectionFactory.enableHostnameVerification();
         } catch (NoSuchAlgorithmException ex) {
             throw new IOException(ex.toString());
         } catch (KeyManagementException ex) {
@@ -85,18 +85,20 @@ public class VerifiedConnection extends UnverifiedConnection {
             throw new IOException(ex.toString());
         }
 
-        int attempt = 0;
-        while(attempt < 3) {
-            try {
-                connection = connectionFactory.newConnection();
-                break;
-            } catch(Exception e) {
-                LoggerFactory.getLogger(getClass()).warn("Error when opening TLS connection");
-                attempt++;
-            }
+        try {
+            connection = connectionFactory.newConnection(
+                () -> singletonList(new Address("127.0.0.1", ConnectionFactory.DEFAULT_AMQP_OVER_SSL_PORT)));
+            fail("The server certificate isn't issued for 127.0.0.1, the TLS handshake should have failed");
+        } catch (SSLHandshakeException ignored) {
+        } catch (IOException e) {
+            fail();
         }
-        if(connection == null) {
-            fail("Couldn't open TLS connection after 3 attempts");
-        }
+    }
+
+    public void openChannel() {
+    }
+
+    @Test
+    public void sSL() {
     }
 }

--- a/src/test/java/com/rabbitmq/client/test/ssl/HostnameVerification.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/HostnameVerification.java
@@ -16,8 +16,10 @@
 package com.rabbitmq.client.test.ssl;
 
 import com.rabbitmq.client.Address;
+import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.test.TestUtils;
+import com.rabbitmq.tools.Host;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +36,7 @@ import java.util.function.Consumer;
 import static com.rabbitmq.client.test.TestUtils.getSSLContext;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
@@ -106,5 +109,15 @@ public class HostnameVerification {
         connectionFactory.newConnection(
             () -> singletonList(new Address("127.0.0.1", ConnectionFactory.DEFAULT_AMQP_OVER_SSL_PORT)));
         fail("The server certificate isn't issued for 127.0.0.1, the TLS handshake should have failed");
+    }
+
+    public void hostnameVerificationSucceeds() throws Exception {
+        ConnectionFactory connectionFactory = TestUtils.connectionFactory();
+        connectionFactory.useSslProtocol(sslContext);
+        customizer.accept(connectionFactory);
+        Connection conn = connectionFactory.newConnection(
+            () -> singletonList(new Address(Host.systemHostname(), ConnectionFactory.DEFAULT_AMQP_OVER_SSL_PORT)));
+        assertTrue(conn.isOpen());
+        conn.close();
     }
 }

--- a/src/test/java/com/rabbitmq/client/test/ssl/HostnameVerification.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/HostnameVerification.java
@@ -18,87 +18,93 @@ package com.rabbitmq.client.test.ssl;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.test.TestUtils;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.FileInputStream;
-import java.io.IOException;
-import java.security.KeyManagementException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
-import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
+import static com.rabbitmq.client.test.TestUtils.getSSLContext;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-public class HostnameVerification extends UnverifiedConnection {
+@RunWith(Parameterized.class)
+public class HostnameVerification {
 
-    public void openConnection()
-        throws IOException, TimeoutException {
-        try {
-            String keystorePath = System.getProperty("test-keystore.ca");
-            assertNotNull(keystorePath);
-            String keystorePasswd = System.getProperty("test-keystore.password");
-            assertNotNull(keystorePasswd);
-            char[] keystorePassword = keystorePasswd.toCharArray();
+    static SSLContext sslContext;
+    @Parameterized.Parameter
+    public Consumer<ConnectionFactory> customizer;
 
-            KeyStore tks = KeyStore.getInstance("JKS");
-            tks.load(new FileInputStream(keystorePath), keystorePassword);
-
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
-            tmf.init(tks);
-
-            String p12Path = System.getProperty("test-client-cert.path");
-            assertNotNull(p12Path);
-            String p12Passwd = System.getProperty("test-client-cert.password");
-            assertNotNull(p12Passwd);
-            KeyStore ks = KeyStore.getInstance("PKCS12");
-            char[] p12Password = p12Passwd.toCharArray();
-            ks.load(new FileInputStream(p12Path), p12Password);
-
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-            kmf.init(ks, p12Password);
-
-            SSLContext c = getSSLContext();
-            c.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
-            c.init(null, tmf.getTrustManagers(), null);
-
-            connectionFactory = TestUtils.connectionFactory();
-            connectionFactory.useSslProtocol(c);
-            connectionFactory.enableHostnameVerification();
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IOException(ex.toString());
-        } catch (KeyManagementException ex) {
-            throw new IOException(ex.toString());
-        } catch (KeyStoreException ex) {
-            throw new IOException(ex.toString());
-        } catch (CertificateException ex) {
-            throw new IOException(ex.toString());
-        } catch (UnrecoverableKeyException ex) {
-            throw new IOException(ex.toString());
-        }
-
-        try {
-            connection = connectionFactory.newConnection(
-                () -> singletonList(new Address("127.0.0.1", ConnectionFactory.DEFAULT_AMQP_OVER_SSL_PORT)));
-            fail("The server certificate isn't issued for 127.0.0.1, the TLS handshake should have failed");
-        } catch (SSLHandshakeException ignored) {
-        } catch (IOException e) {
-            fail();
-        }
+    @Parameterized.Parameters
+    public static Object[] data() {
+        return new Object[] {
+            blockingIo(enableHostnameVerification()),
+            nio(enableHostnameVerification()),
+        };
     }
 
-    public void openChannel() {
+    private static Consumer<ConnectionFactory> blockingIo(final Consumer<ConnectionFactory> customizer) {
+        return connectionFactory -> {
+            connectionFactory.useBlockingIo();
+            customizer.accept(connectionFactory);
+        };
     }
 
-    @Test
-    public void sSL() {
+    private static Consumer<ConnectionFactory> nio(final Consumer<ConnectionFactory> customizer) {
+        return connectionFactory -> {
+            connectionFactory.useNio();
+            customizer.accept(connectionFactory);
+        };
+    }
+
+    private static Consumer<ConnectionFactory> enableHostnameVerification() {
+        return connectionFactory -> connectionFactory.enableHostnameVerification();
+    }
+
+    @BeforeClass
+    public static void initCrypto() throws Exception {
+        String keystorePath = System.getProperty("test-keystore.ca");
+        assertNotNull(keystorePath);
+        String keystorePasswd = System.getProperty("test-keystore.password");
+        assertNotNull(keystorePasswd);
+        char[] keystorePassword = keystorePasswd.toCharArray();
+
+        KeyStore tks = KeyStore.getInstance("JKS");
+        tks.load(new FileInputStream(keystorePath), keystorePassword);
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+        tmf.init(tks);
+
+        String p12Path = System.getProperty("test-client-cert.path");
+        assertNotNull(p12Path);
+        String p12Passwd = System.getProperty("test-client-cert.password");
+        assertNotNull(p12Passwd);
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        char[] p12Password = p12Passwd.toCharArray();
+        ks.load(new FileInputStream(p12Path), p12Password);
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, p12Password);
+
+        sslContext = getSSLContext();
+        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+    }
+
+    @Test(expected = SSLHandshakeException.class)
+    public void hostnameVerificationFailsBecauseCertificateNotIssuedForLoopbackInterface() throws Exception {
+        ConnectionFactory connectionFactory = TestUtils.connectionFactory();
+        connectionFactory.useSslProtocol(sslContext);
+        customizer.accept(connectionFactory);
+        connectionFactory.newConnection(
+            () -> singletonList(new Address("127.0.0.1", ConnectionFactory.DEFAULT_AMQP_OVER_SSL_PORT)));
+        fail("The server certificate isn't issued for 127.0.0.1, the TLS handshake should have failed");
     }
 }

--- a/src/test/java/com/rabbitmq/client/test/ssl/NioTlsUnverifiedConnection.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/NioTlsUnverifiedConnection.java
@@ -82,12 +82,7 @@ public class NioTlsUnverifiedConnection extends BrokerTestCase {
         connectionFactory.useSslProtocol();
         NioParams nioParams = new NioParams();
         final AtomicBoolean sslEngineHasBeenCalled = new AtomicBoolean(false);
-        nioParams.setSslEngineConfigurator(new SslEngineConfigurator() {
-            @Override
-            public void configure(SSLEngine sslEngine) throws IOException {
-                sslEngineHasBeenCalled.set(true);
-            }
-        });
+        nioParams.setSslEngineConfigurator(sslEngine -> sslEngineHasBeenCalled.set(true));
 
         connectionFactory.setNioParams(nioParams);
 

--- a/src/test/java/com/rabbitmq/client/test/ssl/SSLTests.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/SSLTests.java
@@ -32,7 +32,8 @@ import java.util.List;
 	VerifiedConnection.class,
 	BadVerifiedConnection.class,
 	ConnectionFactoryDefaultTlsVersion.class,
-	NioTlsUnverifiedConnection.class
+	NioTlsUnverifiedConnection.class,
+	HostnameVerification.class
 })
 public class SSLTests {
 

--- a/src/test/java/com/rabbitmq/client/test/ssl/UnverifiedConnection.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/UnverifiedConnection.java
@@ -54,7 +54,7 @@ public class UnverifiedConnection extends BrokerTestCase {
             }
         }
         if(connection == null) {
-            fail("Couldn't open TLS connection after 3 attemps");
+            fail("Couldn't open TLS connection after 3 attempts");
         }
     }
 

--- a/src/test/java/com/rabbitmq/tools/Host.java
+++ b/src/test/java/com/rabbitmq/tools/Host.java
@@ -120,6 +120,11 @@ public class Host {
                               " " + command);
     }
 
+    public static String systemHostname() throws IOException {
+        Process process = executeCommandIgnoringErrors("hostname");
+        return capture(process.getInputStream());
+    }
+
     public static String makeCommand()
     {
         return System.getProperty("make.bin", "make");


### PR DESCRIPTION
Hostname verification isn't performed by default in the TLS handshake,
this commit makes it easier to enable server hostname verification for
both blocking and non-blocking IO modes.

Fixes #394