### PR TITLE
Spelling

### DIFF
--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -21,7 +21,7 @@ can control the running node.
 
 `./mvnw verify` will start those nodes with the appropriate configuration.
 
-To easily fullfil all those requirements, you should use `make deps` to
+To easily fulfill all those requirements, you should use `make deps` to
 fetch the dependencies in the `deps` directory.
 
 You then run Maven with the `deps.dir` property set like this:

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -307,7 +307,7 @@ public class ConnectionFactory implements Cloneable {
     /**
      * Convenience method for setting the fields in an AMQP URI: host,
      * port, username, password and virtual host.  If any part of the
-     * URI is ommited, the ConnectionFactory's corresponding variable
+     * URI is omitted, the ConnectionFactory's corresponding variable
      * is left unchanged.
      * @param uri is the AMQP URI containing the data
      */
@@ -366,7 +366,7 @@ public class ConnectionFactory implements Cloneable {
     /**
      * Convenience method for setting the fields in an AMQP URI: host,
      * port, username, password and virtual host.  If any part of the
-     * URI is ommited, the ConnectionFactory's corresponding variable
+     * URI is omitted, the ConnectionFactory's corresponding variable
      * is left unchanged.  Note that not all valid AMQP URIs are
      * accepted; in particular, the hostname must be given if the
      * port, username or password are given, and escapes in the

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -674,7 +674,7 @@ public class ConnectionFactory implements Cloneable {
     public void useSslProtocol()
         throws NoSuchAlgorithmException, KeyManagementException
     {
-        useSslProtocol(computeDefaultTlsProcotol(SSLContext.getDefault().getSupportedSSLParameters().getProtocols()));
+        useSslProtocol(computeDefaultTlsProtocol(SSLContext.getDefault().getSupportedSSLParameters().getProtocols()));
     }
 
     /**
@@ -777,7 +777,7 @@ public class ConnectionFactory implements Cloneable {
         }
     }
 
-    public static String computeDefaultTlsProcotol(String[] supportedProtocols) {
+    public static String computeDefaultTlsProtocol(String[] supportedProtocols) {
         if(supportedProtocols != null) {
             for (String supportedProtocol : supportedProtocols) {
                 if(PREFERRED_TLS_PROTOCOL.equalsIgnoreCase(supportedProtocol)) {

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -851,7 +851,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         SocketCloseWait scw = new SocketCloseWait(sse);
 
         // if shutdown executor is configured, use it. Otherwise
-        // execut socket close monitor the old fashioned way.
+        // execute socket close monitor the old fashioned way.
         // see rabbitmq/rabbitmq-java-client#91
         if(shutdownExecutor != null) {
             shutdownExecutor.execute(scw);

--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -602,7 +602,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
         boolean notify = false;
         try {
             // Synchronize the block below to avoid race conditions in case
-            // connnection wants to send Connection-CloseOK
+            // connection wants to send Connection-CloseOK
             synchronized (_channelMutex) {
                 startProcessShutdownSignal(signal, !initiatedByApplication, true);
                 quiescingRpc(reason, k);

--- a/src/main/java/com/rabbitmq/client/impl/MethodArgumentWriter.java
+++ b/src/main/java/com/rabbitmq/client/impl/MethodArgumentWriter.java
@@ -38,7 +38,7 @@ public class MethodArgumentWriter
     private int bitMask;
 
     /**
-     * Constructs a MethodArgumentWriter targetting the given DataOutputStream.
+     * Constructs a MethodArgumentWriter targeting the given DataOutputStream.
      */
     public MethodArgumentWriter(ValueWriter out)
     {

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -681,7 +681,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
                 recoverEntitiesAsynchronously(executor, Utility.copy(recordedBindings));
                 recoverEntitiesAsynchronously(executor, Utility.copy(consumers).values());
             } catch (final Exception cause) {
-                final String message = "Caught an exception while recovering toplogy: " + cause.getMessage();
+                final String message = "Caught an exception while recovering topology: " + cause.getMessage();
                 final TopologyRecoveryException e = new TopologyRecoveryException(message, cause);
                 getExceptionHandler().handleTopologyRecoveryException(delegate, null, e);
             }

--- a/src/main/java/com/rabbitmq/utility/IntAllocator.java
+++ b/src/main/java/com/rabbitmq/utility/IntAllocator.java
@@ -23,7 +23,7 @@ import java.util.BitSet;
  * {@link BitSet} representation of the free integers.
  * </p>
  *
- * <h2>Concurrecy Semantics:</h2>
+ * <h2>Concurrency Semantics:</h2>
  * This class is <b><i>not</i></b> thread safe.
  *
  * <h2>Implementation notes:</h2>

--- a/src/test/java/com/rabbitmq/client/test/SslContextFactoryTest.java
+++ b/src/test/java/com/rabbitmq/client/test/SslContextFactoryTest.java
@@ -129,7 +129,7 @@ public class SslContextFactoryTest {
     }
 
     private String tlsProtocol() throws NoSuchAlgorithmException {
-        return ConnectionFactory.computeDefaultTlsProcotol(SSLContext.getDefault().getSupportedSSLParameters().getProtocols());
+        return ConnectionFactory.computeDefaultTlsProtocol(SSLContext.getDefault().getSupportedSSLParameters().getProtocols());
     }
 
     private static class TrustNothingTrustManager implements X509TrustManager {

--- a/src/test/java/com/rabbitmq/client/test/functional/AlternateExchange.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/AlternateExchange.java
@@ -96,7 +96,7 @@ public class AlternateExchange extends BrokerTestCase
      *
      * @param name the name of the exchange to be created, and queue
      *        to be bound
-     * @param ae the name of the alternate-exchage
+     * @param ae the name of the alternate-exchange
      */
     protected void setupRouting(String name, String ae) throws IOException {
         Map<String, Object> args = new HashMap<String, Object>();

--- a/src/test/java/com/rabbitmq/client/test/functional/BindingLifecycle.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/BindingLifecycle.java
@@ -49,7 +49,7 @@ public class BindingLifecycle extends BindingLifecycleBase {
         Binding binding = setupExchangeBindings(false);
         channel.basicPublish(binding.x, binding.k, null, payload);
 
-        // Purge the queue, and test that we don't recieve a message
+        // Purge the queue, and test that we don't receive a message
         channel.queuePurge(binding.q);
 
         GetResponse response = channel.basicGet(binding.q, true);

--- a/src/test/java/com/rabbitmq/client/test/functional/BindingLifecycle.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/BindingLifecycle.java
@@ -153,7 +153,7 @@ public class BindingLifecycle extends BindingLifecycleBase {
      * The unsubscribe should cause the queue to auto_delete, which in
      * turn should cause the exchange to auto_delete.
      *
-     * Then re-declare the queue again and try to rebind it to the same exhange.
+     * Then re-declare the queue again and try to rebind it to the same exchange.
      *
      * Because the exchange has been auto-deleted, the bind operation
      * should fail.

--- a/src/test/java/com/rabbitmq/client/test/server/DurableBindingLifecycle.java
+++ b/src/test/java/com/rabbitmq/client/test/server/DurableBindingLifecycle.java
@@ -85,9 +85,9 @@ public class DurableBindingLifecycle extends BindingLifecycleBase {
 
     /**
      * This tests whether the bindings attached to a durable exchange
-     * are correctly blown away when the exhange is nuked.
+     * are correctly blown away when the exchange is nuked.
      *
-     * This complements a unit test for testing non-durable exhanges.
+     * This complements a unit test for testing non-durable exchanges.
      * In that case, an exchange is deleted and you expect any
      * bindings hanging to it to be deleted as well. To verify this,
      * the exchange is deleted and then recreated.

--- a/src/test/java/com/rabbitmq/client/test/ssl/ConnectionFactoryDefaultTlsVersion.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/ConnectionFactoryDefaultTlsVersion.java
@@ -24,19 +24,19 @@ public class ConnectionFactoryDefaultTlsVersion {
 
     @Test public void defaultTlsVersionJdk16ShouldTakeFallback() {
         String [] supportedProtocols = {"SSLv2Hello", "SSLv3", "TLSv1"};
-        String tlsProtocol = ConnectionFactory.computeDefaultTlsProcotol(supportedProtocols);
+        String tlsProtocol = ConnectionFactory.computeDefaultTlsProtocol(supportedProtocols);
         Assert.assertEquals("TLSv1",tlsProtocol);
     }
 
     @Test public void defaultTlsVersionJdk17ShouldTakePrefered() {
         String [] supportedProtocols = {"SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
-        String tlsProtocol = ConnectionFactory.computeDefaultTlsProcotol(supportedProtocols);
+        String tlsProtocol = ConnectionFactory.computeDefaultTlsProtocol(supportedProtocols);
         Assert.assertEquals("TLSv1.2",tlsProtocol);
     }
 
     @Test public void defaultTlsVersionJdk18ShouldTakePrefered() {
         String [] supportedProtocols = {"SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
-        String tlsProtocol = ConnectionFactory.computeDefaultTlsProcotol(supportedProtocols);
+        String tlsProtocol = ConnectionFactory.computeDefaultTlsProtocol(supportedProtocols);
         Assert.assertEquals("TLSv1.2",tlsProtocol);
     }
 


### PR DESCRIPTION
## Proposed Changes

Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`

There are a number of benefits of using correct spelling, one is that it makes it easier to read, another is that it makes it easier to search/cross reference, another is that it reduces ambiguity/confusion.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I'm not claiming to be an erlang expert/user (we're investigating using RabbitMQ for a system, and I like to test the waters of projects to get a sense of how healthy they are with small changes). I haven't yet set up an erlang environment. So I haven't run the tests yet (I can, and understand that the contribution guide encourages me to do so).