### PR TITLE
Handle multiple publisher confirms in metrics

### DIFF
--- a/src/main/java/com/rabbitmq/client/MetricsCollector.java
+++ b/src/main/java/com/rabbitmq/client/MetricsCollector.java
@@ -34,7 +34,7 @@ public interface MetricsCollector {
 
     void closeChannel(Channel channel);
 
-    void basicPublish(Channel channel);
+    void basicPublish(Channel channel, long deliveryTag);
 
     void basicPublishFailure(Channel channel, Throwable cause);
 

--- a/src/main/java/com/rabbitmq/client/NoOpMetricsCollector.java
+++ b/src/main/java/com/rabbitmq/client/NoOpMetricsCollector.java
@@ -66,7 +66,7 @@ public class NoOpMetricsCollector implements MetricsCollector {
     }
 
     @Override
-    public void basicPublish(Channel channel) {
+    public void basicPublish(Channel channel, long deliveryTag) {
 
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -692,9 +692,13 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
                              BasicProperties props, byte[] body)
         throws IOException
     {
+        final long deliveryTag;
         if (nextPublishSeqNo > 0) {
-            unconfirmedSet.add(getNextPublishSeqNo());
+            deliveryTag = getNextPublishSeqNo();
+            unconfirmedSet.add(deliveryTag);
             nextPublishSeqNo++;
+        } else {
+            deliveryTag = 0;
         }
         if (props == null) {
             props = MessageProperties.MINIMAL_BASIC;
@@ -712,7 +716,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
             metricsCollector.basicPublishFailure(this, e);
             throw e;
         }
-        metricsCollector.basicPublish(this);
+        metricsCollector.basicPublish(this, deliveryTag);
     }
 
     /** Public API - {@inheritDoc} */


### PR DESCRIPTION
This is follow-up to #354.

Fixes #372