### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
 
@@ -10,22 +10,22 @@
 
  <name>RabbitMQ Java Client</name>
  <description>RabbitMQ Java client</description>
- <url>http://www.rabbitmq.com</url>
+ <url>https://www.rabbitmq.com</url>
 
  <licenses>
   <license>
    <name>ASL 2.0</name>
-   <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+   <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
    <distribution>repo</distribution>
   </license>
   <license>
    <name>GPL v2</name>
-   <url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
+   <url>https://www.gnu.org/licenses/gpl-2.0.txt</url>
    <distribution>repo</distribution>
   </license>
   <license>
    <name>MPL 1.1</name>
-   <url>http://www.mozilla.org/MPL/MPL-1.1.txt</url>
+   <url>https://www.mozilla.org/MPL/MPL-1.1.txt</url>
    <distribution>repo</distribution>
   </license>
  </licenses>
@@ -270,7 +270,7 @@
   <repository>
    <id>sonatype-nexus-staging</id>
    <name>Nexus Release Repository</name>
-   <url>http://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+   <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
   </repository>
  </distributionManagement>
 </project>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://oss.sonatype.org/service/local/staging/deploy/maven2/ (301) with 1 occurrences migrated to:  
  https://oss.sonatype.org/service/local/staging/deploy/maven2/ ([https](https://oss.sonatype.org/service/local/staging/deploy/maven2/) result 401).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.html with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.html ([https](https://www.apache.org/licenses/LICENSE-2.0.html) result 200).
* http://www.gnu.org/licenses/gpl-2.0.txt with 1 occurrences migrated to:  
  https://www.gnu.org/licenses/gpl-2.0.txt ([https](https://www.gnu.org/licenses/gpl-2.0.txt) result 200).
* http://www.rabbitmq.com with 1 occurrences migrated to:  
  https://www.rabbitmq.com ([https](https://www.rabbitmq.com) result 200).
* http://www.mozilla.org/MPL/MPL-1.1.txt with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/MPL-1.1.txt ([https](https://www.mozilla.org/MPL/MPL-1.1.txt) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences