### PR TITLE
Change # of bits ValueWriter checks for BigDecimal

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/ValueWriter.java
+++ b/src/main/java/com/rabbitmq/client/impl/ValueWriter.java
@@ -143,6 +143,12 @@ public class ValueWriter
         else if(value instanceof BigDecimal) {
             writeOctet('D');
             BigDecimal decimal = (BigDecimal)value;
+            // The scale must be an unsigned octet, therefore its values must
+            // be between 0 and 255
+            if(decimal.scale() > 255 || decimal.scale() < 0)
+                throw new IllegalArgumentException
+                    ("BigDecimal has too large of a scale to be encoded. " +
+                            "The scale was: " + decimal.scale());
             writeOctet(decimal.scale());
             BigInteger unscaled = decimal.unscaledValue();
             // We use 31 instead of 32 because bitLength ignores the sign bit,

--- a/src/main/java/com/rabbitmq/client/impl/ValueWriter.java
+++ b/src/main/java/com/rabbitmq/client/impl/ValueWriter.java
@@ -145,7 +145,9 @@ public class ValueWriter
             BigDecimal decimal = (BigDecimal)value;
             writeOctet(decimal.scale());
             BigInteger unscaled = decimal.unscaledValue();
-            if(unscaled.bitLength() > 32) /*Integer.SIZE in Java 1.5*/
+            // We use 31 instead of 32 because bitLength ignores the sign bit,
+            // so e.g. new BigDecimal(Integer.MAX_VALUE) comes out to 31 bits.
+            if(unscaled.bitLength() > 31) /*Integer.SIZE in Java 1.5*/
                 throw new IllegalArgumentException
                     ("BigDecimal too large to be encoded");
             writeLong(decimal.unscaledValue().intValue());

--- a/src/test/java/com/rabbitmq/client/impl/ValueWriterTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/ValueWriterTest.java
@@ -6,11 +6,13 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayDeque;
 import java.util.Queue;
 
 public class ValueWriterTest {
-    @Test(expected = IllegalArgumentException.class) public void writingOverlyLargeBigDecimalShouldFail() throws IOException {
+    @Test(expected = IllegalArgumentException.class) public void writingOverlyLargeBigDecimalShouldFail()
+        throws IOException {
         Queue<Byte> queue = new ArrayDeque<>();
 
         OutputStream outputStream = new OutputStream() {
@@ -26,5 +28,23 @@ public class ValueWriterTest {
 
         valueWriter.writeFieldValue(new BigDecimal(Integer.MAX_VALUE).add(new BigDecimal(1)));
 
+    }
+
+    @Test(expected = IllegalArgumentException.class) public void writingOverlyLargeScaleInBigDecimalShouldFail()
+        throws IOException {
+        Queue<Byte> queue = new ArrayDeque<>();
+
+        OutputStream outputStream = new OutputStream() {
+            @Override
+            public void write(int b) {
+                queue.add((byte) b);
+            }
+        };
+
+        DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
+
+        ValueWriter valueWriter = new ValueWriter(dataOutputStream);
+
+        valueWriter.writeFieldValue(new BigDecimal(BigInteger.ONE, 500));
     }
 }

--- a/src/test/java/com/rabbitmq/client/impl/ValueWriterTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/ValueWriterTest.java
@@ -7,18 +7,14 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayDeque;
-import java.util.Queue;
 
 public class ValueWriterTest {
     @Test(expected = IllegalArgumentException.class) public void writingOverlyLargeBigDecimalShouldFail()
         throws IOException {
-        Queue<Byte> queue = new ArrayDeque<>();
 
         OutputStream outputStream = new OutputStream() {
             @Override
             public void write(int b) {
-                queue.add((byte) b);
             }
         };
 
@@ -32,12 +28,10 @@ public class ValueWriterTest {
 
     @Test(expected = IllegalArgumentException.class) public void writingOverlyLargeScaleInBigDecimalShouldFail()
         throws IOException {
-        Queue<Byte> queue = new ArrayDeque<>();
 
         OutputStream outputStream = new OutputStream() {
             @Override
             public void write(int b) {
-                queue.add((byte) b);
             }
         };
 

--- a/src/test/java/com/rabbitmq/client/impl/ValueWriterTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/ValueWriterTest.java
@@ -1,0 +1,30 @@
+package com.rabbitmq.client.impl;
+
+import org.junit.Test;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class ValueWriterTest {
+    @Test(expected = IllegalArgumentException.class) public void writingOverlyLargeBigDecimalShouldFail() throws IOException {
+        Queue<Byte> queue = new ArrayDeque<>();
+
+        OutputStream outputStream = new OutputStream() {
+            @Override
+            public void write(int b) {
+                queue.add((byte) b);
+            }
+        };
+
+        DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
+
+        ValueWriter valueWriter = new ValueWriter(dataOutputStream);
+
+        valueWriter.writeFieldValue(new BigDecimal(Integer.MAX_VALUE).add(new BigDecimal(1)));
+
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Fixes #617 by changing the number of bits from 32 to 31. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #617)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I've included a test, but I can't actually run it because
```
make deps
./mvnw -Ddeps.dir=$(pwd)/deps verify -Dit.test=ValueWriterTest
```
blows up with
```
[INFO] --- maven-bundle-plugin:3.2.0:manifest (bundle-manifest) @ amqp-client ---
[INFO] 
[INFO] --- groovy-maven-plugin:2.0:execute (remove-old-test-keystores) @ amqp-client ---
[INFO] 
[INFO] --- groovy-maven-plugin:2.0:execute (query-test-tls-certs-dir) @ amqp-client ---
GEN    /tmp/rabbitmq-test-instances/tls-certs GEN    /tmp/rabbitmq-test-instances/tls-certs/testca/cacert.pemmake[1]: *** [Makefile:41: /tmp/rabbitmq-test-instances/tls-certs/testca/cacert.pem] Error 1make: *** [/home/changlin/Projects/rabbitmq-java-client/deps/rabbit_common/mk/rabbitmq-run.mk:238: /tmp/rabbitmq-test-instances/tls-certs] Error 2
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.019 s
[INFO] Finished at: 2019-06-27T22:58:59-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.gmaven:groovy-maven-plugin:2.0:execute (query-test-tls-certs-dir) on project amqp-client: Execution query-test-tls-certs-dir of goal org.codehaus.gmaven:groovy-maven-plugin:2.0:execute failed: org.apache.maven.plugin.MojoExecutionException: Failed to query test TLS certs directory with command: make -C /home/changlin/Projects/rabbitmq-java-client/deps/rabbit --no-print-directory show-test-tls-certs-dir DEPS_DIR=/home/changlin/Projects/rabbitmq-java-client/deps -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException

```