### PR TITLE
Make instance variables in Frame private

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -689,10 +689,10 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
     private void readFrame(Frame frame) throws IOException {
         if (frame != null) {
             _missedHeartbeats = 0;
-            if (frame.type == AMQP.FRAME_HEARTBEAT) {
+            if (frame.getType() == AMQP.FRAME_HEARTBEAT) {
                 // Ignore it: we've already just reset the heartbeat counter.
             } else {
-                if (frame.channel == 0) { // the special channel
+                if (frame.getChannel() == 0) { // the special channel
                     _channel0.handleFrame(frame);
                 } else {
                     if (isOpen()) {
@@ -705,7 +705,7 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
                         if (cm != null) {
                             ChannelN channel;
                             try {
-                                channel = cm.getChannel(frame.channel);
+                                channel = cm.getChannel(frame.getChannel());
                             } catch(UnknownChannelException e) {
                                 // this can happen if channel has been closed,
                                 // but there was e.g. an in-flight delivery.

--- a/src/main/java/com/rabbitmq/client/impl/CommandAssembler.java
+++ b/src/main/java/com/rabbitmq/client/impl/CommandAssembler.java
@@ -88,7 +88,7 @@ final class CommandAssembler {
     }
 
     private void consumeMethodFrame(Frame f) throws IOException {
-        if (f.type == AMQP.FRAME_METHOD) {
+        if (f.getType() == AMQP.FRAME_METHOD) {
             this.method = AMQImpl.readMethodFrom(f.getInputStream());
             this.state = this.method.hasContent() ? CAState.EXPECTING_CONTENT_HEADER : CAState.COMPLETE;
         } else {
@@ -97,7 +97,7 @@ final class CommandAssembler {
     }
 
     private void consumeHeaderFrame(Frame f) throws IOException {
-        if (f.type == AMQP.FRAME_HEADER) {
+        if (f.getType() == AMQP.FRAME_HEADER) {
             this.contentHeader = AMQImpl.readContentHeaderFrom(f.getInputStream());
             this.remainingBodyBytes = this.contentHeader.getBodySize();
             updateContentBodyState();
@@ -107,7 +107,7 @@ final class CommandAssembler {
     }
 
     private void consumeBodyFrame(Frame f) {
-        if (f.type == AMQP.FRAME_BODY) {
+        if (f.getType() == AMQP.FRAME_BODY) {
             byte[] fragment = f.getPayload();
             this.remainingBodyBytes -= fragment.length;
             updateContentBodyState();

--- a/src/main/java/com/rabbitmq/client/impl/Frame.java
+++ b/src/main/java/com/rabbitmq/client/impl/Frame.java
@@ -29,14 +29,13 @@ import java.util.Map;
 
 /**
  * Represents an AMQP wire-protocol frame, with frame type, channel number, and payload bytes.
- * TODO: make state private
  */
 public class Frame {
     /** Frame type code */
-    public final int type;
+    private final int type;
 
     /** Frame channel number, 0-65535 */
-    public final int channel;
+    private final int channel;
 
     /** Frame payload bytes (for inbound frames) */
     private final byte[] payload;
@@ -344,5 +343,13 @@ public class Frame {
         throws UnsupportedEncodingException
     {
         return str.getBytes("utf-8").length + 1;
+    }
+
+    public int getType() {
+        return type;
+    }
+
+    public int getChannel() {
+        return channel;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/nio/FrameBuilder.java
+++ b/src/main/java/com/rabbitmq/client/impl/nio/FrameBuilder.java
@@ -59,7 +59,7 @@ public class FrameBuilder {
 
     /**
      * Read a frame from the network.
-     * This method returns null f a frame could not have been fully built from
+     * This method returns null if a frame could not have been fully built from
      * the network. The client must then retry later (typically
      * when the channel notifies it has something to read).
      *

--- a/src/test/java/com/rabbitmq/client/test/BrokenFramesTest.java
+++ b/src/test/java/com/rabbitmq/client/test/BrokenFramesTest.java
@@ -62,7 +62,7 @@ public class BrokenFramesTest {
         } catch (IOException e) {
             UnexpectedFrameError unexpectedFrameError = findUnexpectedFrameError(e);
             assertNotNull(unexpectedFrameError);
-            assertEquals(AMQP.FRAME_HEADER, unexpectedFrameError.getReceivedFrame().type);
+            assertEquals(AMQP.FRAME_HEADER, unexpectedFrameError.getReceivedFrame().getType());
             assertEquals(AMQP.FRAME_METHOD, unexpectedFrameError.getExpectedFrameType());
             return;
         }
@@ -88,7 +88,7 @@ public class BrokenFramesTest {
         } catch (IOException e) {
             UnexpectedFrameError unexpectedFrameError = findUnexpectedFrameError(e);
             assertNotNull(unexpectedFrameError);
-            assertEquals(AMQP.FRAME_BODY, unexpectedFrameError.getReceivedFrame().type);
+            assertEquals(AMQP.FRAME_BODY, unexpectedFrameError.getReceivedFrame().getType());
             assertEquals(AMQP.FRAME_HEADER, unexpectedFrameError.getExpectedFrameType());
             return;
         }

--- a/src/test/java/com/rabbitmq/client/test/FrameBuilderTest.java
+++ b/src/test/java/com/rabbitmq/client/test/FrameBuilderTest.java
@@ -53,8 +53,8 @@ public class FrameBuilderTest {
         builder = new FrameBuilder(channel, buffer);
         Frame frame = builder.readFrame();
         assertThat(frame, notNullValue());
-        assertThat(frame.type, is(1));
-        assertThat(frame.channel, is(0));
+        assertThat(frame.getType(), is(1));
+        assertThat(frame.getChannel(), is(0));
         assertThat(frame.getPayload().length, is(3));
     }
 
@@ -74,8 +74,8 @@ public class FrameBuilderTest {
         Frame frame;
         while ((frame = builder.readFrame()) != null) {
             assertThat(frame, notNullValue());
-            assertThat(frame.type, is(1));
-            assertThat(frame.channel, is(0));
+            assertThat(frame.getType(), is(1));
+            assertThat(frame.getChannel(), is(0));
             assertThat(frame.getPayload().length, is(3));
             frameCount++;
         }
@@ -95,8 +95,8 @@ public class FrameBuilderTest {
 
         frame = builder.readFrame();
         assertThat(frame, notNullValue());
-        assertThat(frame.type, is(1));
-        assertThat(frame.channel, is(0));
+        assertThat(frame.getType(), is(1));
+        assertThat(frame.getChannel(), is(0));
         assertThat(frame.getPayload().length, is(3));
     }
 

--- a/src/test/java/com/rabbitmq/client/test/functional/UnexpectedFrames.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/UnexpectedFrames.java
@@ -101,7 +101,7 @@ public class UnexpectedFrames extends BrokerTestCase {
     @Test public void missingHeader() throws IOException {
         expectUnexpectedFrameError(new Confuser() {
             public Frame confuse(Frame frame) {
-                if (frame.type == AMQP.FRAME_HEADER) {
+                if (frame.getType() == AMQP.FRAME_HEADER) {
                     return null;
                 }
                 return frame;
@@ -112,11 +112,11 @@ public class UnexpectedFrames extends BrokerTestCase {
     @Test public void missingMethod() throws IOException {
         expectUnexpectedFrameError(new Confuser() {
             public Frame confuse(Frame frame) {
-                if (frame.type == AMQP.FRAME_METHOD) {
+                if (frame.getType() == AMQP.FRAME_METHOD) {
                     // We can't just skip the method as that will lead us to
                     // send 0 bytes and hang waiting for a response.
                     return new Frame(AMQP.FRAME_HEADER,
-                                     frame.channel, frame.getPayload());
+                                     frame.getChannel(), frame.getPayload());
                 }
                 return frame;
             }
@@ -126,7 +126,7 @@ public class UnexpectedFrames extends BrokerTestCase {
     @Test public void missingBody() throws IOException {
         expectUnexpectedFrameError(new Confuser() {
             public Frame confuse(Frame frame) {
-                if (frame.type == AMQP.FRAME_BODY) {
+                if (frame.getType() == AMQP.FRAME_BODY) {
                     return null;
                 }
                 return frame;
@@ -137,10 +137,10 @@ public class UnexpectedFrames extends BrokerTestCase {
     @Test public void wrongClassInHeader() throws IOException {
         expectUnexpectedFrameError(new Confuser() {
             public Frame confuse(Frame frame) {
-                if (frame.type == AMQP.FRAME_HEADER) {
+                if (frame.getType() == AMQP.FRAME_HEADER) {
                     byte[] payload = frame.getPayload();
                     Frame confusedFrame = new Frame(AMQP.FRAME_HEADER,
-                                                    frame.channel, payload);
+                                                    frame.getChannel(), payload);
                     // First two bytes = class ID, must match class ID from
                     // method.
                     payload[0] = 12;
@@ -155,8 +155,8 @@ public class UnexpectedFrames extends BrokerTestCase {
     @Test public void heartbeatOnChannel() throws IOException {
         expectUnexpectedFrameError(new Confuser() {
             public Frame confuse(Frame frame) {
-                if (frame.type == AMQP.FRAME_METHOD) {
-                    return new Frame(AMQP.FRAME_HEARTBEAT, frame.channel);
+                if (frame.getType() == AMQP.FRAME_METHOD) {
+                    return new Frame(AMQP.FRAME_HEARTBEAT, frame.getChannel());
                 }
                 return frame;
             }
@@ -166,8 +166,8 @@ public class UnexpectedFrames extends BrokerTestCase {
     @Test public void unknownFrameType() throws IOException {
         expectError(AMQP.FRAME_ERROR, new Confuser() {
             public Frame confuse(Frame frame) {
-                if (frame.type == AMQP.FRAME_METHOD) {
-                    return new Frame(0, frame.channel,
+                if (frame.getType() == AMQP.FRAME_METHOD) {
+                    return new Frame(0, frame.getChannel(),
                                      "1234567890\0001234567890".getBytes());
                 }
                 return frame;


### PR DESCRIPTION
Refactor: make the instance variables private and use getters


## Types of Changes

- [x ] Cosmetics (whitespace, appearance)

## Checklist


- [ x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories


