### PR TITLE
Fix warnings in ClientVersion when amqp-client is relocated

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/ClientVersion.java
+++ b/src/main/java/com/rabbitmq/client/impl/ClientVersion.java
@@ -28,6 +28,11 @@ public class ClientVersion {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClientVersion.class);
 
+    // We store the version property in an unusual way because relocating the package can rewrite the key in the property
+    // file, which results in spurious warnings being emitted at start-up.
+    private static final char[] VERSION_PROPERTY = new char[] {'c', 'o', 'm', '.', 'r', 'a', 'b', 'b', 'i', 't', 'm', 'q', '.',
+            'c', 'l', 'i', 'e', 'n', 't', '.', 'v', 'e', 'r', 's', 'i', 'o', 'n'};
+
     public static final String VERSION;
 
     static {
@@ -56,10 +61,12 @@ public class ClientVersion {
                 inputStream.close();
             }
         }
-        if (version.getProperty("com.rabbitmq.client.version") == null) {
-            throw new IllegalStateException("Coulnd't find version property in property file");
+        String propertyName = new String(VERSION_PROPERTY);
+        String versionProperty = version.getProperty(propertyName);
+        if (versionProperty == null) {
+            throw new IllegalStateException("Couldn't find version property in property file");
         }
-        return version.getProperty("com.rabbitmq.client.version");
+        return versionProperty;
     }
 
     private static final String getVersionFromPackage() {


### PR DESCRIPTION
## Proposed Changes

This pull request fixes spurious warnings emitted by the `com.rabbitmq.client.impl.ClientVersion` class when `amqp-client` is relocated. This problem happens because the key `com.rabbitmq.client.version` is rewritten to use a different prefix by whatever produces the uberjar (`maven-shade-plugin` or Gradle Shadow, for instance), but the `rabbitmq-amqp-client.properties` key is not rewritten.

In order to prevent this rewriting, the property key is now stored in a `char[]` and we create a `String` from it. This is unusual, but required if we want to retain backwards-compatibility. Doing so allows us to defeat the rewriting done during relocation.

This behavior has been broken for a while: prior to bd1d73fc2e, the version returned could be `null`.

This issue fixes #436.

While we're here, I also fixed a typo in the exception message thrown by `getVersionFromPropertyFile()`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #436)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [X] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
