### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-[Contributor Covenant](http://contributor-covenant.org), version 1.3.0, available at
-[contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/)
+[Contributor Covenant](https://contributor-covenant.org), version 1.3.0, available at
+[contributor-covenant.org/version/1/3/0/](https://contributor-covenant.org/version/1/3/0/)

--- a/LICENSE-MPL-RabbitMQ
+++ b/LICENSE-MPL-RabbitMQ
@@ -437,7 +437,7 @@ EXHIBIT A -Mozilla Public License.
      ``The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
      compliance with the License. You may obtain a copy of the License at
-     http://www.mozilla.org/MPL/
+     https://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on an "AS IS"
      basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/README.in
+++ b/README.in
@@ -1,4 +1,4 @@
-Please see http://www.rabbitmq.com/build-java-client.html for build 
+Please see https://www.rabbitmq.com/build-java-client.html for build 
 instructions.
 
 For your convenience, a text copy of these instructions is available 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # RabbitMQ Java Client
 
-This repository contains source code of the [RabbitMQ Java client](http://www.rabbitmq.com/api-guide.html).
-The client is maintained by the [RabbitMQ team at Pivotal](http://github.com/rabbitmq/).
+This repository contains source code of the [RabbitMQ Java client](https://www.rabbitmq.com/api-guide.html).
+The client is maintained by the [RabbitMQ team at Pivotal](https://github.com/rabbitmq/).
 
 
 ## Dependency (Maven Artifact)
 
-Maven artifacts are [released to Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3Acom.rabbitmq%20a%3Aamqp-client)
+Maven artifacts are [released to Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cg%3Acom.rabbitmq%20a%3Aamqp-client)
 via [RabbitMQ Maven repository on Bintray](https://bintray.com/rabbitmq/maven). There's also
 a [Maven repository with milestone releases](https://bintray.com/rabbitmq/maven-milestones). [Snapshots are available](https://oss.sonatype.org/content/repositories/snapshots/com/rabbitmq/amqp-client/) as well.
 

--- a/doc/channels/worktransition.graffle
+++ b/doc/channels/worktransition.graffle
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>ActiveLayerIndex</key>

--- a/src/main/java/com/rabbitmq/client/Channel.java
+++ b/src/main/java/com/rabbitmq/client/Channel.java
@@ -32,11 +32,11 @@ import com.rabbitmq.client.AMQP.Confirm;
  * this interface are part of the public API.
  *
  * <h2>Tutorials</h2>
- * <a href="http://www.rabbitmq.com/getstarted.html">RabbitMQ tutorials</a> demonstrate how
+ * <a href="https://www.rabbitmq.com/getstarted.html">RabbitMQ tutorials</a> demonstrate how
  * key methods of this interface are used.
  *
  * <h2>User Guide</h2>
- * See <a href="http://www.rabbitmq.com/api-guide.html">Java Client User Guide</a>.
+ * See <a href="https://www.rabbitmq.com/api-guide.html">Java Client User Guide</a>.
  *
  * <h2>Concurrency Considerations</h2>
  * <p>
@@ -47,13 +47,13 @@ import com.rabbitmq.client.AMQP.Confirm;
  * multiple threads. While some operations on channels are safe to invoke
  * concurrently, some are not and will result in incorrect frame interleaving
  * on the wire. Sharing channels between threads will also interfere with
- * <a href="http://www.rabbitmq.com/confirms.html">Publisher Confirms</a>.
+ * <a href="https://www.rabbitmq.com/confirms.html">Publisher Confirms</a>.
  *
  * As such, applications need to use a {@link Channel} per thread.
  * </p>
  *
- * @see <a href="http://www.rabbitmq.com/getstarted.html">RabbitMQ tutorials</a>
- * @see <a href="http://www.rabbitmq.com/api-guide.html">RabbitMQ Java Client User Guide</a>
+ * @see <a href="https://www.rabbitmq.com/getstarted.html">RabbitMQ tutorials</a>
+ * @see <a href="https://www.rabbitmq.com/api-guide.html">RabbitMQ Java Client User Guide</a>
  */
 public interface Channel extends ShutdownNotifier, AutoCloseable {
     /**
@@ -243,10 +243,10 @@ public interface Channel extends ShutdownNotifier, AutoCloseable {
      * protocol exception, which closes the channel.
      *
      * Invocations of <code>Channel#basicPublish</code> will eventually block if a
-     * <a href="http://www.rabbitmq.com/alarms.html">resource-driven alarm</a> is in effect.
+     * <a href="https://www.rabbitmq.com/alarms.html">resource-driven alarm</a> is in effect.
      *
      * @see com.rabbitmq.client.AMQP.Basic.Publish
-     * @see <a href="http://www.rabbitmq.com/alarms.html">Resource-driven alarms</a>
+     * @see <a href="https://www.rabbitmq.com/alarms.html">Resource-driven alarms</a>
      * @param exchange the exchange to publish the message to
      * @param routingKey the routing key
      * @param props other properties for the message - routing headers etc
@@ -259,10 +259,10 @@ public interface Channel extends ShutdownNotifier, AutoCloseable {
      * Publish a message.
      *
      * Invocations of <code>Channel#basicPublish</code> will eventually block if a
-     * <a href="http://www.rabbitmq.com/alarms.html">resource-driven alarm</a> is in effect.
+     * <a href="https://www.rabbitmq.com/alarms.html">resource-driven alarm</a> is in effect.
      *
      * @see com.rabbitmq.client.AMQP.Basic.Publish
-     * @see <a href="http://www.rabbitmq.com/alarms.html">Resource-driven alarms</a>
+     * @see <a href="https://www.rabbitmq.com/alarms.html">Resource-driven alarms</a>
      * @param exchange the exchange to publish the message to
      * @param routingKey the routing key
      * @param mandatory true if the 'mandatory' flag is to be set
@@ -280,10 +280,10 @@ public interface Channel extends ShutdownNotifier, AutoCloseable {
      * protocol exception, which closes the channel.
      *
      * Invocations of <code>Channel#basicPublish</code> will eventually block if a
-     * <a href="http://www.rabbitmq.com/alarms.html">resource-driven alarm</a> is in effect.
+     * <a href="https://www.rabbitmq.com/alarms.html">resource-driven alarm</a> is in effect.
      *
      * @see com.rabbitmq.client.AMQP.Basic.Publish
-     * @see <a href="http://www.rabbitmq.com/alarms.html">Resource-driven alarms</a>
+     * @see <a href="https://www.rabbitmq.com/alarms.html">Resource-driven alarms</a>
      * @param exchange the exchange to publish the message to
      * @param routingKey the routing key
      * @param mandatory true if the 'mandatory' flag is to be set

--- a/src/main/java/com/rabbitmq/client/Connection.java
+++ b/src/main/java/com/rabbitmq/client/Connection.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 /**
- * Public API: Interface to an AMQ connection. See the see the <a href="http://www.amqp.org/">spec</a> for details.
+ * Public API: Interface to an AMQ connection. See the see the <a href="https://www.amqp.org/">spec</a> for details.
  * <p>
  * To connect to a broker, fill in a {@link ConnectionFactory} and use a {@link ConnectionFactory} as follows:
  *
@@ -116,7 +116,7 @@ public interface Connection extends ShutdownNotifier, Closeable { // rename to A
 
     /**
      * Create a new channel, using an internally allocated channel number.
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the channel returned by this method will be {@link Recoverable}.
      * <p>
      * Use {@link #openChannel()} if you want to use an {@link Optional} to deal
@@ -143,7 +143,7 @@ public interface Connection extends ShutdownNotifier, Closeable { // rename to A
      * Create a new channel wrapped in an {@link Optional}.
      * The channel number is allocated internally.
      * <p>
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the channel returned by this method will be {@link Recoverable}.
      * <p>
      * Use {@link #createChannel()} to return directly a {@link Channel} or {@code null}.

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -493,7 +493,7 @@ public class ConnectionFactory implements Cloneable {
      * If server heartbeat timeout is configured to a non-zero value, this method can only be used
      * to lower the value; otherwise any value provided by the client will be used.
      * @param requestedHeartbeat the initially requested heartbeat timeout, in seconds; zero for none
-     * @see <a href="http://rabbitmq.com/heartbeats.html">RabbitMQ Heartbeats Guide</a>
+     * @see <a href="https://rabbitmq.com/heartbeats.html">RabbitMQ Heartbeats Guide</a>
      */
     public void setRequestedHeartbeat(int requestedHeartbeat) {
         this.requestedHeartbeat = requestedHeartbeat;
@@ -789,19 +789,19 @@ public class ConnectionFactory implements Cloneable {
     }
 
     /**
-     * Returns true if <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * Returns true if <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, false otherwise
      * @return true if automatic connection recovery is enabled, false otherwise
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public boolean isAutomaticRecoveryEnabled() {
         return automaticRecovery;
     }
 
     /**
-     * Enables or disables <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>.
+     * Enables or disables <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>.
      * @param automaticRecovery if true, enables connection recovery
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public void setAutomaticRecoveryEnabled(boolean automaticRecovery) {
         this.automaticRecovery = automaticRecovery;
@@ -810,7 +810,7 @@ public class ConnectionFactory implements Cloneable {
     /**
      * Returns true if topology recovery is enabled, false otherwise
      * @return true if topology recovery is enabled, false otherwise
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public boolean isTopologyRecoveryEnabled() {
         return topologyRecovery;
@@ -819,7 +819,7 @@ public class ConnectionFactory implements Cloneable {
     /**
      * Enables or disables topology recovery
      * @param topologyRecovery if true, enables topology recovery
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public void setTopologyRecoveryEnabled(boolean topologyRecovery) {
         this.topologyRecovery = topologyRecovery;
@@ -873,7 +873,7 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection, picking the first available address from
      * the list.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address from the provided list.
      *
@@ -889,14 +889,14 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection, picking the first available address from
      * the list provided by the {@link AddressResolver}.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address provided by the {@link AddressResolver}.
      *
      * @param addressResolver discovery service to list potential addresses (hostname/port pairs) to connect to
      * @return an interface to the connection
      * @throws IOException if it encounters a problem
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public Connection newConnection(AddressResolver addressResolver) throws IOException, TimeoutException {
         return newConnection(this.sharedExecutor, addressResolver, null);
@@ -907,7 +907,7 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection with a client-provided name, picking the first available address from
      * the list.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address from the provided list.
      *
@@ -928,7 +928,7 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection, picking the first available address from
      * the list.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address from the provided list.
      *
@@ -944,7 +944,7 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection with a client-provided name, picking the first available address from
      * the list.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address from the provided list.
      *
@@ -965,7 +965,7 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection, picking the first available address from
      * the list.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address from the provided list.
      *
@@ -973,7 +973,7 @@ public class ConnectionFactory implements Cloneable {
      * @param addrs an array of known broker addresses (hostname/port pairs) to try in order
      * @return an interface to the connection
      * @throws java.io.IOException if it encounters a problem
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public Connection newConnection(ExecutorService executor, Address[] addrs) throws IOException, TimeoutException {
         return newConnection(executor, Arrays.asList(addrs), null);
@@ -984,7 +984,7 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection with a client-provided name, picking the first available address from
      * the list.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address from the provided list.
      *
@@ -997,7 +997,7 @@ public class ConnectionFactory implements Cloneable {
      *                           This value is supposed to be human-readable.
      * @return an interface to the connection
      * @throws java.io.IOException if it encounters a problem
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public Connection newConnection(ExecutorService executor, Address[] addrs, String clientProvidedName) throws IOException, TimeoutException {
         return newConnection(executor, Arrays.asList(addrs), clientProvidedName);
@@ -1007,7 +1007,7 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection, picking the first available address from
      * the list.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address from the provided list.
      *
@@ -1015,7 +1015,7 @@ public class ConnectionFactory implements Cloneable {
      * @param addrs a List of known broker addrs (hostname/port pairs) to try in order
      * @return an interface to the connection
      * @throws java.io.IOException if it encounters a problem
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public Connection newConnection(ExecutorService executor, List<Address> addrs) throws IOException, TimeoutException {
         return newConnection(executor, addrs, null);
@@ -1025,7 +1025,7 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection, picking the first available address from
      * the list provided by the {@link AddressResolver}.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address provided by the {@link AddressResolver}.
      *
@@ -1033,7 +1033,7 @@ public class ConnectionFactory implements Cloneable {
      * @param addressResolver discovery service to list potential addresses (hostname/port pairs) to connect to
      * @return an interface to the connection
      * @throws java.io.IOException if it encounters a problem
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public Connection newConnection(ExecutorService executor, AddressResolver addressResolver) throws IOException, TimeoutException {
         return newConnection(executor, addressResolver, null);
@@ -1043,7 +1043,7 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection with a client-provided name, picking the first available address from
      * the list.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address from the provided list.
      *
@@ -1056,7 +1056,7 @@ public class ConnectionFactory implements Cloneable {
      *                           This value is supposed to be human-readable.
      * @return an interface to the connection
      * @throws java.io.IOException if it encounters a problem
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public Connection newConnection(ExecutorService executor, List<Address> addrs, String clientProvidedName)
             throws IOException, TimeoutException {
@@ -1067,7 +1067,7 @@ public class ConnectionFactory implements Cloneable {
      * Create a new broker connection with a client-provided name, picking the first available address from
      * the list provided by the {@link AddressResolver}.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Future
      * reconnection attempts will pick a random accessible address provided by the {@link AddressResolver}.
      *
@@ -1080,7 +1080,7 @@ public class ConnectionFactory implements Cloneable {
      *                           This value is supposed to be human-readable.
      * @return an interface to the connection
      * @throws java.io.IOException if it encounters a problem
-     * @see <a href="http://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
+     * @see <a href="https://www.rabbitmq.com/api-guide.html#recovery">Automatic Recovery</a>
      */
     public Connection newConnection(ExecutorService executor, AddressResolver addressResolver, String clientProvidedName)
         throws IOException, TimeoutException {
@@ -1171,7 +1171,7 @@ public class ConnectionFactory implements Cloneable {
     /**
      * Create a new broker connection.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Reconnection
      * attempts will always use the address configured on {@link ConnectionFactory}.
      *
@@ -1185,7 +1185,7 @@ public class ConnectionFactory implements Cloneable {
     /**
      * Create a new broker connection.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Reconnection
      * attempts will always use the address configured on {@link ConnectionFactory}.
      *
@@ -1201,7 +1201,7 @@ public class ConnectionFactory implements Cloneable {
     /**
      * Create a new broker connection.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Reconnection
      * attempts will always use the address configured on {@link ConnectionFactory}.
      *
@@ -1216,7 +1216,7 @@ public class ConnectionFactory implements Cloneable {
     /**
      * Create a new broker connection.
      *
-     * If <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
+     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
      * is enabled, the connection returned by this method will be {@link Recoverable}. Reconnection
      * attempts will always use the address configured on {@link ConnectionFactory}.
      *

--- a/src/main/java/com/rabbitmq/client/Method.java
+++ b/src/main/java/com/rabbitmq/client/Method.java
@@ -18,7 +18,7 @@ package com.rabbitmq.client;
 
 /**
  * Public interface to objects representing an AMQP 0-9-1 method
- * @see http://www.rabbitmq.com/specification.html.
+ * @see https://www.rabbitmq.com/specification.html.
  */
 
 public interface Method {

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 final class Copyright {
     final static String COPYRIGHT="Copyright (c) 2007-2019 Pivotal Software, Inc.";
-    final static String LICENSE="Licensed under the MPL. See http://www.rabbitmq.com/";
+    final static String LICENSE="Licensed under the MPL. See https://www.rabbitmq.com/";
 }
 
 /**

--- a/src/main/java/com/rabbitmq/client/impl/VariableLinkedBlockingQueue.java
+++ b/src/main/java/com/rabbitmq/client/impl/VariableLinkedBlockingQueue.java
@@ -21,7 +21,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package com.rabbitmq.client.impl;

--- a/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcClient.java
+++ b/src/main/java/com/rabbitmq/tools/jsonrpc/JsonRpcClient.java
@@ -31,8 +31,8 @@ import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 /**
- * <a href="http://json-rpc.org">JSON-RPC</a> is a lightweight
- * RPC mechanism using <a href="http://www.json.org/">JSON</a>
+ * <a href="https://www.jsonrpc.org/">JSON-RPC</a> is a lightweight
+ * RPC mechanism using <a href="https://www.json.org/">JSON</a>
  * as a data language for request and reply messages. It is
  * rapidly becoming a standard in web development, where it is
  * used to make RPC requests over HTTP. RabbitMQ provides an

--- a/src/test/java/com/rabbitmq/client/test/AmqpUriTest.java
+++ b/src/test/java/com/rabbitmq/client/test/AmqpUriTest.java
@@ -63,7 +63,7 @@ public class AmqpUriTest extends BrokerTestCase
                      "user", "pass", "[::1]", 100, "/");
 
         /* Various failure cases */
-        parseFail("http://www.rabbitmq.com");
+        parseFail("https://www.rabbitmq.com");
         parseFail("amqp://foo[::1]");
         parseFail("amqp://foo:[::1]");
         parseFail("amqp://[::1]foo");

--- a/src/test/java/com/rabbitmq/client/test/TestUtils.java
+++ b/src/test/java/com/rabbitmq/client/test/TestUtils.java
@@ -221,7 +221,7 @@ public class TestUtils {
     }
 
     /**
-     * http://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java
+     * https://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java
      */
     static int versionCompare(String str1, String str2) {
         String[] vals1 = str1.split("\\.");


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://javadoc.iaik.tugraz.at/iaik_jce/current/iaik/asn1/BIT_STRING.html (200) with 1 occurrences could not be migrated:  
   ([https](https://javadoc.iaik.tugraz.at/iaik_jce/current/iaik/asn1/BIT_STRING.html) result NotSslRecordException).
* http://luca.ntop.org/Teaching/Appunti/asn1.html (200) with 1 occurrences could not be migrated:  
   ([https](https://luca.ntop.org/Teaching/Appunti/asn1.html) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/rabbitmq/ with 1 occurrences migrated to:  
  https://github.com/rabbitmq/ ([https](https://github.com/rabbitmq/) result 200).
* http://search.maven.org/ with 1 occurrences migrated to:  
  https://search.maven.org/ ([https](https://search.maven.org/) result 200).
* http://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java ([https](https://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java) result 200).
* http://www.amqp.org/ with 1 occurrences migrated to:  
  https://www.amqp.org/ ([https](https://www.amqp.org/) result 200).
* http://www.apple.com/DTDs/PropertyList-1.0.dtd with 1 occurrences migrated to:  
  https://www.apple.com/DTDs/PropertyList-1.0.dtd ([https](https://www.apple.com/DTDs/PropertyList-1.0.dtd) result 200).
* http://www.json.org/ with 1 occurrences migrated to:  
  https://www.json.org/ ([https](https://www.json.org/) result 200).
* http://json-rpc.org (302) with 1 occurrences migrated to:  
  https://www.jsonrpc.org/ ([https](https://json-rpc.org) result 200).
* http://www.rabbitmq.com with 1 occurrences migrated to:  
  https://www.rabbitmq.com ([https](https://www.rabbitmq.com) result 200).
* http://www.rabbitmq.com/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/ ([https](https://www.rabbitmq.com/) result 200).
* http://www.rabbitmq.com/alarms.html with 6 occurrences migrated to:  
  https://www.rabbitmq.com/alarms.html ([https](https://www.rabbitmq.com/alarms.html) result 200).
* http://www.rabbitmq.com/api-guide.html with 33 occurrences migrated to:  
  https://www.rabbitmq.com/api-guide.html ([https](https://www.rabbitmq.com/api-guide.html) result 200).
* http://www.rabbitmq.com/build-java-client.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/build-java-client.html ([https](https://www.rabbitmq.com/build-java-client.html) result 200).
* http://www.rabbitmq.com/confirms.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/confirms.html ([https](https://www.rabbitmq.com/confirms.html) result 200).
* http://www.rabbitmq.com/getstarted.html with 2 occurrences migrated to:  
  https://www.rabbitmq.com/getstarted.html ([https](https://www.rabbitmq.com/getstarted.html) result 200).
* http://www.rabbitmq.com/specification.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/specification.html ([https](https://www.rabbitmq.com/specification.html) result 200).
* http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* http://rabbitmq.com/heartbeats.html with 1 occurrences migrated to:  
  https://rabbitmq.com/heartbeats.html ([https](https://rabbitmq.com/heartbeats.html) result 301).
* http://www.mozilla.org/MPL/ with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).
* http://creativecommons.org/licenses/publicdomain with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/publicdomain ([https](https://creativecommons.org/licenses/publicdomain) result 302).