### PR TITLE
Add link to Java libraries support page

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ See [Contributing](./CONTRIBUTING.md) and [How to Run Tests](./RUNNING_TESTS.md)
 
 This library uses [semantic versioning](https://semver.org/).
 
+## Support
+
+See the [RabbitMQ Java libraries support page](https://www.rabbitmq.com/java-versions.html)
+for the support timeline of this library.
+
 ## License
 
 This package, the RabbitMQ Java client library, is [triple-licensed](https://www.rabbitmq.com/api-guide.html#license) under


### PR DESCRIPTION
Depends on https://github.com/rabbitmq/rabbitmq-website/pull/923.