### PR TITLE
Add OAuth 2 credentials provider and refresh service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <awaitility.version>3.1.6</awaitility.version>
     <mockito.version>2.25.1</mockito.version>
     <assertj.version>3.12.2</assertj.version>
+    <jetty.version>9.4.19.v20190610</jetty.version>
 
     <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
@@ -742,6 +743,12 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <mockito.version>2.25.1</mockito.version>
     <assertj.version>3.12.2</assertj.version>
     <jetty.version>9.4.19.v20190610</jetty.version>
+    <bouncycastle.version>1.61</bouncycastle.version>
 
     <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
@@ -749,6 +750,12 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
       <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -15,15 +15,7 @@
 
 package com.rabbitmq.client;
 
-import com.rabbitmq.client.impl.AMQConnection;
-import com.rabbitmq.client.impl.ConnectionParams;
-import com.rabbitmq.client.impl.CredentialsProvider;
-import com.rabbitmq.client.impl.DefaultCredentialsProvider;
-import com.rabbitmq.client.impl.DefaultExceptionHandler;
-import com.rabbitmq.client.impl.ErrorOnWriteListener;
-import com.rabbitmq.client.impl.FrameHandler;
-import com.rabbitmq.client.impl.FrameHandlerFactory;
-import com.rabbitmq.client.impl.SocketFrameHandlerFactory;
+import com.rabbitmq.client.impl.*;
 import com.rabbitmq.client.impl.nio.NioParams;
 import com.rabbitmq.client.impl.nio.SocketChannelFrameHandlerFactory;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
@@ -208,6 +200,8 @@ public class ConnectionFactory implements Cloneable {
      * @since 5.5.0
      */
     private TrafficListener trafficListener = TrafficListener.NO_OP;
+
+    private CredentialsRefreshService credentialsRefreshService;
 
     /** @return the default host to use for connections */
     public String getHost() {
@@ -854,6 +848,10 @@ public class ConnectionFactory implements Cloneable {
         return metricsCollector;
     }
 
+    public void setCredentialsRefreshService(CredentialsRefreshService credentialsRefreshService) {
+        this.credentialsRefreshService = credentialsRefreshService;
+    }
+
     protected synchronized FrameHandlerFactory createFrameHandlerFactory() throws IOException {
         if(nio) {
             if(this.frameHandlerFactory == null) {
@@ -1161,6 +1159,7 @@ public class ConnectionFactory implements Cloneable {
         result.setConnectionRecoveryTriggeringCondition(connectionRecoveryTriggeringCondition);
         result.setTopologyRecoveryRetryHandler(topologyRecoveryRetryHandler);
         result.setTrafficListener(trafficListener);
+        result.setCredentialsRefreshService(credentialsRefreshService);
         return result;
     }
 

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -32,17 +32,8 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeoutException;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.function.Predicate;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -848,6 +839,21 @@ public class ConnectionFactory implements Cloneable {
         return metricsCollector;
     }
 
+    /**
+     * Set a {@link CredentialsRefreshService} instance to handle credentials refresh if appropriate.
+     * <p>
+     * Each created connection will register to the refresh service to send an AMQP <code>update.secret</code>
+     * frame when credentials are about to expire. This is the refresh service responsibility to schedule
+     * credentials refresh and <code>udpate.secret</code> frame sending, based on the information provided
+     * by the {@link CredentialsProvider}.
+     * <p>
+     * Note the {@link CredentialsRefreshService} is used only when the {@link CredentialsProvider}
+     * signals credentials can expire, by returning a non-null value from {@link CredentialsProvider#getTimeBeforeExpiration()}.
+     *
+     * @param credentialsRefreshService the refresh service to use
+     * @see #setCredentialsProvider(CredentialsProvider)
+     * @see DefaultCredentialsRefreshService
+     */
     public void setCredentialsRefreshService(CredentialsRefreshService credentialsRefreshService) {
         this.credentialsRefreshService = credentialsRefreshService;
     }

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-Present Pivotal Software, Inc.  All rights reserved.
+// Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
@@ -341,8 +341,8 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
             String username = credentialsProvider.getUsername();
             String password = credentialsProvider.getPassword();
 
-            if (credentialsProvider.getExpiration() != null) {
-                if (this.credentialsRefreshService.needRefresh(credentialsProvider.getExpiration())) {
+            if (credentialsProvider.getTimeBeforeExpiration() != null) {
+                if (this.credentialsRefreshService.needRefresh(credentialsProvider.getTimeBeforeExpiration())) {
                     credentialsProvider.refresh();
                     username = credentialsProvider.getUsername();
                     password = credentialsProvider.getPassword();
@@ -423,7 +423,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
             throw AMQChannel.wrap(sse);
         }
 
-        if (this.credentialsProvider.getExpiration() != null) {
+        if (this.credentialsProvider.getTimeBeforeExpiration() != null) {
             String registrationId = this.credentialsRefreshService.register(credentialsProvider, () -> {
                 // return false if connection is closed, so refresh service can get rid of this registration
                 if (!isOpen()) {

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -243,11 +243,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
 
         this.credentialsRefreshService = params.getCredentialsRefreshService();
 
-        this._channel0 = new AMQChannel(this, 0) {
-            @Override public boolean processAsync(Command c) throws IOException {
-                return getConnection().processControlCommand(c);
-            }
-        };
+        this._channel0 = createChannel0();
 
         this._channelManager = null;
 
@@ -260,6 +256,14 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         this.errorOnWriteListener = params.getErrorOnWriteListener() != null ? params.getErrorOnWriteListener() :
             (connection, exception) -> { throw exception; }; // we just propagate the exception for non-recoverable connections
         this.workPoolTimeout = params.getWorkPoolTimeout();
+    }
+
+    AMQChannel createChannel0() {
+        return new AMQChannel(this, 0) {
+            @Override public boolean processAsync(Command c) throws IOException {
+                return getConnection().processControlCommand(c);
+            }
+        };
     }
 
     private void initializeConsumerWorkService() {
@@ -438,7 +442,12 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
                 AMQImpl.Connection.UpdateSecret updateSecret = new AMQImpl.Connection.UpdateSecret(
                         LongStringHelper.asLongString(refreshedPassword), "Refresh scheduled by client"
                 );
-                _channel0.rpc(updateSecret);
+                try {
+                    _channel0.rpc(updateSecret);
+                } catch (ShutdownSignalException e) {
+                    LOGGER.warn("Error while trying to update secret: {}. Connection has been closed.", e.getMessage());
+                    return false;
+                }
                 return true;
             });
 

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -346,6 +346,9 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
             String password = credentialsProvider.getPassword();
 
             if (credentialsProvider.getTimeBeforeExpiration() != null) {
+                if (this.credentialsRefreshService == null) {
+                    throw new IllegalStateException("Credentials can expire, a credentials refresh service should be set");
+                }
                 if (this.credentialsRefreshService.needRefresh(credentialsProvider.getTimeBeforeExpiration())) {
                     credentialsProvider.refresh();
                     username = credentialsProvider.getUsername();

--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -435,8 +435,10 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
                 }
                 String refreshedPassword = credentialsProvider.getPassword();
 
-                // TODO send password to server with update-secret extension, using channel 0
-
+                AMQImpl.Connection.UpdateSecret updateSecret = new AMQImpl.Connection.UpdateSecret(
+                        LongStringHelper.asLongString(refreshedPassword), "Refresh scheduled by client"
+                );
+                _channel0.rpc(updateSecret);
                 return true;
             });
 

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -60,6 +60,8 @@ public class ConnectionParams {
 
     private TrafficListener trafficListener;
 
+    private CredentialsRefreshService credentialsRefreshService;
+
     public ConnectionParams() {}
 
     public CredentialsProvider getCredentialsProvider() {
@@ -276,5 +278,13 @@ public class ConnectionParams {
 
     public TrafficListener getTrafficListener() {
         return trafficListener;
+    }
+
+    public void setCredentialsRefreshService(CredentialsRefreshService credentialsRefreshService) {
+        this.credentialsRefreshService = credentialsRefreshService;
+    }
+
+    public CredentialsRefreshService getCredentialsRefreshService() {
+        return credentialsRefreshService;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/CredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/CredentialsProvider.java
@@ -1,16 +1,67 @@
+// Copyright (c) 2018-2019 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
 package com.rabbitmq.client.impl;
+
+import java.util.Date;
 
 /**
  * Provider interface for establishing credentials for connecting to the broker. Especially useful
- * for situations where credentials might change before a recovery takes place or where it is 
+ * for situations where credentials might expire or change before a recovery takes place or where it is
  * convenient to plug in an outside custom implementation.
  *
- * @since 4.5.0
+ * @see CredentialsRefreshService
+ * @since 5.2.0
  */
 public interface CredentialsProvider {
 
+    /**
+     * Username to use for authentication
+     *
+     * @return username
+     */
     String getUsername();
 
+    /**
+     * Password/secret/token to use for authentication
+     *
+     * @return password/secret/token
+     */
     String getPassword();
+
+    /**
+     * The expiration date of the credentials, if any.
+     * <p>
+     * If credentials do not expire, must return null. Default
+     * behavior is to return null, assuming credentials never
+     * expire.
+     *
+     * @return credentials expiration date
+     */
+    default Date getExpiration() {
+        // no expiration by default
+        return null;
+    }
+
+    /**
+     * Instructs the provider to refresh or renew credentials.
+     * <p>
+     * Default behavior is no-op.
+     */
+    default void refresh() {
+        // no need to refresh anything by default
+    }
 
 }

--- a/src/main/java/com/rabbitmq/client/impl/CredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/CredentialsProvider.java
@@ -15,7 +15,7 @@
 
 package com.rabbitmq.client.impl;
 
-import java.util.Date;
+import java.time.Duration;
 
 /**
  * Provider interface for establishing credentials for connecting to the broker. Especially useful
@@ -42,16 +42,15 @@ public interface CredentialsProvider {
     String getPassword();
 
     /**
-     * The expiration date of the credentials, if any.
+     * The time before the credentials expire, if they do expire.
      * <p>
      * If credentials do not expire, must return null. Default
      * behavior is to return null, assuming credentials never
      * expire.
      *
-     * @return credentials expiration date
+     * @return time before expiration
      */
-    default Date getExpiration() {
-        // no expiration by default
+    default Duration getTimeBeforeExpiration() {
         return null;
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/CredentialsRefreshService.java
+++ b/src/main/java/com/rabbitmq/client/impl/CredentialsRefreshService.java
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import java.util.Date;
+import java.util.concurrent.Callable;
+
+/**
+ * Provider interface to refresh credentials when appropriate
+ * and perform an operation once the credentials have been
+ * renewed. In the context of RabbitMQ, the operation consists
+ * in calling the <code>update.secret</code> AMQP extension
+ * to provide new valid credentials before the current ones
+ * expire.
+ * <p>
+ * New connections are registered and implementations must perform
+ * credentials renewal when appropriate. Implementations
+ * must call a registered callback once credentials are renewed.
+ *
+ * @see CredentialsProvider
+ * @see DefaultCredentialsRefreshService
+ */
+public interface CredentialsRefreshService {
+
+    /**
+     * Register a new entity that needs credentials renewal.
+     * <p>
+     * The registered callback must return true if the action was
+     * performed correctly, throw an exception if something goes wrong,
+     * and return false if it became stale and wants to be unregistered.
+     * <p>
+     * Implementations are free to automatically unregister an entity whose
+     * callback has failed a given number of times.
+     *
+     * @param credentialsProvider the credentials provider
+     * @param refreshAction       the action to perform after credentials renewal
+     * @return a tracking ID for the registration
+     */
+    String register(CredentialsProvider credentialsProvider, Callable<Boolean> refreshAction);
+
+    /**
+     * Unregister the entity with the given registration ID.
+     * <p>
+     * Its state is cleaned up and its registered callback will not be
+     * called again.
+     *
+     * @param credentialsProvider the credentials provider
+     * @param registrationId      the registration ID
+     */
+    void unregister(CredentialsProvider credentialsProvider, String registrationId);
+
+    /**
+     * Provide a hint about whether credentials should be renewed.
+     *
+     * @param expiration
+     * @return true if credentials should be renewed, false otherwise
+     */
+    boolean needRefresh(Date expiration);
+
+}

--- a/src/main/java/com/rabbitmq/client/impl/CredentialsRefreshService.java
+++ b/src/main/java/com/rabbitmq/client/impl/CredentialsRefreshService.java
@@ -15,7 +15,7 @@
 
 package com.rabbitmq.client.impl;
 
-import java.util.Date;
+import java.time.Duration;
 import java.util.concurrent.Callable;
 
 /**
@@ -65,9 +65,9 @@ public interface CredentialsRefreshService {
     /**
      * Provide a hint about whether credentials should be renewed.
      *
-     * @param expiration
+     * @param timeBeforeExpiration
      * @return true if credentials should be renewed, false otherwise
      */
-    boolean needRefresh(Date expiration);
+    boolean needRefresh(Duration timeBeforeExpiration);
 
 }

--- a/src/main/java/com/rabbitmq/client/impl/DefaultCredentialsRefreshService.java
+++ b/src/main/java/com/rabbitmq/client/impl/DefaultCredentialsRefreshService.java
@@ -1,0 +1,307 @@
+// Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Scheduling-based implementation of {@link CredentialsRefreshService}.
+ * <p>
+ * This implementation keeps track of entities (typically AMQP connections) that need
+ * to renew credentials. Token renewal is scheduled based on token expiration, using
+ * a <code>Function<Date, Long> refreshDelayStrategy</code>. Once credentials
+ * for a {@link CredentialsProvider} have been renewed, the callback registered
+ * by each entity/connection is performed. This callback typically propagates
+ * the new credentials in the entity state, e.g. sending the new password to the
+ * broker for AMQP connections.
+ */
+public class DefaultCredentialsRefreshService implements CredentialsRefreshService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCredentialsRefreshService.class);
+
+    private final ScheduledExecutorService scheduler;
+
+    private final ConcurrentMap<CredentialsProvider, CredentialsProviderState> credentialsProviderStates = new ConcurrentHashMap<>();
+
+    private final boolean privateScheduler;
+
+    private final Function<Date, Long> refreshDelayStrategy;
+
+    private final Function<Date, Boolean> needRefreshStrategy;
+
+    public DefaultCredentialsRefreshService(ScheduledExecutorService scheduler, Function<Date, Long> refreshDelayStrategy, Function<Date, Boolean> needRefreshStrategy) {
+        this.refreshDelayStrategy = refreshDelayStrategy;
+        this.needRefreshStrategy = needRefreshStrategy;
+        if (scheduler == null) {
+            this.scheduler = Executors.newScheduledThreadPool(1);
+            privateScheduler = true;
+        } else {
+            this.scheduler = scheduler;
+            privateScheduler = false;
+        }
+    }
+
+    /**
+     * Delay before refresh is <code>TTL - specified duration</code>.
+     * <p>
+     * E.g. if TTL is 60 seconds and specified duration is 20 seconds, refresh will
+     * be scheduled in 60 - 20 = 40 seconds.
+     *
+     * @param duration
+     * @return
+     */
+    public static Function<Date, Long> fixedDelayBeforeExpirationRefreshDelayStrategy(Duration duration) {
+        return new FixedDelayBeforeExpirationRefreshDelayStrategy(duration.toMillis());
+    }
+
+    /**
+     * Advise to refresh credentials if <code>TTL <= limit</code>.
+     *
+     * @param limitBeforeExpiration
+     * @return
+     */
+    public static Function<Date, Boolean> fixedTimeNeedRefreshStrategy(Duration limitBeforeExpiration) {
+        return new FixedTimeNeedRefreshStrategy(limitBeforeExpiration.toMillis());
+    }
+
+    // TODO add a delay refresh strategy that bases the time on a percentage of the TTL, use it as default with 80% TTL
+
+    private static Runnable refresh(ScheduledExecutorService scheduler, CredentialsProviderState credentialsProviderState,
+                                    Function<Date, Long> refreshDelayStrategy) {
+        return () -> {
+            LOGGER.debug("Refreshing token");
+            credentialsProviderState.refresh();
+
+            Date expirationAfterRefresh = credentialsProviderState.credentialsProvider.getExpiration();
+            long newDelay = refreshDelayStrategy.apply(expirationAfterRefresh);
+
+            LOGGER.debug("Scheduling refresh in {} milliseconds", newDelay);
+
+            ScheduledFuture<?> scheduledFuture = scheduler.schedule(refresh(scheduler, credentialsProviderState, refreshDelayStrategy), newDelay, TimeUnit.MILLISECONDS);
+            credentialsProviderState.refreshTask.set(scheduledFuture);
+        };
+    }
+
+    @Override
+    public String register(CredentialsProvider credentialsProvider, Callable<Boolean> refreshAction) {
+        String registrationId = UUID.randomUUID().toString();
+        LOGGER.debug("New registration {}", registrationId);
+
+        Registration registration = new Registration(registrationId, refreshAction);
+        CredentialsProviderState credentialsProviderState = credentialsProviderStates.computeIfAbsent(
+                credentialsProvider,
+                credentialsProviderKey -> new CredentialsProviderState(credentialsProviderKey)
+        );
+
+        credentialsProviderState.add(registration);
+
+        credentialsProviderState.maybeSetRefreshTask(() -> {
+            Date expiration = credentialsProvider.getExpiration();
+            long delay = refreshDelayStrategy.apply(expiration);
+            LOGGER.debug("Scheduling refresh in {} milliseconds", delay);
+            return scheduler.schedule(refresh(scheduler, credentialsProviderState, refreshDelayStrategy), delay, TimeUnit.MILLISECONDS);
+        });
+
+        return registrationId;
+    }
+
+    @Override
+    public void unregister(CredentialsProvider credentialsProvider, String registrationId) {
+        CredentialsProviderState credentialsProviderState = this.credentialsProviderStates.get(credentialsProvider);
+        if (credentialsProviderState != null) {
+            credentialsProviderState.unregister(registrationId);
+        }
+    }
+
+    @Override
+    public boolean needRefresh(Date expiration) {
+        return this.needRefreshStrategy.apply(expiration);
+    }
+
+    public void close() {
+        if (privateScheduler) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    private static class FixedTimeNeedRefreshStrategy implements Function<Date, Boolean> {
+
+        private final long limitBeforeExpiration;
+
+        private FixedTimeNeedRefreshStrategy(long limitBeforeExpiration) {
+            this.limitBeforeExpiration = limitBeforeExpiration;
+        }
+
+        @Override
+        public Boolean apply(Date expiration) {
+            long ttl = expiration.getTime() - new Date().getTime();
+            return ttl <= limitBeforeExpiration;
+        }
+    }
+
+    private static class FixedDelayBeforeExpirationRefreshDelayStrategy implements Function<Date, Long> {
+
+        private final long delay;
+
+        private FixedDelayBeforeExpirationRefreshDelayStrategy(long delay) {
+            this.delay = delay;
+        }
+
+        @Override
+        public Long apply(Date expiration) {
+            long ttl = expiration.getTime() - new Date().getTime();
+            long refreshTimeBeforeExpiration = ttl - delay;
+            if (refreshTimeBeforeExpiration < 0) {
+                return ttl;
+            } else {
+                return refreshTimeBeforeExpiration;
+            }
+        }
+    }
+
+    static class Registration {
+
+        private final Callable<Boolean> refreshAction;
+
+        private final AtomicInteger errorHistory = new AtomicInteger(0);
+
+        private final String id;
+
+        Registration(String id, Callable<Boolean> refreshAction) {
+            this.refreshAction = refreshAction;
+            this.id = id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Registration that = (Registration) o;
+
+            return id.equals(that.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return id.hashCode();
+        }
+    }
+
+    /**
+     * State and refresh behavior for a {@link CredentialsProvider} and
+     * its registered entities.
+     */
+    static class CredentialsProviderState {
+
+        private final CredentialsProvider credentialsProvider;
+
+        private final Map<String, Registration> registrations = new ConcurrentHashMap<>();
+
+        private final AtomicReference<ScheduledFuture<?>> refreshTask = new AtomicReference<>();
+
+        private final AtomicBoolean refreshTaskSet = new AtomicBoolean(false);
+
+        CredentialsProviderState(CredentialsProvider credentialsProvider) {
+            this.credentialsProvider = credentialsProvider;
+        }
+
+        void add(Registration registration) {
+            this.registrations.put(registration.id, registration);
+        }
+
+        void maybeSetRefreshTask(Supplier<ScheduledFuture<?>> scheduledFutureSupplier) {
+            if (refreshTaskSet.compareAndSet(false, true)) {
+                refreshTask.set(scheduledFutureSupplier.get());
+            }
+        }
+
+        void refresh() {
+            // FIXME check whether thread has been cancelled or not before refresh() and registratAction.call()
+
+            // FIXME protect this call, or at least log some error
+            this.credentialsProvider.refresh();
+
+            Iterator<Registration> iterator = registrations.values().iterator();
+            while (iterator.hasNext()) {
+                Registration registration = iterator.next();
+                // FIXME set a timeout on the call? (needs a separate thread)
+                try {
+                    boolean refreshed = registration.refreshAction.call();
+                    if (!refreshed) {
+                        LOGGER.debug("Registration did not refresh token");
+                        iterator.remove();
+                    }
+                    registration.errorHistory.set(0);
+                } catch (Exception e) {
+                    LOGGER.warn("Error while trying to refresh a connection token", e);
+                    registration.errorHistory.incrementAndGet();
+                    if (registration.errorHistory.get() >= 5) {
+                        registrations.remove(registration.id);
+                    }
+                }
+            }
+        }
+
+        void unregister(String registrationId) {
+            this.registrations.remove(registrationId);
+        }
+    }
+
+    public static class DefaultCredentialsRefreshServiceBuilder {
+
+
+        private ScheduledExecutorService scheduler;
+
+        private Function<Date, Long> refreshDelayStrategy = fixedDelayBeforeExpirationRefreshDelayStrategy(Duration.ofSeconds(60));
+
+        private Function<Date, Boolean> needRefreshStrategy = fixedTimeNeedRefreshStrategy(Duration.ofSeconds(60));
+
+        public DefaultCredentialsRefreshServiceBuilder scheduler(ScheduledThreadPoolExecutor scheduler) {
+            this.scheduler = scheduler;
+            return this;
+        }
+
+        public DefaultCredentialsRefreshServiceBuilder refreshDelayStrategy(Function<Date, Long> refreshDelayStrategy) {
+            this.refreshDelayStrategy = refreshDelayStrategy;
+            return this;
+        }
+
+        public DefaultCredentialsRefreshServiceBuilder needRefreshStrategy(Function<Date, Boolean> needRefreshStrategy) {
+            this.needRefreshStrategy = needRefreshStrategy;
+            return this;
+        }
+
+        public DefaultCredentialsRefreshService build() {
+            return new DefaultCredentialsRefreshService(scheduler, refreshDelayStrategy, needRefreshStrategy);
+        }
+
+    }
+
+}

--- a/src/main/java/com/rabbitmq/client/impl/OAuth2ClientCredentialsGrantCredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/OAuth2ClientCredentialsGrantCredentialsProvider.java
@@ -25,6 +25,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.function.Consumer;
 
@@ -143,9 +146,8 @@ public class OAuth2ClientCredentialsGrantCredentialsProvider extends RefreshProt
         try {
             Map<?, ?> map = objectMapper.readValue(response, Map.class);
             int expiresIn = ((Number) map.get("expires_in")).intValue();
-            Calendar calendar = Calendar.getInstance();
-            calendar.add(Calendar.SECOND, expiresIn);
-            return new Token(map.get("access_token").toString(), calendar.getTime());
+            Instant receivedAt = Instant.now();
+            return new Token(map.get("access_token").toString(), expiresIn, receivedAt);
         } catch (IOException e) {
             throw new OAuthTokenManagementException("Error while parsing OAuth 2 token", e);
         }
@@ -226,8 +228,8 @@ public class OAuth2ClientCredentialsGrantCredentialsProvider extends RefreshProt
     }
 
     @Override
-    protected Date expirationFromToken(Token token) {
-        return token.getExpiration();
+    protected Duration timeBeforeExpiration(Token token) {
+        return token.getTimeBeforeExpiration();
     }
 
     protected void configureConnection(HttpURLConnection connection) {
@@ -266,19 +268,32 @@ public class OAuth2ClientCredentialsGrantCredentialsProvider extends RefreshProt
 
         private final String access;
 
-        private final Date expiration;
+        private final int expiresIn;
 
-        public Token(String access, Date expiration) {
+        private final Instant receivedAt;
+
+        public Token(String access, int expiresIn, Instant receivedAt) {
             this.access = access;
-            this.expiration = expiration;
-        }
-
-        public Date getExpiration() {
-            return expiration;
+            this.expiresIn = expiresIn;
+            this.receivedAt = receivedAt;
         }
 
         public String getAccess() {
             return access;
+        }
+
+        public int getExpiresIn() {
+            return expiresIn;
+        }
+
+        public Instant getReceivedAt() {
+            return receivedAt;
+        }
+
+        public Duration getTimeBeforeExpiration() {
+            Instant now = Instant.now();
+            long age = receivedAt.until(now, ChronoUnit.SECONDS);
+            return Duration.ofSeconds(expiresIn - age);
         }
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/OAuth2ClientCredentialsGrantCredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/OAuth2ClientCredentialsGrantCredentialsProvider.java
@@ -1,0 +1,233 @@
+// Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+
+public class OAuth2ClientCredentialsGrantCredentialsProvider implements CredentialsProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OAuth2ClientCredentialsGrantCredentialsProvider.class);
+
+    private static final String UTF_8_CHARSET = "UTF-8";
+    private final String serverUri; // should be renamed to tokenEndpointUri?
+    private final String clientId;
+    private final String clientSecret;
+    private final String grantType;
+    // UAA specific, to distinguish between different users
+    private final String username, password;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String id;
+
+    private final AtomicReference<Token> token = new AtomicReference<>();
+
+    private final Lock refreshLock = new ReentrantLock();
+    private final AtomicReference<CountDownLatch> latch = new AtomicReference<>();
+    private AtomicBoolean refreshInProcess = new AtomicBoolean(false);
+
+    public OAuth2ClientCredentialsGrantCredentialsProvider(String serverUri, String clientId, String clientSecret, String grantType, String username, String password) {
+        this.serverUri = serverUri;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.grantType = grantType;
+        this.username = username;
+        this.password = password;
+        this.id = UUID.randomUUID().toString();
+    }
+
+    private static StringBuilder encode(StringBuilder builder, String name, String value) throws UnsupportedEncodingException {
+        if (value != null) {
+            if (builder.length() > 0) {
+                builder.append("&");
+            }
+            builder.append(URLEncoder.encode(name, UTF_8_CHARSET))
+                    .append("=")
+                    .append(URLEncoder.encode(value, UTF_8_CHARSET));
+        }
+        return builder;
+    }
+
+    private static String basicAuthentication(String username, String password) {
+        String credentials = username + ":" + password;
+        byte[] credentialsAsBytes = credentials.getBytes(StandardCharsets.ISO_8859_1);
+        byte[] encodedBytes = Base64.getEncoder().encode(credentialsAsBytes);
+        String encodedCredentials = new String(encodedBytes, StandardCharsets.ISO_8859_1);
+        return "Basic " + encodedCredentials;
+    }
+
+    @Override
+    public String getUsername() {
+        return "";
+    }
+
+    @Override
+    public String getPassword() {
+        if (token.get() == null) {
+            refresh();
+        }
+        return token.get().getAccess();
+    }
+
+    @Override
+    public Date getExpiration() {
+        if (token.get() == null) {
+            refresh();
+        }
+        return token.get().getExpiration();
+    }
+
+    protected Token parseToken(String response) {
+        try {
+            Map<?, ?> map = objectMapper.readValue(response, Map.class);
+            int expiresIn = ((Number) map.get("expires_in")).intValue();
+            Calendar calendar = Calendar.getInstance();
+            calendar.add(Calendar.SECOND, expiresIn);
+            return new Token(map.get("access_token").toString(), calendar.getTime());
+        } catch (IOException e) {
+            throw new OAuthTokenManagementException("Error while parsing OAuth 2 token", e);
+        }
+    }
+
+    @Override
+    public void refresh() {
+        // refresh should happen at once. Other calls wait for the refresh to finish and move on.
+        if (refreshLock.tryLock()) {
+            LOGGER.debug("Refreshing token");
+            try {
+                latch.set(new CountDownLatch(1));
+                refreshInProcess.set(true);
+                token.set(retrieveToken());
+                LOGGER.debug("Token refreshed");
+            } finally {
+                latch.get().countDown();
+                refreshInProcess.set(false);
+                refreshLock.unlock();
+            }
+        } else {
+            try {
+                LOGGER.debug("Waiting for token refresh to be finished");
+                while (!refreshInProcess.get()) {
+                    Thread.sleep(10);
+                }
+                latch.get().await();
+                LOGGER.debug("Done waiting for token refresh");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    protected Token retrieveToken() {
+        // FIXME handle TLS specific settings
+        try {
+            StringBuilder urlParameters = new StringBuilder();
+            encode(urlParameters, "grant_type", grantType);
+            encode(urlParameters, "username", username);
+            encode(urlParameters, "password", password);
+            byte[] postData = urlParameters.toString().getBytes(StandardCharsets.UTF_8);
+            int postDataLength = postData.length;
+            URL url = new URL(serverUri);
+            // FIXME close connection?
+            // FIXME set timeout on request
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setDoOutput(true);
+            conn.setInstanceFollowRedirects(false);
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("authorization", basicAuthentication(clientId, clientSecret));
+            conn.setRequestProperty("content-type", "application/x-www-form-urlencoded");
+            conn.setRequestProperty("charset", UTF_8_CHARSET);
+            conn.setRequestProperty("accept", "application/json");
+            conn.setRequestProperty("content-length", Integer.toString(postDataLength));
+            conn.setUseCaches(false);
+            try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream())) {
+                wr.write(postData);
+            }
+            int responseCode = conn.getResponseCode();
+            if (responseCode != 200) {
+                throw new OAuthTokenManagementException(
+                        "HTTP request for token retrieval did not " +
+                                "return 200 response code: " + responseCode
+                );
+            }
+
+            StringBuffer content = new StringBuffer();
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+                String inputLine;
+                while ((inputLine = in.readLine()) != null) {
+                    content.append(inputLine);
+                }
+            }
+
+            // FIXME check result is json
+
+
+            return parseToken(content.toString());
+        } catch (IOException e) {
+            throw new OAuthTokenManagementException("Error while retrieving OAuth 2 token", e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OAuth2ClientCredentialsGrantCredentialsProvider that = (OAuth2ClientCredentialsGrantCredentialsProvider) o;
+
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    public static class Token {
+
+        private final String access;
+
+        private final Date expiration;
+
+        public Token(String access, Date expiration) {
+            this.access = access;
+            this.expiration = expiration;
+        }
+
+        public Date getExpiration() {
+            return expiration;
+        }
+
+        public String getAccess() {
+            return access;
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/client/impl/OAuthTokenManagementException.java
+++ b/src/main/java/com/rabbitmq/client/impl/OAuthTokenManagementException.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Pivotal Software, Inc.  All rights reserved.
+// Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
@@ -15,30 +15,13 @@
 
 package com.rabbitmq.client.impl;
 
-/**
- * Default implementation of a CredentialsProvider which simply holds a static
- * username and password.
- *
- * @since 4.5.0
- */
-public class DefaultCredentialsProvider implements CredentialsProvider {
+public class OAuthTokenManagementException extends RuntimeException {
 
-    private final String username;
-    private final String password;
-
-    public DefaultCredentialsProvider(String username, String password) {
-        this.username = username;
-        this.password = password;
+    public OAuthTokenManagementException(String message, Throwable cause) {
+        super(message, cause);
     }
 
-    @Override
-    public String getUsername() {
-        return username;
+    public OAuthTokenManagementException(String message) {
+        super(message);
     }
-
-    @Override
-    public String getPassword() {
-        return password;
-    }
-    
 }

--- a/src/main/java/com/rabbitmq/client/impl/RefreshProtectedCredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/RefreshProtectedCredentialsProvider.java
@@ -18,7 +18,7 @@ package com.rabbitmq.client.impl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,8 +35,8 @@ import java.util.concurrent.locks.ReentrantLock;
  * is already being renewed.
  * <p>
  * Subclasses need to provide the actual token retrieval (whether is a first retrieval or a renewal is
- * a implementation detail) and how to extract information (username, password, expiration date) from the retrieved
- * token.
+ * a implementation detail) and how to extract information (username, password, time before expiration)
+ * from the retrieved token.
  *
  * @param <T> the type of token (usually specified by the subclass)
  */
@@ -67,11 +67,11 @@ public abstract class RefreshProtectedCredentialsProvider<T> implements Credenti
     }
 
     @Override
-    public Date getExpiration() {
+    public Duration getTimeBeforeExpiration() {
         if (token.get() == null) {
             refresh();
         }
-        return expirationFromToken(token.get());
+        return timeBeforeExpiration(token.get());
     }
 
     @Override
@@ -109,5 +109,5 @@ public abstract class RefreshProtectedCredentialsProvider<T> implements Credenti
 
     protected abstract String passwordFromToken(T token);
 
-    protected abstract Date expirationFromToken(T token);
+    protected abstract Duration timeBeforeExpiration(T token);
 }

--- a/src/main/java/com/rabbitmq/client/impl/RefreshProtectedCredentialsProvider.java
+++ b/src/main/java/com/rabbitmq/client/impl/RefreshProtectedCredentialsProvider.java
@@ -1,0 +1,113 @@
+// Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * An abstract {@link CredentialsProvider} that does not let token refresh happen concurrently.
+ * <p>
+ * A token is usually long-lived (several minutes or more), can be re-used inside the same application,
+ * and refreshing it is a costly operation. This base class lets a first call to {@link #refresh()}
+ * pass and block concurrent calls until the first call is over. Concurrent calls are then unblocked and
+ * can benefit from the refresh. This avoids unnecessary refresh operations to happen if a token
+ * is already being renewed.
+ * <p>
+ * Subclasses need to provide the actual token retrieval (whether is a first retrieval or a renewal is
+ * a implementation detail) and how to extract information (username, password, expiration date) from the retrieved
+ * token.
+ *
+ * @param <T> the type of token (usually specified by the subclass)
+ */
+public abstract class RefreshProtectedCredentialsProvider<T> implements CredentialsProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RefreshProtectedCredentialsProvider.class);
+
+    private final AtomicReference<T> token = new AtomicReference<>();
+
+    private final Lock refreshLock = new ReentrantLock();
+    private final AtomicReference<CountDownLatch> latch = new AtomicReference<>();
+    private AtomicBoolean refreshInProcess = new AtomicBoolean(false);
+
+    @Override
+    public String getUsername() {
+        if (token.get() == null) {
+            refresh();
+        }
+        return usernameFromToken(token.get());
+    }
+
+    @Override
+    public String getPassword() {
+        if (token.get() == null) {
+            refresh();
+        }
+        return passwordFromToken(token.get());
+    }
+
+    @Override
+    public Date getExpiration() {
+        if (token.get() == null) {
+            refresh();
+        }
+        return expirationFromToken(token.get());
+    }
+
+    @Override
+    public void refresh() {
+        // refresh should happen at once. Other calls wait for the refresh to finish and move on.
+        if (refreshLock.tryLock()) {
+            LOGGER.debug("Refreshing token");
+            try {
+                latch.set(new CountDownLatch(1));
+                refreshInProcess.set(true);
+                token.set(retrieveToken());
+                LOGGER.debug("Token refreshed");
+            } finally {
+                latch.get().countDown();
+                refreshInProcess.set(false);
+                refreshLock.unlock();
+            }
+        } else {
+            try {
+                LOGGER.debug("Waiting for token refresh to be finished");
+                while (!refreshInProcess.get()) {
+                    Thread.sleep(10);
+                }
+                latch.get().await();
+                LOGGER.debug("Done waiting for token refresh");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    protected abstract T retrieveToken();
+
+    protected abstract String usernameFromToken(T token);
+
+    protected abstract String passwordFromToken(T token);
+
+    protected abstract Date expirationFromToken(T token);
+}

--- a/src/test/java/com/rabbitmq/client/RefreshCredentialsTest.java
+++ b/src/test/java/com/rabbitmq/client/RefreshCredentialsTest.java
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client;
+
+import com.rabbitmq.client.impl.DefaultCredentialsRefreshService;
+import com.rabbitmq.client.impl.OAuth2ClientCredentialsGrantCredentialsProvider;
+import com.rabbitmq.client.test.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Calendar;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RefreshCredentialsTest {
+
+    DefaultCredentialsRefreshService refreshService;
+
+    @Before
+    public void tearDown() {
+        if (refreshService != null) {
+            refreshService.close();
+        }
+    }
+
+    @Test
+    public void connectionAndRefreshCredentials() throws Exception {
+        ConnectionFactory cf = TestUtils.connectionFactory();
+        CountDownLatch latch = new CountDownLatch(5);
+        // OAuth server is actually not used in this test, default RabbitMQ authentication backend is
+        OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider(
+                "http://localhost:8080/uaa/oauth/token/",
+                "rabbit_client", "rabbit_secret",
+                "password", // UAA-specific, standard is client_credentials
+                "rabbit_super", "rabbit_super" // UAA-specific, to distinguish between RabbitMQ users
+        ) {
+            @Override
+            protected Token retrieveToken() {
+                latch.countDown();
+                Calendar calendar = Calendar.getInstance();
+                calendar.add(Calendar.SECOND, 2);
+                return new Token("guest", calendar.getTime());
+            }
+
+            @Override
+            public String getUsername() {
+                return "guest";
+            }
+        };
+        cf.setCredentialsProvider(provider);
+        refreshService = new DefaultCredentialsRefreshService.DefaultCredentialsRefreshServiceBuilder()
+                .refreshDelayStrategy(DefaultCredentialsRefreshService.fixedDelayBeforeExpirationRefreshDelayStrategy(Duration.ofSeconds(1)))
+                .needRefreshStrategy(expiration -> false)
+                .build();
+        cf.setCredentialsRefreshService(refreshService);
+
+        try (Connection c = cf.newConnection()) {
+            Channel ch = c.createChannel();
+            String queue = ch.queueDeclare().getQueue();
+            TestUtils.sendAndConsumeMessage("", queue, queue, c);
+            assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+}

--- a/src/test/java/com/rabbitmq/client/impl/AMQConnectionRefreshCredentialsTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/AMQConnectionRefreshCredentialsTest.java
@@ -1,0 +1,173 @@
+// Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import com.rabbitmq.client.Method;
+import com.rabbitmq.client.*;
+import com.rabbitmq.client.test.TestUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AMQConnectionRefreshCredentialsTest {
+
+    @ClassRule
+    public static TestRule brokerVersionTestRule = TestUtils.atLeast38();
+
+    @Mock
+    CredentialsProvider credentialsProvider;
+
+    @Mock
+    CredentialsRefreshService refreshService;
+
+    private static ConnectionFactory connectionFactoryThatSendsGarbageAfterUpdateSecret() {
+        ConnectionFactory cf = new ConnectionFactory() {
+            @Override
+            protected AMQConnection createConnection(ConnectionParams params, FrameHandler frameHandler, MetricsCollector metricsCollector) {
+                return new AMQConnection(params, frameHandler, metricsCollector) {
+
+                    @Override
+                    AMQChannel createChannel0() {
+                        return new AMQChannel(this, 0) {
+                            @Override
+                            public boolean processAsync(Command c) throws IOException {
+                                return getConnection().processControlCommand(c);
+                            }
+
+                            @Override
+                            public AMQCommand rpc(Method m) throws IOException, ShutdownSignalException {
+                                if (m instanceof AMQImpl.Connection.UpdateSecret) {
+                                    super.rpc(m);
+                                    return super.rpc(new AMQImpl.Connection.UpdateSecret(LongStringHelper.asLongString(""), "Refresh scheduled by client") {
+                                        @Override
+                                        public int protocolMethodId() {
+                                            return 255;
+                                        }
+                                    });
+                                } else {
+                                    return super.rpc(m);
+                                }
+
+                            }
+                        };
+
+                    }
+                };
+            }
+        };
+        cf.setAutomaticRecoveryEnabled(false);
+        if (TestUtils.USE_NIO) {
+            cf.useNio();
+        }
+        return cf;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void connectionIsUnregisteredFromRefreshServiceWhenClosed() throws Exception {
+        when(credentialsProvider.getUsername()).thenReturn("guest");
+        when(credentialsProvider.getPassword()).thenReturn("guest");
+        when(credentialsProvider.getTimeBeforeExpiration()).thenReturn(Duration.ofSeconds(10));
+
+        ConnectionFactory cf = TestUtils.connectionFactory();
+        cf.setCredentialsProvider(credentialsProvider);
+
+        String registrationId = UUID.randomUUID().toString();
+        CountDownLatch unregisteredLatch = new CountDownLatch(1);
+
+        AtomicReference<Callable<Boolean>> refreshTokenCallable = new AtomicReference<>();
+        when(refreshService.register(eq(credentialsProvider), any(Callable.class))).thenAnswer(invocation -> {
+            refreshTokenCallable.set(invocation.getArgument(1));
+            return registrationId;
+        });
+        doAnswer(invocation -> {
+            unregisteredLatch.countDown();
+            return null;
+        }).when(refreshService).unregister(credentialsProvider, registrationId);
+
+        cf.setCredentialsRefreshService(refreshService);
+
+        verify(refreshService, never()).register(any(CredentialsProvider.class), any(Callable.class));
+        try (Connection c = cf.newConnection()) {
+            verify(refreshService, times(1)).register(eq(credentialsProvider), any(Callable.class));
+            Channel ch = c.createChannel();
+            String queue = ch.queueDeclare().getQueue();
+            TestUtils.sendAndConsumeMessage("", queue, queue, c);
+            verify(refreshService, never()).unregister(any(CredentialsProvider.class), anyString());
+            // calling refresh
+            assertThat(refreshTokenCallable.get().call()).isTrue();
+        }
+        verify(refreshService, times(1)).register(eq(credentialsProvider), any(Callable.class));
+        assertThat(unregisteredLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        verify(refreshService, times(1)).unregister(credentialsProvider, registrationId);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void connectionIsUnregisteredFromRefreshServiceIfUpdateSecretFails() throws Exception {
+        when(credentialsProvider.getUsername()).thenReturn("guest");
+        when(credentialsProvider.getPassword()).thenReturn("guest");
+        when(credentialsProvider.getTimeBeforeExpiration()).thenReturn(Duration.ofSeconds(10));
+
+        ConnectionFactory cf = connectionFactoryThatSendsGarbageAfterUpdateSecret();
+        cf.setCredentialsProvider(credentialsProvider);
+
+        String registrationId = UUID.randomUUID().toString();
+        CountDownLatch unregisteredLatch = new CountDownLatch(1);
+        AtomicReference<Callable<Boolean>> refreshTokenCallable = new AtomicReference<>();
+        when(refreshService.register(eq(credentialsProvider), any(Callable.class))).thenAnswer(invocation -> {
+            refreshTokenCallable.set(invocation.getArgument(1));
+            return registrationId;
+        });
+        doAnswer(invocation -> {
+            unregisteredLatch.countDown();
+            return null;
+        }).when(refreshService).unregister(credentialsProvider, registrationId);
+
+        cf.setCredentialsRefreshService(refreshService);
+
+        Connection c = cf.newConnection();
+        verify(refreshService, times(1)).register(eq(credentialsProvider), any(Callable.class));
+        Channel ch = c.createChannel();
+        String queue = ch.queueDeclare().getQueue();
+        TestUtils.sendAndConsumeMessage("", queue, queue, c);
+        verify(refreshService, never()).unregister(any(CredentialsProvider.class), anyString());
+
+        verify(refreshService, never()).unregister(any(CredentialsProvider.class), anyString());
+        // calling refresh, this sends garbage and should make the broker close the connection
+        assertThat(refreshTokenCallable.get().call()).isFalse();
+        assertThat(unregisteredLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        verify(refreshService, times(1)).unregister(credentialsProvider, registrationId);
+        assertThat(c.isOpen()).isFalse();
+    }
+}

--- a/src/test/java/com/rabbitmq/client/impl/DefaultCredentialsRefreshServiceTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/DefaultCredentialsRefreshServiceTest.java
@@ -166,9 +166,7 @@ public class DefaultCredentialsRefreshServiceTest {
         state.add(new DefaultCredentialsRefreshService.Registration("1", refreshAction));
 
         int callsCountBeforeCancellation = 5;
-        IntStream.range(0, callsCountBeforeCancellation).forEach(i -> {
-            state.refresh();
-        });
+        IntStream.range(0, callsCountBeforeCancellation).forEach(i -> state.refresh());
 
         verify(credentialsProvider, times(callsCountBeforeCancellation)).refresh();
         verify(refreshAction, times(callsCountBeforeCancellation)).call();

--- a/src/test/java/com/rabbitmq/client/impl/DefaultCredentialsRefreshServiceTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/DefaultCredentialsRefreshServiceTest.java
@@ -15,6 +15,10 @@
 
 package com.rabbitmq.client.impl;
 
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.test.TestUtils;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -32,8 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
-import static com.rabbitmq.client.impl.DefaultCredentialsRefreshService.fixedDelayBeforeExpirationRefreshDelayStrategy;
-import static com.rabbitmq.client.impl.DefaultCredentialsRefreshService.fixedTimeNeedRefreshStrategy;
+import static com.rabbitmq.client.impl.DefaultCredentialsRefreshService.*;
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -54,6 +58,55 @@ public class DefaultCredentialsRefreshServiceTest {
         if (refreshService != null) {
             refreshService.close();
         }
+    }
+
+    @Test public void renew() {
+        ConnectionFactory cf = new ConnectionFactory();
+        OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider.OAuth2ClientCredentialsGrantCredentialsProviderBuilder()
+                .tokenEndpointUri("http://localhost:" + 8080 + "/uaa/oauth/token")
+                .clientId("rabbit_client").clientSecret("rabbit_secret")
+                .grantType("password")
+                .parameter("username", "rabbit_super")
+                .parameter("password", "rabbit_super")
+                .build();
+        cf.setCredentialsProvider(provider);
+
+
+    }
+
+    @Test public void connect() throws Exception {
+        ConnectionFactory cf = new ConnectionFactory();
+        OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider.OAuth2ClientCredentialsGrantCredentialsProviderBuilder()
+                .tokenEndpointUri("http://localhost:" + 8080 + "/uaa/oauth/token")
+                .clientId("rabbit_client").clientSecret("rabbit_secret")
+                .grantType("password")
+                .parameter("username", "rabbit_super")
+                .parameter("password", "rabbit_super")
+                .build();
+        cf.setCredentialsProvider(provider);
+        refreshService = new DefaultCredentialsRefreshService.DefaultCredentialsRefreshServiceBuilder()
+//                .refreshDelayStrategy(ttl -> Duration.ofSeconds(60))
+                .refreshDelayStrategy(ratioRefreshDelayStrategy(0.8))
+                .needRefreshStrategy(expiration -> false)
+                .build();
+        cf.setCredentialsRefreshService(refreshService);
+        try (Connection c = cf.newConnection()) {
+
+            while (true) {
+                try {
+                    Channel ch = c.createChannel();
+                    String queue = ch.queueDeclare().getQueue();
+                    TestUtils.sendAndConsumeMessage("", queue, queue, c);
+                    System.out.println("Message sent and consumed");
+                    ch.close();
+                } catch (IOException e) {
+                    System.out.println(e.getCause().getMessage());
+                }
+                Thread.sleep(10_000L);
+            }
+        }
+
+
     }
 
     @Test

--- a/src/test/java/com/rabbitmq/client/impl/DefaultCredentialsRefreshServiceTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/DefaultCredentialsRefreshServiceTest.java
@@ -23,8 +23,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 import java.time.Duration;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -63,11 +61,7 @@ public class DefaultCredentialsRefreshServiceTest {
         AtomicInteger passwordSequence = new AtomicInteger(0);
         when(credentialsProvider.getPassword()).thenAnswer(
                 (Answer<String>) invocation -> "password-" + passwordSequence.get());
-        when(credentialsProvider.getExpiration()).thenAnswer((Answer<Date>) invocation -> {
-            Calendar calendar = Calendar.getInstance();
-            calendar.add(Calendar.SECOND, 5);
-            return calendar.getTime();
-        });
+        when(credentialsProvider.getTimeBeforeExpiration()).thenAnswer((Answer<Duration>) invocation -> Duration.ofSeconds(5));
         doAnswer(invocation -> {
             passwordSequence.incrementAndGet();
             return null;
@@ -88,11 +82,7 @@ public class DefaultCredentialsRefreshServiceTest {
         AtomicInteger passwordSequence2 = new AtomicInteger(0);
         CredentialsProvider credentialsProvider2 = mock(CredentialsProvider.class);
         when(credentialsProvider2.getPassword()).thenAnswer((Answer<String>) invocation -> "password2-" + passwordSequence2.get());
-        when(credentialsProvider2.getExpiration()).thenAnswer((Answer<Date>) invocation -> {
-            Calendar calendar = Calendar.getInstance();
-            calendar.add(Calendar.SECOND, 4);
-            return calendar.getTime();
-        });
+        when(credentialsProvider2.getTimeBeforeExpiration()).thenAnswer((Answer<Duration>) invocation -> Duration.ofSeconds(4));
         doAnswer(invocation -> {
             passwordSequence2.incrementAndGet();
             return null;

--- a/src/test/java/com/rabbitmq/client/impl/DefaultCredentialsRefreshServiceTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/DefaultCredentialsRefreshServiceTest.java
@@ -1,0 +1,181 @@
+// Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.time.Duration;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultCredentialsRefreshServiceTest {
+
+    @Mock
+    Callable<Boolean> refreshAction;
+
+    @Mock
+    CredentialsProvider credentialsProvider;
+
+    DefaultCredentialsRefreshService refreshService;
+
+    @After
+    public void tearDown() {
+        if (refreshService != null) {
+            refreshService.close();
+        }
+    }
+
+    @Test
+    public void scheduling() throws Exception {
+        refreshService = new DefaultCredentialsRefreshService.DefaultCredentialsRefreshServiceBuilder()
+                .refreshDelayStrategy(DefaultCredentialsRefreshService.fixedDelayBeforeExpirationRefreshDelayStrategy(Duration.ofSeconds(2)))
+                .build();
+
+        AtomicInteger passwordSequence = new AtomicInteger(0);
+        when(credentialsProvider.getPassword()).thenAnswer(
+                (Answer<String>) invocation -> "password-" + passwordSequence.get());
+        when(credentialsProvider.getExpiration()).thenAnswer((Answer<Date>) invocation -> {
+            Calendar calendar = Calendar.getInstance();
+            calendar.add(Calendar.SECOND, 5);
+            return calendar.getTime();
+        });
+        doAnswer(invocation -> {
+            passwordSequence.incrementAndGet();
+            return null;
+        }).when(credentialsProvider).refresh();
+
+        List<String> passwords = new CopyOnWriteArrayList<>();
+        CountDownLatch latch = new CountDownLatch(2 * 2);
+        refreshAction = () -> {
+            passwords.add(credentialsProvider.getPassword());
+            latch.countDown();
+            return true;
+        };
+        refreshService.register(credentialsProvider, refreshAction);
+        refreshService.register(credentialsProvider, refreshAction);
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(passwords).hasSize(4).containsExactlyInAnyOrder("password-1", "password-2", "password-1", "password-2");
+
+        AtomicInteger passwordSequence2 = new AtomicInteger(0);
+        CredentialsProvider credentialsProvider2 = mock(CredentialsProvider.class);
+        when(credentialsProvider2.getPassword()).thenAnswer((Answer<String>) invocation -> "password2-" + passwordSequence2.get());
+        when(credentialsProvider2.getExpiration()).thenAnswer((Answer<Date>) invocation -> {
+            Calendar calendar = Calendar.getInstance();
+            calendar.add(Calendar.SECOND, 4);
+            return calendar.getTime();
+        });
+        doAnswer(invocation -> {
+            passwordSequence2.incrementAndGet();
+            return null;
+        }).when(credentialsProvider2).refresh();
+
+
+        List<String> passwords2 = new CopyOnWriteArrayList<>();
+        CountDownLatch latch2 = new CountDownLatch(2 * 1);
+        refreshAction = () -> {
+            passwords2.add(credentialsProvider2.getPassword());
+            latch2.countDown();
+            return true;
+        };
+
+        refreshService.register(credentialsProvider2, refreshAction);
+
+        assertThat(latch2.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(passwords2).hasSize(2).containsExactlyInAnyOrder(
+                "password2-1", "password2-2"
+        );
+        assertThat(passwords).hasSizeGreaterThan(4);
+
+
+    }
+
+    @Test
+    public void refreshActionIsCorrectlyRegisteredCalledAndCanceled() throws Exception {
+        DefaultCredentialsRefreshService.CredentialsProviderState state = new DefaultCredentialsRefreshService.CredentialsProviderState(
+                credentialsProvider
+        );
+        when(refreshAction.call()).thenReturn(true);
+        state.add(new DefaultCredentialsRefreshService.Registration("1", refreshAction));
+
+        state.refresh();
+        verify(credentialsProvider, times(1)).refresh();
+        verify(refreshAction, times(1)).call();
+
+        state.refresh();
+        verify(credentialsProvider, times(2)).refresh();
+        verify(refreshAction, times(2)).call();
+
+        state.unregister("1");
+        state.refresh();
+        verify(credentialsProvider, times(3)).refresh();
+        verify(refreshAction, times(2)).call();
+    }
+
+    @Test
+    public void refreshActionIsRemovedIfItReturnsFalse() throws Exception {
+        DefaultCredentialsRefreshService.CredentialsProviderState state = new DefaultCredentialsRefreshService.CredentialsProviderState(
+                credentialsProvider
+        );
+        when(refreshAction.call()).thenReturn(false);
+        state.add(new DefaultCredentialsRefreshService.Registration("1", refreshAction));
+
+        state.refresh();
+        verify(credentialsProvider, times(1)).refresh();
+        verify(refreshAction, times(1)).call();
+
+        state.refresh();
+        verify(credentialsProvider, times(2)).refresh();
+        verify(refreshAction, times(1)).call();
+    }
+
+    @Test
+    public void refreshActionIsRemovedIfItErrorsTooMuch() throws Exception {
+        DefaultCredentialsRefreshService.CredentialsProviderState state = new DefaultCredentialsRefreshService.CredentialsProviderState(
+                credentialsProvider
+        );
+        when(refreshAction.call()).thenThrow(RuntimeException.class);
+        state.add(new DefaultCredentialsRefreshService.Registration("1", refreshAction));
+
+        int callsCountBeforeCancellation = 5;
+        IntStream.range(0, callsCountBeforeCancellation).forEach(i -> {
+            state.refresh();
+        });
+
+        verify(credentialsProvider, times(callsCountBeforeCancellation)).refresh();
+        verify(refreshAction, times(callsCountBeforeCancellation)).call();
+
+        state.refresh();
+        verify(credentialsProvider, times(callsCountBeforeCancellation + 1)).refresh();
+        verify(refreshAction, times(callsCountBeforeCancellation)).call();
+    }
+
+}

--- a/src/test/java/com/rabbitmq/client/impl/OAuth2ClientCredentialsGrantCredentialsProviderTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/OAuth2ClientCredentialsGrantCredentialsProviderTest.java
@@ -16,28 +16,39 @@
 package com.rabbitmq.client.impl;
 
 import com.rabbitmq.client.test.TestUtils;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.After;
 import org.junit.Test;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Set;
+import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,23 +76,26 @@ public class OAuth2ClientCredentialsGrantCredentialsProviderTest {
         AtomicReference<String> authorization = new AtomicReference<>();
         AtomicReference<String> accept = new AtomicReference<>();
         AtomicReference<String> accessToken = new AtomicReference<>();
+        AtomicReference<Map<String, String[]>> httpParameters = new AtomicReference<>();
 
         int expiresIn = 60;
 
         ContextHandler context = new ContextHandler();
-        context.setContextPath("/uaa/oauth/token/");
+        context.setContextPath("/uaa/oauth/token");
         context.setHandler(new AbstractHandler() {
 
             @Override
             public void handle(String s, Request request, HttpServletRequest httpServletRequest, HttpServletResponse response)
                     throws IOException {
-
                 httpMethod.set(request.getMethod());
                 contentType.set(request.getContentType());
                 authorization.set(request.getHeader("authorization"));
                 accept.set(request.getHeader("accept"));
 
                 accessToken.set(UUID.randomUUID().toString());
+
+                httpParameters.set(request.getParameterMap());
+
                 String json = sampleJsonToken(accessToken.get(), expiresIn);
 
                 response.setStatus(HttpServletResponse.SC_OK);
@@ -91,7 +105,6 @@ public class OAuth2ClientCredentialsGrantCredentialsProviderTest {
                 response.getWriter().print(json);
 
                 request.setHandled(true);
-
             }
         });
 
@@ -100,12 +113,13 @@ public class OAuth2ClientCredentialsGrantCredentialsProviderTest {
         server.setStopTimeout(1000);
         server.start();
 
-        OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider(
-                "http://localhost:" + port + "/uaa/oauth/token/",
-                "rabbit_client", "rabbit_secret",
-                "password", // UAA-specific, standard is client_credentials
-                "rabbit_super", "rabbit_super" // UAA-specific, to distinguish between RabbitMQ users
-        );
+        OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider.OAuth2ClientCredentialsGrantCredentialsProviderBuilder()
+                .tokenEndpointUri("http://localhost:" + port + "/uaa/oauth/token/")
+                .clientId("rabbit_client").clientSecret("rabbit_secret")
+                .grantType("password")
+                .parameter("username", "rabbit_super")
+                .parameter("password", "rabbit_super")
+                .build();
 
         String password = provider.getPassword();
 
@@ -116,49 +130,59 @@ public class OAuth2ClientCredentialsGrantCredentialsProviderTest {
         assertThat(contentType).hasValue("application/x-www-form-urlencoded");
         assertThat(authorization).hasValue("Basic cmFiYml0X2NsaWVudDpyYWJiaXRfc2VjcmV0");
         assertThat(accept).hasValue("application/json");
+        Map<String, String[]> parameters = httpParameters.get();
+        assertThat(parameters).isNotNull().hasSize(3).containsKeys("grant_type", "username", "password")
+                .hasEntrySatisfying("grant_type", v -> assertThat(v).hasSize(1).contains("password"))
+                .hasEntrySatisfying("username", v -> assertThat(v).hasSize(1).contains("rabbit_super"))
+                .hasEntrySatisfying("password", v -> assertThat(v).hasSize(1).contains("rabbit_super"));
     }
 
     @Test
-    public void refresh() throws Exception {
-        AtomicInteger retrieveTokenCallCount = new AtomicInteger(0);
-        OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider(
-                "http://localhost:8080/uaa/oauth/token/",
-                "rabbit_client", "rabbit_secret",
-                "password", // UAA-specific, standard is client_credentials
-                "rabbit_super", "rabbit_super" // UAA-specific, to distinguish between RabbitMQ users
-        ) {
+    public void tls() throws Exception {
+        int port = TestUtils.randomNetworkPort();
+
+        String accessToken = UUID.randomUUID().toString();
+        int expiresIn = 60;
+
+        AbstractHandler httpHandler = new AbstractHandler() {
             @Override
-            protected Token retrieveToken() {
-                retrieveTokenCallCount.incrementAndGet();
-                try {
-                    Thread.sleep(2000L);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-                return new Token(UUID.randomUUID().toString(), new Date());
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+                String json = sampleJsonToken(accessToken, expiresIn);
+
+                response.setStatus(HttpServletResponse.SC_OK);
+                response.setContentLength(json.length());
+                response.setContentType("application/json");
+
+                response.getWriter().print(json);
+
+                baseRequest.setHandled(true);
             }
         };
 
-        Set<String> passwords = ConcurrentHashMap.newKeySet();
-        CountDownLatch latch = new CountDownLatch(5);
-        IntStream.range(0, 5).forEach(i -> new Thread(() -> {
-            passwords.add(provider.getPassword());
-            latch.countDown();
-        }).start());
+        KeyStore keyStore = startHttpsServer(port, httpHandler);
 
-        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+        tmf.init(keyStore);
+        SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+        sslContext.init(null, tmf.getTrustManagers(), null);
 
-        assertThat(retrieveTokenCallCount).hasValue(1);
-        assertThat(passwords).hasSize(1);
+        OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider.OAuth2ClientCredentialsGrantCredentialsProviderBuilder()
+                .tokenEndpointUri("https://localhost:" + port + "/uaa/oauth/token/")
+                .clientId("rabbit_client").clientSecret("rabbit_secret")
+                .setSslSocketFactory(sslContext.getSocketFactory())
+                .build();
+
+        String password = provider.getPassword();
+        assertThat(password).isEqualTo(accessToken);
+        assertThat(provider.getExpiration()).isBetween(offsetNow(expiresIn - 10), offsetNow(expiresIn + 10));
     }
 
     @Test
     public void parseToken() {
         OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider(
-                "http://localhost:8080/uaa/oauth/token",
+                "http://localhost:8080/uaa/oauth/token/",
                 "rabbit_client", "rabbit_secret",
-                "password", // UAA-specific, standard is client_credentials
-                "rabbit_super", "rabbit_super" // UAA-specific, to distinguish between RabbitMQ users
+                "client_credentials"
         );
 
         String accessToken = "18c1b1dfdda04382a8bcc14d077b71dd";
@@ -185,6 +209,64 @@ public class OAuth2ClientCredentialsGrantCredentialsProviderTest {
                 "  \"jti\" : \"18c1b1dfdda04382a8bcc14d077b71dd\"\n" +
                 "}";
         return json.replace("{accessToken}", accessToken).replace("{expiresIn}", expiresIn + "");
+    }
+
+    KeyStore startHttpsServer(int port, Handler handler) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        String keyStorePassword = "password";
+        keyStore.load(null, keyStorePassword.toCharArray());
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+
+        JcaX509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
+                new X500NameBuilder().addRDN(BCStyle.CN, "localhost").build(),
+                BigInteger.valueOf(new SecureRandom().nextInt()),
+                Date.from(Instant.now().minus(10, ChronoUnit.DAYS)),
+                Date.from(Instant.now().plus(10, ChronoUnit.DAYS)),
+                new X500NameBuilder().addRDN(BCStyle.CN, "localhost").build(),
+                kp.getPublic()
+        );
+
+        X509CertificateHolder certificateHolder = certificateBuilder.build(new JcaContentSignerBuilder("SHA256WithRSAEncryption")
+                .build(kp.getPrivate()));
+
+        X509Certificate certificate = new JcaX509CertificateConverter().getCertificate(certificateHolder);
+
+        keyStore.setKeyEntry("default", kp.getPrivate(), keyStorePassword.toCharArray(), new Certificate[]{certificate});
+
+        server = new Server();
+        SslContextFactory sslContextFactory = new SslContextFactory.Server();
+        sslContextFactory.setKeyStore(keyStore);
+        sslContextFactory.setKeyStorePassword(keyStorePassword);
+
+        HttpConfiguration httpsConfiguration = new HttpConfiguration();
+        httpsConfiguration.setSecureScheme("https");
+        httpsConfiguration.setSecurePort(port);
+        httpsConfiguration.setOutputBufferSize(32768);
+
+        SecureRequestCustomizer src = new SecureRequestCustomizer();
+        src.setStsMaxAge(2000);
+        src.setStsIncludeSubDomains(true);
+        httpsConfiguration.addCustomizer(src);
+
+        ServerConnector https = new ServerConnector(server,
+                new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()),
+                new HttpConnectionFactory(httpsConfiguration));
+        https.setPort(port);
+        https.setIdleTimeout(500000);
+
+        server.setConnectors(new Connector[]{https});
+
+        ContextHandler context = new ContextHandler();
+        context.setContextPath("/uaa/oauth/token");
+        context.setHandler(handler);
+
+        server.setHandler(context);
+
+        server.start();
+        return keyStore;
     }
 
 }

--- a/src/test/java/com/rabbitmq/client/impl/OAuth2ClientCredentialsGrantCredentialsProviderTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/OAuth2ClientCredentialsGrantCredentialsProviderTest.java
@@ -42,9 +42,9 @@ import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
@@ -124,7 +124,7 @@ public class OAuth2ClientCredentialsGrantCredentialsProviderTest {
         String password = provider.getPassword();
 
         assertThat(password).isEqualTo(accessToken.get());
-        assertThat(provider.getExpiration()).isBetween(offsetNow(expiresIn - 10), offsetNow(expiresIn + 10));
+        assertThat(provider.getTimeBeforeExpiration()).isBetween(Duration.ofSeconds(expiresIn - 10), Duration.ofSeconds(expiresIn + 10));
 
         assertThat(httpMethod).hasValue("POST");
         assertThat(contentType).hasValue("application/x-www-form-urlencoded");
@@ -174,7 +174,7 @@ public class OAuth2ClientCredentialsGrantCredentialsProviderTest {
 
         String password = provider.getPassword();
         assertThat(password).isEqualTo(accessToken);
-        assertThat(provider.getExpiration()).isBetween(offsetNow(expiresIn - 10), offsetNow(expiresIn + 10));
+        assertThat(provider.getTimeBeforeExpiration()).isBetween(Duration.ofSeconds(expiresIn - 10), Duration.ofSeconds(expiresIn + 10));
     }
 
     @Test
@@ -191,13 +191,7 @@ public class OAuth2ClientCredentialsGrantCredentialsProviderTest {
 
         OAuth2ClientCredentialsGrantCredentialsProvider.Token token = provider.parseToken(response);
         assertThat(token.getAccess()).isEqualTo("18c1b1dfdda04382a8bcc14d077b71dd");
-        assertThat(token.getExpiration()).isBetween(offsetNow(expiresIn - 10), offsetNow(expiresIn + 1));
-    }
-
-    Date offsetNow(int seconds) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.SECOND, seconds);
-        return calendar.getTime();
+        assertThat(token.getTimeBeforeExpiration()).isBetween(Duration.ofSeconds(expiresIn - 10), Duration.ofSeconds(expiresIn + 1));
     }
 
     String sampleJsonToken(String accessToken, int expiresIn) {

--- a/src/test/java/com/rabbitmq/client/impl/OAuth2ClientCredentialsGrantCredentialsProviderTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/OAuth2ClientCredentialsGrantCredentialsProviderTest.java
@@ -1,0 +1,190 @@
+// Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import com.rabbitmq.client.test.TestUtils;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.junit.After;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OAuth2ClientCredentialsGrantCredentialsProviderTest {
+
+    Server server;
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void getToken() throws Exception {
+        Server server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        int port = TestUtils.randomNetworkPort();
+        connector.setPort(port);
+        server.setConnectors(new Connector[]{connector});
+
+        AtomicReference<String> httpMethod = new AtomicReference<>();
+        AtomicReference<String> contentType = new AtomicReference<>();
+        AtomicReference<String> authorization = new AtomicReference<>();
+        AtomicReference<String> accept = new AtomicReference<>();
+        AtomicReference<String> accessToken = new AtomicReference<>();
+
+        int expiresIn = 60;
+
+        ContextHandler context = new ContextHandler();
+        context.setContextPath("/uaa/oauth/token/");
+        context.setHandler(new AbstractHandler() {
+
+            @Override
+            public void handle(String s, Request request, HttpServletRequest httpServletRequest, HttpServletResponse response)
+                    throws IOException {
+
+                httpMethod.set(request.getMethod());
+                contentType.set(request.getContentType());
+                authorization.set(request.getHeader("authorization"));
+                accept.set(request.getHeader("accept"));
+
+                accessToken.set(UUID.randomUUID().toString());
+                String json = sampleJsonToken(accessToken.get(), expiresIn);
+
+                response.setStatus(HttpServletResponse.SC_OK);
+                response.setContentLength(json.length());
+                response.setContentType("application/json");
+
+                response.getWriter().print(json);
+
+                request.setHandled(true);
+
+            }
+        });
+
+        server.setHandler(context);
+
+        server.setStopTimeout(1000);
+        server.start();
+
+        OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider(
+                "http://localhost:" + port + "/uaa/oauth/token/",
+                "rabbit_client", "rabbit_secret",
+                "password", // UAA-specific, standard is client_credentials
+                "rabbit_super", "rabbit_super" // UAA-specific, to distinguish between RabbitMQ users
+        );
+
+        String password = provider.getPassword();
+
+        assertThat(password).isEqualTo(accessToken.get());
+        assertThat(provider.getExpiration()).isBetween(offsetNow(expiresIn - 10), offsetNow(expiresIn + 10));
+
+        assertThat(httpMethod).hasValue("POST");
+        assertThat(contentType).hasValue("application/x-www-form-urlencoded");
+        assertThat(authorization).hasValue("Basic cmFiYml0X2NsaWVudDpyYWJiaXRfc2VjcmV0");
+        assertThat(accept).hasValue("application/json");
+    }
+
+    @Test
+    public void refresh() throws Exception {
+        AtomicInteger retrieveTokenCallCount = new AtomicInteger(0);
+        OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider(
+                "http://localhost:8080/uaa/oauth/token/",
+                "rabbit_client", "rabbit_secret",
+                "password", // UAA-specific, standard is client_credentials
+                "rabbit_super", "rabbit_super" // UAA-specific, to distinguish between RabbitMQ users
+        ) {
+            @Override
+            protected Token retrieveToken() {
+                retrieveTokenCallCount.incrementAndGet();
+                try {
+                    Thread.sleep(2000L);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                return new Token(UUID.randomUUID().toString(), new Date());
+            }
+        };
+
+        Set<String> passwords = ConcurrentHashMap.newKeySet();
+        CountDownLatch latch = new CountDownLatch(5);
+        IntStream.range(0, 5).forEach(i -> new Thread(() -> {
+            passwords.add(provider.getPassword());
+            latch.countDown();
+        }).start());
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(retrieveTokenCallCount).hasValue(1);
+        assertThat(passwords).hasSize(1);
+    }
+
+    @Test
+    public void parseToken() {
+        OAuth2ClientCredentialsGrantCredentialsProvider provider = new OAuth2ClientCredentialsGrantCredentialsProvider(
+                "http://localhost:8080/uaa/oauth/token",
+                "rabbit_client", "rabbit_secret",
+                "password", // UAA-specific, standard is client_credentials
+                "rabbit_super", "rabbit_super" // UAA-specific, to distinguish between RabbitMQ users
+        );
+
+        String accessToken = "18c1b1dfdda04382a8bcc14d077b71dd";
+        int expiresIn = 43199;
+        String response = sampleJsonToken(accessToken, expiresIn);
+
+        OAuth2ClientCredentialsGrantCredentialsProvider.Token token = provider.parseToken(response);
+        assertThat(token.getAccess()).isEqualTo("18c1b1dfdda04382a8bcc14d077b71dd");
+        assertThat(token.getExpiration()).isBetween(offsetNow(expiresIn - 10), offsetNow(expiresIn + 1));
+    }
+
+    Date offsetNow(int seconds) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.SECOND, seconds);
+        return calendar.getTime();
+    }
+
+    String sampleJsonToken(String accessToken, int expiresIn) {
+        String json = "{\n" +
+                "  \"access_token\" : \"{accessToken}\",\n" +
+                "  \"token_type\" : \"bearer\",\n" +
+                "  \"expires_in\" : {expiresIn},\n" +
+                "  \"scope\" : \"clients.read emails.write scim.userids password.write idps.write notifications.write oauth.login scim.write critical_notifications.write\",\n" +
+                "  \"jti\" : \"18c1b1dfdda04382a8bcc14d077b71dd\"\n" +
+                "}";
+        return json.replace("{accessToken}", accessToken).replace("{expiresIn}", expiresIn + "");
+    }
+
+}

--- a/src/test/java/com/rabbitmq/client/impl/RefreshProtectedCredentialsProviderTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/RefreshProtectedCredentialsProviderTest.java
@@ -1,0 +1,90 @@
+// Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.impl;
+
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RefreshProtectedCredentialsProviderTest {
+
+    @Test
+    public void refresh() throws Exception {
+        AtomicInteger retrieveTokenCallCount = new AtomicInteger(0);
+
+        RefreshProtectedCredentialsProvider<TestToken> credentialsProvider = new RefreshProtectedCredentialsProvider<TestToken>() {
+
+            @Override
+            protected TestToken retrieveToken() {
+                retrieveTokenCallCount.incrementAndGet();
+                try {
+                    Thread.sleep(2000L);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                return new TestToken(UUID.randomUUID().toString(), new Date());
+            }
+
+            @Override
+            protected String usernameFromToken(TestToken token) {
+                return "";
+            }
+
+            @Override
+            protected String passwordFromToken(TestToken token) {
+                return token.secret;
+            }
+
+            @Override
+            protected Date expirationFromToken(TestToken token) {
+                return token.expiration;
+            }
+        };
+
+        Set<String> passwords = ConcurrentHashMap.newKeySet();
+        CountDownLatch latch = new CountDownLatch(5);
+        IntStream.range(0, 5).forEach(i -> new Thread(() -> {
+            passwords.add(credentialsProvider.getPassword());
+            latch.countDown();
+        }).start());
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(retrieveTokenCallCount).hasValue(1);
+        assertThat(passwords).hasSize(1);
+    }
+
+    private static class TestToken {
+
+        final String secret;
+        final Date expiration;
+
+        TestToken(String secret, Date expiration) {
+            this.secret = secret;
+            this.expiration = expiration;
+        }
+    }
+
+}

--- a/src/test/java/com/rabbitmq/client/impl/RefreshProtectedCredentialsProviderTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/RefreshProtectedCredentialsProviderTest.java
@@ -17,7 +17,7 @@ package com.rabbitmq.client.impl;
 
 import org.junit.Test;
 
-import java.util.Date;
+import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,7 +44,7 @@ public class RefreshProtectedCredentialsProviderTest {
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
-                return new TestToken(UUID.randomUUID().toString(), new Date());
+                return new TestToken(UUID.randomUUID().toString());
             }
 
             @Override
@@ -58,8 +58,8 @@ public class RefreshProtectedCredentialsProviderTest {
             }
 
             @Override
-            protected Date expirationFromToken(TestToken token) {
-                return token.expiration;
+            protected Duration timeBeforeExpiration(TestToken token) {
+                return Duration.ofSeconds(1);
             }
         };
 
@@ -79,11 +79,9 @@ public class RefreshProtectedCredentialsProviderTest {
     private static class TestToken {
 
         final String secret;
-        final Date expiration;
 
-        TestToken(String secret, Date expiration) {
+        TestToken(String secret) {
             this.secret = secret;
-            this.expiration = expiration;
         }
     }
 

--- a/src/test/java/com/rabbitmq/client/test/ClientTests.java
+++ b/src/test/java/com/rabbitmq/client/test/ClientTests.java
@@ -17,6 +17,10 @@
 package com.rabbitmq.client.test;
 
 import com.rabbitmq.client.JacksonJsonRpcTest;
+import com.rabbitmq.client.RefreshCredentialsTest;
+import com.rabbitmq.client.impl.DefaultCredentialsRefreshServiceTest;
+import com.rabbitmq.client.impl.OAuth2ClientCredentialsGrantCredentialsProvider;
+import com.rabbitmq.client.impl.OAuth2ClientCredentialsGrantCredentialsProviderTest;
 import com.rabbitmq.utility.IntAllocatorTests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -68,7 +72,10 @@ import org.junit.runners.Suite;
     RpcTopologyRecordingTest.class,
     ConnectionTest.class,
     TlsUtilsTest.class,
-    ChannelNTest.class
+    ChannelNTest.class,
+    DefaultCredentialsRefreshServiceTest.class,
+    OAuth2ClientCredentialsGrantCredentialsProviderTest.class,
+    RefreshCredentialsTest.class
 })
 public class ClientTests {
 

--- a/src/test/java/com/rabbitmq/client/test/ClientTests.java
+++ b/src/test/java/com/rabbitmq/client/test/ClientTests.java
@@ -17,10 +17,9 @@
 package com.rabbitmq.client.test;
 
 import com.rabbitmq.client.JacksonJsonRpcTest;
-import com.rabbitmq.client.RefreshCredentialsTest;
 import com.rabbitmq.client.impl.DefaultCredentialsRefreshServiceTest;
-import com.rabbitmq.client.impl.OAuth2ClientCredentialsGrantCredentialsProvider;
 import com.rabbitmq.client.impl.OAuth2ClientCredentialsGrantCredentialsProviderTest;
+import com.rabbitmq.client.impl.RefreshProtectedCredentialsProviderTest;
 import com.rabbitmq.utility.IntAllocatorTests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -73,6 +72,7 @@ import org.junit.runners.Suite;
     ConnectionTest.class,
     TlsUtilsTest.class,
     ChannelNTest.class,
+    RefreshProtectedCredentialsProviderTest.class,
     DefaultCredentialsRefreshServiceTest.class,
     OAuth2ClientCredentialsGrantCredentialsProviderTest.class,
     RefreshCredentialsTest.class

--- a/src/test/java/com/rabbitmq/client/test/ClientTests.java
+++ b/src/test/java/com/rabbitmq/client/test/ClientTests.java
@@ -17,10 +17,7 @@
 package com.rabbitmq.client.test;
 
 import com.rabbitmq.client.JacksonJsonRpcTest;
-import com.rabbitmq.client.impl.DefaultCredentialsRefreshServiceTest;
-import com.rabbitmq.client.impl.OAuth2ClientCredentialsGrantCredentialsProviderTest;
-import com.rabbitmq.client.impl.RefreshProtectedCredentialsProviderTest;
-import com.rabbitmq.client.impl.ValueWriterTest;
+import com.rabbitmq.client.impl.*;
 import com.rabbitmq.utility.IntAllocatorTests;
 
 import org.junit.runner.RunWith;
@@ -78,6 +75,7 @@ import org.junit.runners.Suite;
     DefaultCredentialsRefreshServiceTest.class,
     OAuth2ClientCredentialsGrantCredentialsProviderTest.class,
     RefreshCredentialsTest.class,
+    AMQConnectionRefreshCredentialsTest.class,
     ValueWriterTest.class
 })
 public class ClientTests {

--- a/src/test/java/com/rabbitmq/client/test/RefreshCredentialsTest.java
+++ b/src/test/java/com/rabbitmq/client/test/RefreshCredentialsTest.java
@@ -21,7 +21,9 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.impl.DefaultCredentialsRefreshService;
 import com.rabbitmq.client.impl.RefreshProtectedCredentialsProvider;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -33,6 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RefreshCredentialsTest {
 
+    @ClassRule
+    public static TestRule brokerVersionTestRule = TestUtils.atLeast38();
     DefaultCredentialsRefreshService refreshService;
 
     @Before

--- a/src/test/java/com/rabbitmq/client/test/TestUtils.java
+++ b/src/test/java/com/rabbitmq/client/test/TestUtils.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -239,5 +240,13 @@ public class TestUtils {
         // the strings are equal or one string is a substring of the other
         // e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
         return Integer.signum(vals1.length - vals2.length);
+    }
+
+    public static int randomNetworkPort() throws IOException {
+        ServerSocket socket = new ServerSocket();
+        socket.bind(null);
+        int port = socket.getLocalPort();
+        socket.close();
+        return port;
     }
 }

--- a/src/test/java/com/rabbitmq/client/test/TestUtilsTest.java
+++ b/src/test/java/com/rabbitmq/client/test/TestUtilsTest.java
@@ -43,4 +43,23 @@ public class TestUtilsTest {
         serverProperties.put("version", "3.7.1-alpha.40");
         assertThat(TestUtils.isVersion37orLater(connection), is(true));
     }
+
+    @Test
+    public void isVersion38orLater() {
+        Map<String, Object> serverProperties = new HashMap<>();
+        Connection connection = mock(Connection.class);
+        when(connection.getServerProperties()).thenReturn(serverProperties);
+
+        serverProperties.put("version", "3.7.0+rc.1.4.gedc5d96");
+        assertThat(TestUtils.isVersion38orLater(connection), is(false));
+
+        serverProperties.put("version", "3.7.0~alpha.449-1");
+        assertThat(TestUtils.isVersion38orLater(connection), is(false));
+
+        serverProperties.put("version", "3.7.1-alpha.40");
+        assertThat(TestUtils.isVersion38orLater(connection), is(false));
+
+        serverProperties.put("version", "3.8.0+beta.4.38.g33a7f97");
+        assertThat(TestUtils.isVersion38orLater(connection), is(true));
+    }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <logger name="com.rabbitmq.client.impl.DefaultCredentialsRefreshService" level="DEBUG" />
+    <logger name="com.rabbitmq.client.impl.OAuth2ClientCredentialsGrantCredentialsProvider" level="DEBUG" />
+<!--    <logger name="org.eclipse.jetty" level="DEBUG" />-->
+
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
## Proposed Changes

Initial OAuth 2 token refresh support in the Java client.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
