### PR TITLE
Backport hostname verification to 4.x.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,13 @@
     <metrics.version>3.2.6</metrics.version>
     <micrometer.version>1.0.2</micrometer.version>
     <jackson.version>2.9.6</jackson.version>
+    <httpclient.version>4.5.6</httpclient.version>
     <logback.version>1.2.3</logback.version>
     <commons-cli.version>1.1</commons-cli.version>
     <junit.version>4.12</junit.version>
     <awaitility.version>3.1.0</awaitility.version>
     <mockito.version>2.16.0</mockito.version>
+    <bouncycastle.version>1.60</bouncycastle.version>
 
     <maven.javadoc.plugin.version>3.0.0</maven.javadoc.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
@@ -648,6 +650,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>${commons-cli.version}</version>
@@ -681,6 +689,12 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/rabbitmq/client/ConnectionContext.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionContext.java
@@ -1,0 +1,74 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client;
+
+import javax.net.ssl.SSLSession;
+import java.net.Socket;
+
+/**
+ * The context of the freshly open TCP connection.
+ *
+ * @see ConnectionPostProcessor
+ * @since 4.8.0
+ */
+public class ConnectionContext {
+
+    private final Socket socket;
+    private final Address address;
+    private final boolean ssl;
+    private final SSLSession sslSession;
+
+    public ConnectionContext(Socket socket, Address address, boolean ssl, SSLSession sslSession) {
+        this.socket = socket;
+        this.address = address;
+        this.ssl = ssl;
+        this.sslSession = sslSession;
+    }
+
+    /**
+     * The network socket. Can be an {@link javax.net.ssl.SSLSocket}.
+     *
+     * @return
+     */
+    public Socket getSocket() {
+        return socket;
+    }
+
+    /**
+     * The address (hostname and port) used for connecting.
+     *
+     * @return
+     */
+    public Address getAddress() {
+        return address;
+    }
+
+    /**
+     * Whether this is a SSL/TLS connection.
+     * @return
+     */
+    public boolean isSsl() {
+        return ssl;
+    }
+
+    /**
+     * The {@link SSLSession} for a TLS connection, <code>null</code> otherwise.
+     * @return
+     */
+    public SSLSession getSslSession() {
+        return sslSession;
+    }
+}

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -29,8 +29,10 @@ import com.rabbitmq.client.impl.nio.SocketChannelFrameHandlerFactory;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 import com.rabbitmq.client.impl.recovery.RetryHandler;
 import com.rabbitmq.client.impl.recovery.TopologyRecoveryFilter;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 
 import javax.net.SocketFactory;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -187,6 +189,19 @@ public class ConnectionFactory implements Cloneable {
      * @since 4.8.0
      */
     private RetryHandler topologyRecoveryRetryHandler;
+
+    /**
+     * Hook to post-process the freshly open TCP connection.
+     *
+     * @since 4.8.0
+     */
+    private ConnectionPostProcessor connectionPostProcessor = new ConnectionPostProcessor() {
+
+        @Override
+        public void postProcess(ConnectionContext context) {
+
+        }
+    };
 
     /** @return the default host to use for connections */
     public String getHost() {
@@ -679,12 +694,19 @@ public class ConnectionFactory implements Cloneable {
      * Pass in the TLS protocol version to use, e.g. "TLSv1.2" or "TLSv1.1", and
      * a desired {@link TrustManager}.
      *
+     * Note <strong>you must explicitly enable hostname verification</strong> with the
+     * {@link ConnectionFactory#enableHostnameVerification()} or the
+     * {@link ConnectionFactory#enableHostnameVerification(HostnameVerifier)}
+     * method.
+     *
      *
      * The produced {@link SSLContext} instance will be shared with all
      * the connections created by this connection factory.
      * @param protocol the TLS protocol to use.
      * @param trustManager the {@link TrustManager} implementation to use.
      * @see #useSslProtocol(SSLContext)
+     * @see #enableHostnameVerification()
+     * @see #enableHostnameVerification(HostnameVerifier)
      */
     public void useSslProtocol(String protocol, TrustManager trustManager)
         throws NoSuchAlgorithmException, KeyManagementException
@@ -699,9 +721,16 @@ public class ConnectionFactory implements Cloneable {
      * for setting up the context with a {@link TrustManager} with suitable security guarantees,
      * e.g. peer verification.
      *
+     * Note <strong>you must explicitly enable hostname verification</strong> with the
+     * {@link ConnectionFactory#enableHostnameVerification()} or the
+     * {@link ConnectionFactory#enableHostnameVerification(HostnameVerifier)}
+     * method.
+     *
      * The {@link SSLContext} instance will be shared with all
      * the connections created by this connection factory.
      * @param context An initialized SSLContext
+     * @see #enableHostnameVerification()
+     * @see #enableHostnameVerification(HostnameVerifier)
      */
     public void useSslProtocol(SSLContext context) {
         setSocketFactory(context.getSocketFactory());
@@ -716,6 +745,15 @@ public class ConnectionFactory implements Cloneable {
      * <p>
      * This can be called typically after setting the {@link SSLContext}
      * with one of the <code>useSslProtocol</code> methods.
+     * <p>
+     * If <strong>using Java 7 or more</strong>, the hostname verification will be
+     * performed by Java, as part of the TLS handshake.
+     * <p>
+     * If <strong>using Java 6</strong>, the hostname verification will be handled after
+     * the TLS handshake, using the {@link HostnameVerifier} from the
+     * Commons HttpClient project. This requires to add Commons HttpClient
+     * and its dependencies to the classpath. To use a custom {@link HostnameVerifier},
+     * use {@link ConnectionFactory#enableHostnameVerification(HostnameVerifier)}.
      *
      * @see NioParams#enableHostnameVerification()
      * @see NioParams#setSslEngineConfigurator(SslEngineConfigurator)
@@ -725,10 +763,43 @@ public class ConnectionFactory implements Cloneable {
      * @see ConnectionFactory#useSslProtocol(SSLContext)
      * @see ConnectionFactory#useSslProtocol()
      * @see ConnectionFactory#useSslProtocol(String, TrustManager)
+     * @see ConnectionFactory#enableHostnameVerification(HostnameVerifier)
+     * @since 4.8.0
      */
     public void enableHostnameVerification() {
-        enableHostnameVerificationForNio();
-        enableHostnameVerificationForBlockingIo();
+        if (isJava6()) {
+            enableHostnameVerification(new DefaultHostnameVerifier());
+        } else {
+            enableHostnameVerificationForNio();
+            enableHostnameVerificationForBlockingIo();
+        }
+    }
+
+    /**
+     * Enable TLS hostname verification performed by the passed-in {@link HostnameVerifier}.
+     * <p>
+     * Using an {@link HostnameVerifier} is relevant only for Java 6, for Java 7 or more,
+     * calling ConnectionFactory{@link #enableHostnameVerification()} is enough.
+     *
+     * @param hostnameVerifier
+     * @since 4.8.0
+     * @see ConnectionFactory#enableHostnameVerification()
+     */
+    public void enableHostnameVerification(HostnameVerifier hostnameVerifier) {
+        if (this.connectionPostProcessor == null) {
+            this.connectionPostProcessor = ConnectionPostProcessors.builder()
+                .enableHostnameVerification(hostnameVerifier)
+                .build();
+        } else {
+            this.connectionPostProcessor = ConnectionPostProcessors.builder()
+                .add(this.connectionPostProcessor)
+                .enableHostnameVerification(hostnameVerifier)
+                .build();
+        }
+    }
+
+    protected boolean isJava6() {
+        return System.getProperty("java.specification.version").startsWith("1.6");
     }
 
     protected void enableHostnameVerificationForNio() {
@@ -835,11 +906,11 @@ public class ConnectionFactory implements Cloneable {
                 if(this.nioParams.getNioExecutor() == null && this.nioParams.getThreadFactory() == null) {
                     this.nioParams.setThreadFactory(getThreadFactory());
                 }
-                this.frameHandlerFactory = new SocketChannelFrameHandlerFactory(connectionTimeout, nioParams, isSSL(), sslContext);
+                this.frameHandlerFactory = new SocketChannelFrameHandlerFactory(connectionTimeout, nioParams, isSSL(), sslContext, connectionPostProcessor);
             }
             return this.frameHandlerFactory;
         } else {
-            return new SocketFrameHandlerFactory(connectionTimeout, factory, socketConf, isSSL(), this.shutdownExecutor);
+            return new SocketFrameHandlerFactory(connectionTimeout, factory, socketConf, isSSL(), this.shutdownExecutor, connectionPostProcessor);
         }
 
     }
@@ -1482,5 +1553,16 @@ public class ConnectionFactory implements Cloneable {
      */
     public void setTopologyRecoveryRetryHandler(RetryHandler topologyRecoveryRetryHandler) {
         this.topologyRecoveryRetryHandler = topologyRecoveryRetryHandler;
+    }
+
+    /**
+     * Hook to post-process the freshly open TCP connection.
+     *
+     * @param connectionPostProcessor
+     * @see #enableHostnameVerification()
+     * @see #enableHostnameVerification(HostnameVerifier)
+     */
+    public void setConnectionPostProcessor(ConnectionPostProcessor connectionPostProcessor) {
+        this.connectionPostProcessor = connectionPostProcessor;
     }
 }

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -15,8 +15,6 @@
 
 package com.rabbitmq.client;
 
-import static java.util.concurrent.TimeUnit.*;
-
 import com.rabbitmq.client.impl.AMQConnection;
 import com.rabbitmq.client.impl.ConnectionParams;
 import com.rabbitmq.client.impl.CredentialsProvider;
@@ -32,6 +30,10 @@ import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 import com.rabbitmq.client.impl.recovery.RetryHandler;
 import com.rabbitmq.client.impl.recovery.TopologyRecoveryFilter;
 
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -49,10 +51,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeoutException;
-import javax.net.SocketFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
  * Convenience "factory" class to facilitate opening a {@link Connection} to an AMQP broker.
@@ -126,7 +126,7 @@ public class ConnectionFactory implements Cloneable {
     // connections uses, see rabbitmq/rabbitmq-java-client#86
     private ExecutorService shutdownExecutor;
     private ScheduledExecutorService heartbeatExecutor;
-    private SocketConfigurator socketConf           = new DefaultSocketConfigurator();
+    private SocketConfigurator socketConf           = SocketConfigurators.defaultConfigurator();
     private ExceptionHandler exceptionHandler       = new DefaultExceptionHandler();
     private CredentialsProvider credentialsProvider = new DefaultCredentialsProvider(DEFAULT_USER, DEFAULT_PASS);
 
@@ -706,6 +706,50 @@ public class ConnectionFactory implements Cloneable {
     public void useSslProtocol(SSLContext context) {
         setSocketFactory(context.getSocketFactory());
         this.sslContext = context;
+    }
+
+    /**
+     * Enable server hostname verification for TLS connections.
+     * <p>
+     * This enables hostname verification regardless of the IO mode
+     * used (blocking or non-blocking IO).
+     * <p>
+     * This can be called typically after setting the {@link SSLContext}
+     * with one of the <code>useSslProtocol</code> methods.
+     *
+     * @see NioParams#enableHostnameVerification()
+     * @see NioParams#setSslEngineConfigurator(SslEngineConfigurator)
+     * @see SslEngineConfigurators#ENABLE_HOSTNAME_VERIFICATION
+     * @see SocketConfigurators#ENABLE_HOSTNAME_VERIFICATION
+     * @see ConnectionFactory#useSslProtocol(String)
+     * @see ConnectionFactory#useSslProtocol(SSLContext)
+     * @see ConnectionFactory#useSslProtocol()
+     * @see ConnectionFactory#useSslProtocol(String, TrustManager)
+     */
+    public void enableHostnameVerification() {
+        enableHostnameVerificationForNio();
+        enableHostnameVerificationForBlockingIo();
+    }
+
+    protected void enableHostnameVerificationForNio() {
+        if (this.nioParams == null) {
+            this.nioParams = new NioParams();
+        }
+        this.nioParams = this.nioParams.enableHostnameVerification();
+    }
+
+    protected void enableHostnameVerificationForBlockingIo() {
+        if (this.socketConf == null) {
+            this.socketConf = SocketConfigurators.builder()
+                .defaultConfigurator()
+                .enableHostnameVerification()
+                .build();
+        } else {
+            this.socketConf = SocketConfigurators.builder()
+                .add(this.socketConf)
+                .enableHostnameVerification()
+                .build();
+        }
     }
 
     public static String computeDefaultTlsProcotol(String[] supportedProtocols) {

--- a/src/main/java/com/rabbitmq/client/ConnectionPostProcessor.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionPostProcessor.java
@@ -1,0 +1,36 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client;
+
+import java.io.IOException;
+
+/**
+ * Hook to add processing on the open TCP connection.
+ * <p>
+ * Used e.g. to add hostname verification on TLS connection.
+ *
+ * @since 4.8.0
+ */
+public interface ConnectionPostProcessor {
+
+    /**
+     * Post-process the open TCP connection.
+     *
+     * @param context some TCP connection context (e.g. socket)
+     * @throws IOException
+     */
+    void postProcess(ConnectionContext context) throws IOException;
+}

--- a/src/main/java/com/rabbitmq/client/ConnectionPostProcessors.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionPostProcessors.java
@@ -1,0 +1,137 @@
+package com.rabbitmq.client;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import java.io.IOException;
+
+/**
+ * Ready-to-use instances and builder for {@link ConnectionPostProcessor}.
+ * <p>
+ * Note {@link ConnectionPostProcessor}s can be combined with
+ * {@link AbstractConnectionPostProcessor#andThen(ConnectionPostProcessor)}.
+ *
+ * @since 4.8.0
+ */
+public abstract class ConnectionPostProcessors {
+
+    /**
+     * Perform hostname verification for TLS connections.
+     * <p>
+     * Enforcing hostname verification this way is relevant for Java 6.
+     * If using Java 7 or more, you'd better off using {@link SocketConfigurators}
+     * or {@link SslEngineConfigurators}, depending on whether you're using
+     * blocking IO or non-blocking IO, respectively.
+     *
+     * @param verifier the {@link HostnameVerifier} to use
+     * @return
+     */
+    public static AbstractConnectionPostProcessor hostnameVerificationConnectionPostProcessor(HostnameVerifier verifier) {
+        return new HostnameVerificationConnectionPostProcessor(verifier);
+    }
+
+    /**
+     * Builder to configure and create a {@link ConnectionPostProcessor} instance.
+     *
+     * @return
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Perform hostname verification for TLS connections.
+     */
+    private static class HostnameVerificationConnectionPostProcessor extends AbstractConnectionPostProcessor {
+
+        private final HostnameVerifier verifier;
+
+        private HostnameVerificationConnectionPostProcessor(HostnameVerifier verifier) {
+            this.verifier = verifier;
+        }
+
+        @Override
+        public void postProcess(ConnectionContext context) throws IOException {
+            SSLSession sslSession = context.getSslSession();
+            if (sslSession == null && context.getSocket() instanceof SSLSocket) {
+                sslSession = ((SSLSocket) context.getSocket()).getSession();
+            }
+            if (sslSession != null) {
+                String hostname = context.getAddress().getHost();
+                if (!verifier.verify(hostname, sslSession)) {
+                    throw new SSLHandshakeException("Hostname " + hostname + " does not match "
+                        + "TLS certificate SAN or CN");
+                }
+            }
+        }
+    }
+
+    public abstract static class AbstractConnectionPostProcessor implements ConnectionPostProcessor {
+
+        /**
+         * Returns a composed processor that performs, in sequence, this
+         * operation followed by the {@code after} operation.
+         *
+         * @param after the operation to perform after this operation
+         * @return a composed processor that performs in sequence this
+         * operation followed by the {@code after} operation
+         * @throws NullPointerException if {@code after} is null
+         */
+        public AbstractConnectionPostProcessor andThen(final ConnectionPostProcessor after) {
+            if (after == null) {
+                throw new NullPointerException();
+            }
+            return new AbstractConnectionPostProcessor() {
+
+                @Override
+                public void postProcess(ConnectionContext t) throws IOException {
+                    AbstractConnectionPostProcessor.this.postProcess(t);
+                    after.postProcess(t);
+                }
+            };
+        }
+    }
+
+    public static class Builder {
+
+        private AbstractConnectionPostProcessor postProcessor = new AbstractConnectionPostProcessor() {
+
+            @Override
+            public void postProcess(ConnectionContext context) {
+
+            }
+        };
+
+        /**
+         * Enable hostname verification enforced by the provided {@link HostnameVerifier}.
+         *
+         * @param hostnameVerifier
+         * @return
+         */
+        public Builder enableHostnameVerification(HostnameVerifier hostnameVerifier) {
+            this.postProcessor = this.postProcessor.andThen(hostnameVerificationConnectionPostProcessor(hostnameVerifier));
+            return this;
+        }
+
+        /**
+         * Add an extra post-processing step.
+         *
+         * @param connectionPostProcessor
+         * @return
+         */
+        public Builder add(ConnectionPostProcessor connectionPostProcessor) {
+            this.postProcessor = this.postProcessor.andThen(connectionPostProcessor);
+            return this;
+        }
+
+        /**
+         * Return the configured {@link ConnectionPostProcessor}.
+         *
+         * @return
+         */
+        public ConnectionPostProcessor build() {
+            return this.postProcessor;
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/client/SocketChannelConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SocketChannelConfigurators.java
@@ -1,0 +1,150 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client;
+
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+
+/**
+ * Ready-to-use instances and builder for {@link SocketChannelConfigurator}.
+ * <p>
+ * Note {@link SocketChannelConfigurator}s can be combined with
+ * {@link AbstractSocketChannelConfigurator#andThen(SocketChannelConfigurator)}.
+ *
+ * @since 4.8.0
+ */
+public abstract class SocketChannelConfigurators {
+
+    /**
+     * Disable Nagle's algorithm.
+     */
+    public static final AbstractSocketChannelConfigurator DISABLE_NAGLE_ALGORITHM =
+        new AbstractSocketChannelConfigurator() {
+
+            @Override
+            public void configure(SocketChannel socketChannel) throws IOException {
+                SocketConfigurators.DISABLE_NAGLE_ALGORITHM.configure(socketChannel.socket());
+            }
+        };
+
+    /**
+     * Default {@link SocketChannelConfigurator} that disables Nagle's algorithm.
+     */
+    public static final AbstractSocketChannelConfigurator DEFAULT = DISABLE_NAGLE_ALGORITHM;
+
+    /**
+     * The default {@link SocketChannelConfigurator} that disables Nagle's algorithm.
+     *
+     * @return
+     */
+    public static AbstractSocketChannelConfigurator defaultConfigurator() {
+        return DEFAULT;
+    }
+
+    /**
+     * {@link SocketChannelConfigurator} that disables Nagle's algorithm.
+     *
+     * @return
+     */
+    public static AbstractSocketChannelConfigurator disableNagleAlgorithm() {
+        return DISABLE_NAGLE_ALGORITHM;
+    }
+
+    /**
+     * Builder to configure and creates a {@link SocketChannelConfigurator} instance.
+     *
+     * @return
+     */
+    public static SocketChannelConfigurators.Builder builder() {
+        return new SocketChannelConfigurators.Builder();
+    }
+
+    public static abstract class AbstractSocketChannelConfigurator implements SocketChannelConfigurator {
+
+        /**
+         * Returns a composed configurator that performs, in sequence, this
+         * operation followed by the {@code after} operation.
+         *
+         * @param after the operation to perform after this operation
+         * @return a composed configurator that performs in sequence this
+         * operation followed by the {@code after} operation
+         * @throws NullPointerException if {@code after} is null
+         */
+        public AbstractSocketChannelConfigurator andThen(final SocketChannelConfigurator after) {
+            if (after == null) {
+                throw new NullPointerException();
+            }
+            return new AbstractSocketChannelConfigurator() {
+
+                @Override
+                public void configure(SocketChannel socketChannel) throws IOException {
+                    AbstractSocketChannelConfigurator.this.configure(socketChannel);
+                    after.configure(socketChannel);
+                }
+            };
+        }
+    }
+
+    public static class Builder {
+
+        private AbstractSocketChannelConfigurator configurator = new AbstractSocketChannelConfigurator() {
+
+            @Override
+            public void configure(SocketChannel channel) {
+            }
+        };
+
+        /**
+         * Set default configuration.
+         *
+         * @return
+         */
+        public Builder defaultConfigurator() {
+            configurator = configurator.andThen(DEFAULT);
+            return this;
+        }
+
+        /**
+         * Disable Nagle's Algorithm.
+         *
+         * @return
+         */
+        public Builder disableNagleAlgorithm() {
+            configurator = configurator.andThen(DISABLE_NAGLE_ALGORITHM);
+            return this;
+        }
+
+        /**
+         * Add an extra configuration step.
+         *
+         * @param extraConfiguration
+         * @return
+         */
+        public Builder add(SocketChannelConfigurator extraConfiguration) {
+            configurator = configurator.andThen(extraConfiguration);
+            return this;
+        }
+
+        /**
+         * Return the configured {@link SocketConfigurator}.
+         *
+         * @return
+         */
+        public SocketChannelConfigurator build() {
+            return configurator;
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/client/SocketConfigurator.java
+++ b/src/main/java/com/rabbitmq/client/SocketConfigurator.java
@@ -19,9 +19,11 @@ import java.io.IOException;
 import java.net.Socket;
 
 public interface SocketConfigurator {
+
     /**
      * Provides a hook to insert custom configuration of the sockets
      * used to connect to an AMQP server before they connect.
      */
     void configure(Socket socket) throws IOException;
+
 }

--- a/src/main/java/com/rabbitmq/client/SocketConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SocketConfigurators.java
@@ -1,0 +1,195 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client;
+
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import java.io.IOException;
+import java.net.Socket;
+
+/**
+ * Ready-to-use instances and builder for {@link SocketConfigurator}.
+ * <p>
+ * Note {@link SocketConfigurator}s can be combined with
+ * {@link AbstractSocketConfigurator#andThen(SocketConfigurator)}.
+ *
+ * @since 4.8.0
+ */
+public abstract class SocketConfigurators {
+
+    /**
+     * Disable Nagle's algorithm.
+     */
+    public static final AbstractSocketConfigurator DISABLE_NAGLE_ALGORITHM = new AbstractSocketConfigurator() {
+
+        @Override
+        public void configure(Socket socket) throws IOException {
+            socket.setTcpNoDelay(true);
+        }
+    };
+
+    /**
+     * Default {@link SocketConfigurator} that disables Nagle's algorithm.
+     */
+    public static final AbstractSocketConfigurator DEFAULT = DISABLE_NAGLE_ALGORITHM;
+
+    /**
+     * Enable server hostname validation for TLS connections.
+     */
+    public static final AbstractSocketConfigurator ENABLE_HOSTNAME_VERIFICATION = new AbstractSocketConfigurator() {
+
+        @Override
+        public void configure(Socket socket) {
+            if (socket instanceof SSLSocket) {
+                SSLSocket sslSocket = (SSLSocket) socket;
+                SSLParameters sslParameters = enableHostnameVerification(sslSocket.getSSLParameters());
+                sslSocket.setSSLParameters(sslParameters);
+            }
+        }
+    };
+
+    static final SSLParameters enableHostnameVerification(SSLParameters sslParameters) {
+        if (sslParameters == null) {
+            sslParameters = new SSLParameters();
+        }
+        // It says HTTPS but works also for any TCP connection.
+        // It checks SAN (Subject Alternative Name) as well as CN.
+        sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+        return sslParameters;
+    }
+
+    /**
+     * The default {@link SocketConfigurator} that disables Nagle's algorithm.
+     *
+     * @return
+     */
+    public static AbstractSocketConfigurator defaultConfigurator() {
+        return DEFAULT;
+    }
+
+    /**
+     * {@link SocketConfigurator} that disables Nagle's algorithm.
+     *
+     * @return
+     */
+    public static AbstractSocketConfigurator disableNagleAlgorithm() {
+        return DISABLE_NAGLE_ALGORITHM;
+    }
+
+    /**
+     * {@link SocketConfigurator} that enable server hostname verification for TLS connections.
+     *
+     * @return
+     */
+    public static AbstractSocketConfigurator enableHostnameVerification() {
+        return ENABLE_HOSTNAME_VERIFICATION;
+    }
+
+    /**
+     * Builder to configure and creates a {@link SocketConfigurator} instance.
+     *
+     * @return
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static abstract class AbstractSocketConfigurator implements SocketConfigurator {
+
+        /**
+         * Returns a composed configurator that performs, in sequence, this
+         * operation followed by the {@code after} operation.
+         *
+         * @param after the operation to perform after this operation
+         * @return a composed configurator that performs in sequence this
+         * operation followed by the {@code after} operation
+         * @throws NullPointerException if {@code after} is null
+         */
+        public AbstractSocketConfigurator andThen(final SocketConfigurator after) {
+            if (after == null) {
+                throw new NullPointerException();
+            }
+            return new AbstractSocketConfigurator() {
+
+                @Override
+                public void configure(Socket t) throws IOException {
+                    AbstractSocketConfigurator.this.configure(t);
+                    after.configure(t);
+                }
+            };
+        }
+    }
+
+    public static class Builder {
+
+        private AbstractSocketConfigurator configurator = new AbstractSocketConfigurator() {
+
+            @Override
+            public void configure(Socket socket) {
+            }
+        };
+
+        /**
+         * Set default configuration.
+         *
+         * @return
+         */
+        public Builder defaultConfigurator() {
+            configurator = configurator.andThen(DEFAULT);
+            return this;
+        }
+
+        /**
+         * Disable Nagle's Algorithm.
+         *
+         * @return
+         */
+        public Builder disableNagleAlgorithm() {
+            configurator = configurator.andThen(DISABLE_NAGLE_ALGORITHM);
+            return this;
+        }
+
+        /**
+         * Enable server hostname verification for TLS connections.
+         *
+         * @return
+         */
+        public Builder enableHostnameVerification() {
+            configurator = configurator.andThen(ENABLE_HOSTNAME_VERIFICATION);
+            return this;
+        }
+
+        /**
+         * Add an extra configuration step.
+         *
+         * @param extraConfiguration
+         * @return
+         */
+        public Builder add(SocketConfigurator extraConfiguration) {
+            configurator = configurator.andThen(extraConfiguration);
+            return this;
+        }
+
+        /**
+         * Return the configured {@link SocketConfigurator}.
+         *
+         * @return
+         */
+        public SocketConfigurator build() {
+            return configurator;
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/client/SocketConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SocketConfigurators.java
@@ -48,6 +48,8 @@ public abstract class SocketConfigurators {
 
     /**
      * Enable server hostname validation for TLS connections.
+     * <p>
+     * Requires Java 7 or more.
      */
     public static final AbstractSocketConfigurator ENABLE_HOSTNAME_VERIFICATION = new AbstractSocketConfigurator() {
 
@@ -91,6 +93,9 @@ public abstract class SocketConfigurators {
 
     /**
      * {@link SocketConfigurator} that enable server hostname verification for TLS connections.
+     *
+     * <p>
+     * Requires Java 7 or more.
      *
      * @return
      */
@@ -164,6 +169,9 @@ public abstract class SocketConfigurators {
 
         /**
          * Enable server hostname verification for TLS connections.
+         *
+         * <p>
+         * Requires Java 7 or more.
          *
          * @return
          */

--- a/src/main/java/com/rabbitmq/client/SslEngineConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SslEngineConfigurators.java
@@ -1,0 +1,158 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import java.io.IOException;
+
+/**
+ * Ready-to-use instances and builder for {@link SslEngineConfigurator}s.
+ * <p>
+ * Note {@link SslEngineConfigurator}s can be combined with
+ * {@link AbstractSslEngineConfigurator#andThen(SslEngineConfigurator)}.
+ *
+ * @since 4.8.0
+ */
+public abstract class SslEngineConfigurators {
+
+    /**
+     * Default {@link SslEngineConfigurator}, does nothing.
+     */
+    public static AbstractSslEngineConfigurator DEFAULT = new AbstractSslEngineConfigurator() {
+
+        @Override
+        public void configure(SSLEngine sslEngine) {
+        }
+    };
+
+    /**
+     * {@link SslEngineConfigurator} that enables server hostname verification.
+     */
+    public static AbstractSslEngineConfigurator ENABLE_HOSTNAME_VERIFICATION = new AbstractSslEngineConfigurator() {
+
+        @Override
+        public void configure(SSLEngine sslEngine) throws IOException {
+            SSLParameters sslParameters = SocketConfigurators.enableHostnameVerification(sslEngine.getSSLParameters());
+            sslEngine.setSSLParameters(sslParameters);
+        }
+    };
+
+    /**
+     * Default {@link SslEngineConfigurator}, does nothing.
+     *
+     * @return
+     */
+    public static AbstractSslEngineConfigurator defaultConfigurator() {
+        return DEFAULT;
+    }
+
+    /**
+     * {@link SslEngineConfigurator} that enables server hostname verification.
+     *
+     * @return
+     */
+    public static AbstractSslEngineConfigurator enableHostnameVerification() {
+        return ENABLE_HOSTNAME_VERIFICATION;
+    }
+
+    /**
+     * Builder to configure and creates a {@link SslEngineConfigurator} instance.
+     *
+     * @return
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static abstract class AbstractSslEngineConfigurator implements SslEngineConfigurator {
+
+
+        /**
+         * Returns a composed configurator that performs, in sequence, this
+         * operation followed by the {@code after} operation.
+         *
+         * @param after the operation to perform after this operation
+         * @return a composed configurator that performs in sequence this
+         * operation followed by the {@code after} operation
+         * @throws NullPointerException if {@code after} is null
+         */
+        public AbstractSslEngineConfigurator andThen(final SslEngineConfigurator after) {
+            if (after == null) {
+                throw new NullPointerException();
+            }
+            return new AbstractSslEngineConfigurator() {
+
+                @Override
+                public void configure(SSLEngine t) throws IOException {
+                    AbstractSslEngineConfigurator.this.configure(t);
+                    after.configure(t);
+                }
+            };
+        }
+
+    }
+
+    public static class Builder {
+
+        private AbstractSslEngineConfigurator configurator = new AbstractSslEngineConfigurator() {
+
+            @Override
+            public void configure(SSLEngine channel) {
+            }
+        };
+
+        /**
+         * Set default configuration (no op).
+         *
+         * @return
+         */
+        public Builder defaultConfigurator() {
+            configurator = configurator.andThen(DEFAULT);
+            return this;
+        }
+
+        /**
+         * Enables server hostname verification.
+         *
+         * @return
+         */
+        public Builder enableHostnameVerification() {
+            configurator = configurator.andThen(ENABLE_HOSTNAME_VERIFICATION);
+            return this;
+        }
+
+        /**
+         * Add extra configuration step.
+         *
+         * @param extraConfiguration
+         * @return
+         */
+        public Builder add(SslEngineConfigurator extraConfiguration) {
+            configurator = configurator.andThen(extraConfiguration);
+            return this;
+        }
+
+        /**
+         * Return the configured {@link SslEngineConfigurator}.
+         *
+         * @return
+         */
+        public SslEngineConfigurator build() {
+            return configurator;
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/client/SslEngineConfigurators.java
+++ b/src/main/java/com/rabbitmq/client/SslEngineConfigurators.java
@@ -41,6 +41,10 @@ public abstract class SslEngineConfigurators {
 
     /**
      * {@link SslEngineConfigurator} that enables server hostname verification.
+     *
+     * <p>
+     * Requires Java 7 or more.
+     *
      */
     public static AbstractSslEngineConfigurator ENABLE_HOSTNAME_VERIFICATION = new AbstractSslEngineConfigurator() {
 
@@ -62,6 +66,9 @@ public abstract class SslEngineConfigurators {
 
     /**
      * {@link SslEngineConfigurator} that enables server hostname verification.
+     *
+     * <p>
+     * Requires Java 7 or more.
      *
      * @return
      */
@@ -127,6 +134,9 @@ public abstract class SslEngineConfigurators {
 
         /**
          * Enables server hostname verification.
+         *
+         * <p>
+         * Requires Java 7 or more.
          *
          * @return
          */

--- a/src/main/java/com/rabbitmq/client/impl/AbstractFrameHandlerFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/AbstractFrameHandlerFactory.java
@@ -1,6 +1,10 @@
 package com.rabbitmq.client.impl;
 
+import com.rabbitmq.client.ConnectionContext;
+import com.rabbitmq.client.ConnectionPostProcessor;
 import com.rabbitmq.client.SocketConfigurator;
+
+import java.io.IOException;
 
 /**
  *
@@ -10,10 +14,18 @@ public abstract class AbstractFrameHandlerFactory implements FrameHandlerFactory
     protected final int connectionTimeout;
     protected final SocketConfigurator configurator;
     protected final boolean ssl;
+    protected final ConnectionPostProcessor connectionPostProcessor;
 
-    protected AbstractFrameHandlerFactory(int connectionTimeout, SocketConfigurator configurator, boolean ssl) {
+    protected AbstractFrameHandlerFactory(int connectionTimeout, SocketConfigurator configurator, boolean ssl, ConnectionPostProcessor connectionPostProcessor) {
         this.connectionTimeout = connectionTimeout;
         this.configurator = configurator;
         this.ssl = ssl;
+        this.connectionPostProcessor = connectionPostProcessor == null ? new ConnectionPostProcessor() {
+
+            @Override
+            public void postProcess(ConnectionContext context) {
+
+            }
+        } : connectionPostProcessor;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/SocketFrameHandlerFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/SocketFrameHandlerFactory.java
@@ -16,7 +16,9 @@
 package com.rabbitmq.client.impl;
 
 import com.rabbitmq.client.Address;
+import com.rabbitmq.client.ConnectionContext;
 import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.ConnectionPostProcessor;
 import com.rabbitmq.client.SocketConfigurator;
 
 import javax.net.SocketFactory;
@@ -35,7 +37,12 @@ public class SocketFrameHandlerFactory extends AbstractFrameHandlerFactory {
     }
 
     public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory factory, SocketConfigurator configurator, boolean ssl, ExecutorService shutdownExecutor) {
-        super(connectionTimeout, configurator, ssl);
+        this(connectionTimeout, factory, configurator, ssl, shutdownExecutor, null);
+    }
+
+    public SocketFrameHandlerFactory(int connectionTimeout, SocketFactory factory, SocketConfigurator configurator,
+            boolean ssl, ExecutorService shutdownExecutor, ConnectionPostProcessor connectionPostProcessor) {
+        super(connectionTimeout, configurator, ssl, connectionPostProcessor);
         this.factory = factory;
         this.shutdownExecutor = shutdownExecutor;
     }
@@ -49,6 +56,11 @@ public class SocketFrameHandlerFactory extends AbstractFrameHandlerFactory {
             configurator.configure(socket);
             socket.connect(new InetSocketAddress(hostName, portNumber),
                     connectionTimeout);
+
+            this.connectionPostProcessor.postProcess(new ConnectionContext(
+                socket, addr,
+                ssl, null
+            ));
             return create(socket);
         } catch (IOException ioe) {
             quietTrySocketClose(socket);

--- a/src/main/java/com/rabbitmq/client/impl/nio/NioParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/nio/NioParams.java
@@ -15,14 +15,17 @@
 
 package com.rabbitmq.client.impl.nio;
 
-import com.rabbitmq.client.DefaultSocketChannelConfigurator;
 import com.rabbitmq.client.SocketChannelConfigurator;
+import com.rabbitmq.client.SocketChannelConfigurators;
 import com.rabbitmq.client.SslEngineConfigurator;
+import com.rabbitmq.client.SslEngineConfigurators;
 
 import javax.net.ssl.SSLEngine;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
+
+import static com.rabbitmq.client.SslEngineConfigurators.ENABLE_HOSTNAME_VERIFICATION;
 
 /**
  * Parameters used to configure the NIO mode of a {@link com.rabbitmq.client.ConnectionFactory}.
@@ -69,7 +72,7 @@ public class NioParams {
     /**
      * the hook to configure the socket channel before it's open
      */
-    private SocketChannelConfigurator socketChannelConfigurator = new DefaultSocketChannelConfigurator();
+    private SocketChannelConfigurator socketChannelConfigurator = SocketChannelConfigurators.defaultConfigurator();
 
     /**
      * the hook to configure the SSL engine before the connection is open
@@ -99,8 +102,28 @@ public class NioParams {
         setWriteQueueCapacity(nioParams.getWriteQueueCapacity());
         setNioExecutor(nioParams.getNioExecutor());
         setThreadFactory(nioParams.getThreadFactory());
+        setSocketChannelConfigurator(nioParams.getSocketChannelConfigurator());
         setSslEngineConfigurator(nioParams.getSslEngineConfigurator());
         setConnectionShutdownExecutor(nioParams.getConnectionShutdownExecutor());
+    }
+
+    /**
+     * Enable server hostname verification for TLS connections.
+     *
+     * @return this {@link NioParams} instance
+     * @see NioParams#setSslEngineConfigurator(SslEngineConfigurator)
+     * @see com.rabbitmq.client.SslEngineConfigurators#ENABLE_HOSTNAME_VERIFICATION
+     */
+    public NioParams enableHostnameVerification() {
+        if (this.sslEngineConfigurator == null) {
+            this.sslEngineConfigurator = ENABLE_HOSTNAME_VERIFICATION;
+        } else {
+            this.sslEngineConfigurator = SslEngineConfigurators.builder()
+                .add(this.sslEngineConfigurator)
+                .enableHostnameVerification()
+                .build();
+        }
+        return this;
     }
 
     public int getReadByteBufferSize() {

--- a/src/main/java/com/rabbitmq/tools/jsonrpc/DefaultJsonRpcMapper.java
+++ b/src/main/java/com/rabbitmq/tools/jsonrpc/DefaultJsonRpcMapper.java
@@ -31,7 +31,7 @@ import java.util.Map;
  *
  * @see JsonRpcMapper
  * @see JacksonJsonRpcMapper
- * @since 5.4.0
+ * @since 4.8.0
  * @deprecated use {@link JacksonJsonRpcMapper} instead
  */
 public class DefaultJsonRpcMapper implements JsonRpcMapper {

--- a/src/main/java/com/rabbitmq/tools/jsonrpc/JacksonJsonRpcMapper.java
+++ b/src/main/java/com/rabbitmq/tools/jsonrpc/JacksonJsonRpcMapper.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * Uses the streaming and databind modules.
  *
  * @see JsonRpcMapper
- * @since 5.4.0
+ * @since 4.8.0
  */
 public class JacksonJsonRpcMapper implements JsonRpcMapper {
 
@@ -137,6 +137,7 @@ public class JacksonJsonRpcMapper implements JsonRpcMapper {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public JsonRpcResponse parse(String responseBody, Class<?> expectedReturnType) {
         JsonFactory jsonFactory = new MappingJsonFactory();
         Object result = null;

--- a/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcMapper.java
+++ b/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcMapper.java
@@ -19,7 +19,7 @@ package com.rabbitmq.tools.jsonrpc;
  * Abstraction to handle JSON parsing and generation.
  * Used by {@link JsonRpcServer} and {@link JsonRpcClient}.
  *
- * @since 5.4.0
+ * @since 4.8.0
  */
 public interface JsonRpcMapper {
 

--- a/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcMappingException.java
+++ b/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcMappingException.java
@@ -17,7 +17,7 @@ package com.rabbitmq.tools.jsonrpc;
 
 /**
  *
- * @since 5.4.0
+ * @since 4.8.0
  */
 public class JsonRpcMappingException extends RuntimeException {
 

--- a/src/test/java/com/rabbitmq/client/test/BrokerTestCase.java
+++ b/src/test/java/com/rabbitmq/client/test/BrokerTestCase.java
@@ -352,18 +352,6 @@ public class BrokerTestCase {
     }
 
     protected SSLContext getSSLContext() throws NoSuchAlgorithmException {
-        SSLContext c = null;
-
-        // pick the first protocol available, preferring TLSv1.2, then TLSv1,
-        // falling back to SSLv3 if running on an ancient/crippled JDK
-        for(String proto : Arrays.asList("TLSv1.2", "TLSv1", "SSLv3")) {
-            try {
-                c = SSLContext.getInstance(proto);
-                return c;
-            } catch (NoSuchAlgorithmException x) {
-                // keep trying
-            }
-        }
-        throw new NoSuchAlgorithmException();
+        return TestUtils.getSSLContext();
     }
 }

--- a/src/test/java/com/rabbitmq/client/test/ChannelRpcTimeoutIntegrationTest.java
+++ b/src/test/java/com/rabbitmq/client/test/ChannelRpcTimeoutIntegrationTest.java
@@ -84,7 +84,7 @@ public class ChannelRpcTimeoutIntegrationTest {
 
     private FrameHandler createFrameHandler() throws IOException {
         SocketFrameHandlerFactory socketFrameHandlerFactory = new SocketFrameHandlerFactory(ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT,
-            SocketFactory.getDefault(), new DefaultSocketConfigurator(), false, null);
+            SocketFactory.getDefault(), SocketConfigurators.defaultConfigurator(), false, null);
         return socketFrameHandlerFactory.create(new Address("localhost"));
     }
 

--- a/src/test/java/com/rabbitmq/client/test/TestUtils.java
+++ b/src/test/java/com/rabbitmq/client/test/TestUtils.java
@@ -30,7 +30,10 @@ import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 import com.rabbitmq.tools.Host;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.Callable;
@@ -62,6 +65,22 @@ public class TestUtils {
                 throw new RuntimeException(e);
             }
         }
+    }
+
+    public static SSLContext getSSLContext() throws NoSuchAlgorithmException {
+        SSLContext c = null;
+
+        // pick the first protocol available, preferring TLSv1.2, then TLSv1,
+        // falling back to SSLv3 if running on an ancient/crippled JDK
+        for(String proto : Arrays.asList("TLSv1.2", "TLSv1", "SSLv3")) {
+            try {
+                c = SSLContext.getInstance(proto);
+                return c;
+            } catch (NoSuchAlgorithmException x) {
+                // keep trying
+            }
+        }
+        throw new NoSuchAlgorithmException();
     }
 
     public static boolean isVersion37orLater(Connection connection) {

--- a/src/test/java/com/rabbitmq/client/test/functional/UnexpectedFrames.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/UnexpectedFrames.java
@@ -18,6 +18,7 @@ package com.rabbitmq.client.test.functional;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultSocketConfigurator;
+import com.rabbitmq.client.SocketConfigurators;
 import com.rabbitmq.client.impl.*;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 import com.rabbitmq.client.test.BrokerTestCase;
@@ -85,7 +86,7 @@ public class UnexpectedFrames extends BrokerTestCase {
 
     private static class ConfusedFrameHandlerFactory extends SocketFrameHandlerFactory {
         private ConfusedFrameHandlerFactory() {
-            super(1000, SocketFactory.getDefault(), new DefaultSocketConfigurator(), false);
+            super(1000, SocketFactory.getDefault(), SocketConfigurators.defaultConfigurator(), false);
         }
 
         @Override public FrameHandler create(Socket sock) throws IOException {

--- a/src/test/java/com/rabbitmq/client/test/ssl/HostnameVerification.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/HostnameVerification.java
@@ -18,94 +18,173 @@ package com.rabbitmq.client.test.ssl;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.AddressResolver;
 import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.ConnectionPostProcessors;
 import com.rabbitmq.client.test.TestUtils;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.bouncycastle.est.jcajce.JsseDefaultHostnameAuthorizer;
+import org.bouncycastle.est.jcajce.JsseHostnameAuthorizer;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.security.KeyManagementException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 
+import static com.rabbitmq.client.test.TestUtils.getSSLContext;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-public class HostnameVerification extends UnverifiedConnection {
+@RunWith(Parameterized.class)
+public class HostnameVerification {
 
-    public void openConnection()
-        throws IOException, TimeoutException {
-        try {
-            String keystorePath = System.getProperty("test-keystore.ca");
-            assertNotNull(keystorePath);
-            String keystorePasswd = System.getProperty("test-keystore.password");
-            assertNotNull(keystorePasswd);
-            char[] keystorePassword = keystorePasswd.toCharArray();
+    static SSLContext sslContext;
+    @Parameterized.Parameter
+    public ConnectionFactoryCustomizer customizer;
 
-            KeyStore tks = KeyStore.getInstance("JKS");
-            tks.load(new FileInputStream(keystorePath), keystorePassword);
+    @Parameterized.Parameters
+    public static Object[] data() {
+        return new Object[] {
+            blockingIo(enableOnConnectionFactory()), nio(enableOnConnectionFactory()),
+            blockingIo(useCommonsHttpHostnameVerifierInConnectionPostProcessor()), nio(useCommonsHttpHostnameVerifierInConnectionPostProcessor()),
+            blockingIo(useCommonsHttpHostnameVerifierOnConnectionFactory()), nio(useCommonsHttpHostnameVerifierOnConnectionFactory()),
+            blockingIo(bouncyCastleHostnameVerifierAdapter()), nio(bouncyCastleHostnameVerifierAdapter())
+        };
+    }
 
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
-            tmf.init(tks);
+    private static ConnectionFactoryCustomizer blockingIo(final ConnectionFactoryCustomizer customizer) {
+        return new ConnectionFactoryCustomizer() {
 
-            String p12Path = System.getProperty("test-client-cert.path");
-            assertNotNull(p12Path);
-            String p12Passwd = System.getProperty("test-client-cert.password");
-            assertNotNull(p12Passwd);
-            KeyStore ks = KeyStore.getInstance("PKCS12");
-            char[] p12Password = p12Passwd.toCharArray();
-            ks.load(new FileInputStream(p12Path), p12Password);
+            @Override
+            public void customize(ConnectionFactory connectionFactory) {
+                connectionFactory.useBlockingIo();
+                customizer.customize(connectionFactory);
+            }
+        };
+    }
 
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-            kmf.init(ks, p12Password);
+    private static ConnectionFactoryCustomizer nio(final ConnectionFactoryCustomizer customizer) {
+        return new ConnectionFactoryCustomizer() {
 
-            SSLContext c = getSSLContext();
-            c.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
-            c.init(null, tmf.getTrustManagers(), null);
+            @Override
+            public void customize(ConnectionFactory connectionFactory) {
+                connectionFactory.useNio();
+                customizer.customize(connectionFactory);
+            }
+        };
+    }
 
-            connectionFactory = TestUtils.connectionFactory();
-            connectionFactory.useSslProtocol(c);
-            connectionFactory.enableHostnameVerification();
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IOException(ex.toString());
-        } catch (KeyManagementException ex) {
-            throw new IOException(ex.toString());
-        } catch (KeyStoreException ex) {
-            throw new IOException(ex.toString());
-        } catch (CertificateException ex) {
-            throw new IOException(ex.toString());
-        } catch (UnrecoverableKeyException ex) {
-            throw new IOException(ex.toString());
-        }
+    // a simple adapter for Bouncy Castle
+    private static ConnectionFactoryCustomizer bouncyCastleHostnameVerifierAdapter() {
+        return new ConnectionFactoryCustomizer() {
 
-        try {
-            connection = connectionFactory.newConnection(
-                new AddressResolver() {
+            @Override
+            public void customize(ConnectionFactory connectionFactory) {
+                final JsseHostnameAuthorizer hostnameAuthorizer = new JsseDefaultHostnameAuthorizer(Collections.EMPTY_SET);
+                connectionFactory.enableHostnameVerification(new HostnameVerifier() {
+
                     @Override
-                    public List<Address> getAddresses() throws IOException {
-                        return singletonList(new Address("127.0.0.1", ConnectionFactory.DEFAULT_AMQP_OVER_SSL_PORT));
+                    public boolean verify(String hostname, SSLSession sslSession) {
+                        try {
+                            return hostnameAuthorizer.verified(hostname, sslSession);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
                     }
                 });
-            fail("The server certificate isn't issued for 127.0.0.1, the TLS handshake should have failed");
-        } catch (SSLHandshakeException ignored) {
-        } catch (IOException e) {
-            fail();
-        }
+            }
+        };
     }
 
-    public void openChannel() {
+    private static ConnectionFactoryCustomizer useCommonsHttpHostnameVerifierOnConnectionFactory() {
+        return new ConnectionFactoryCustomizer() {
+
+            @Override
+            public void customize(ConnectionFactory connectionFactory) {
+                connectionFactory.enableHostnameVerification(new DefaultHostnameVerifier());
+            }
+        };
     }
 
-    @Test
-    public void sSL() {
+    private static ConnectionFactoryCustomizer useCommonsHttpHostnameVerifierInConnectionPostProcessor() {
+        return new ConnectionFactoryCustomizer() {
+
+            @Override
+            public void customize(ConnectionFactory connectionFactory) {
+                connectionFactory.setConnectionPostProcessor(ConnectionPostProcessors.builder()
+                    .enableHostnameVerification(new DefaultHostnameVerifier())
+                    .build());
+            }
+        };
+    }
+
+    private static ConnectionFactoryCustomizer enableOnConnectionFactory() {
+        return new ConnectionFactoryCustomizer() {
+
+            @Override
+            public void customize(ConnectionFactory connectionFactory) {
+                connectionFactory.enableHostnameVerification();
+            }
+        };
+    }
+
+    @BeforeClass
+    public static void initCrypto() throws Exception {
+        String keystorePath = System.getProperty("test-keystore.ca");
+        assertNotNull(keystorePath);
+        String keystorePasswd = System.getProperty("test-keystore.password");
+        assertNotNull(keystorePasswd);
+        char[] keystorePassword = keystorePasswd.toCharArray();
+
+        KeyStore tks = KeyStore.getInstance("JKS");
+        tks.load(new FileInputStream(keystorePath), keystorePassword);
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+        tmf.init(tks);
+
+        String p12Path = System.getProperty("test-client-cert.path");
+        assertNotNull(p12Path);
+        String p12Passwd = System.getProperty("test-client-cert.password");
+        assertNotNull(p12Passwd);
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        char[] p12Password = p12Passwd.toCharArray();
+        ks.load(new FileInputStream(p12Path), p12Password);
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, p12Password);
+
+        sslContext = getSSLContext();
+        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+    }
+
+    @Test(expected = SSLHandshakeException.class)
+    public void hostnameVerificationFailsBecauseCertificateNotIssuedForLoopbackInterface() throws Exception {
+        ConnectionFactory connectionFactory = TestUtils.connectionFactory();
+        connectionFactory.useSslProtocol(sslContext);
+        customizer.customize(connectionFactory);
+        connectionFactory.newConnection(
+            new AddressResolver() {
+
+                @Override
+                public List<Address> getAddresses() {
+                    return singletonList(new Address("127.0.0.1", ConnectionFactory.DEFAULT_AMQP_OVER_SSL_PORT));
+                }
+            });
+        fail("The server certificate isn't issued for 127.0.0.1, the TLS handshake should have failed");
+    }
+
+    interface ConnectionFactoryCustomizer {
+
+        void customize(ConnectionFactory connectionFactory);
     }
 }

--- a/src/test/java/com/rabbitmq/client/test/ssl/NioTlsUnverifiedConnection.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/NioTlsUnverifiedConnection.java
@@ -83,6 +83,7 @@ public class NioTlsUnverifiedConnection extends BrokerTestCase {
         NioParams nioParams = new NioParams();
         final AtomicBoolean sslEngineHasBeenCalled = new AtomicBoolean(false);
         nioParams.setSslEngineConfigurator(new SslEngineConfigurator() {
+
             @Override
             public void configure(SSLEngine sslEngine) throws IOException {
                 sslEngineHasBeenCalled.set(true);

--- a/src/test/java/com/rabbitmq/client/test/ssl/SSLTests.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/SSLTests.java
@@ -32,7 +32,8 @@ import java.util.List;
 	VerifiedConnection.class,
 	BadVerifiedConnection.class,
 	ConnectionFactoryDefaultTlsVersion.class,
-	NioTlsUnverifiedConnection.class
+	NioTlsUnverifiedConnection.class,
+	HostnameVerification.class
 })
 public class SSLTests {
 

--- a/src/test/java/com/rabbitmq/client/test/ssl/UnverifiedConnection.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/UnverifiedConnection.java
@@ -54,7 +54,7 @@ public class UnverifiedConnection extends BrokerTestCase {
             }
         }
         if(connection == null) {
-            fail("Couldn't open TLS connection after 3 attemps");
+            fail("Couldn't open TLS connection after 3 attempts");
         }
     }
 


### PR DESCRIPTION
This PR is a backport of #398 to 4.x.x. It also adds support for TLS hostname verification with `HostnameVerifier` (for Java 6).