### PR TITLE
Binding recovery retry should recover all bindings on the recovered queue

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -1091,6 +1091,10 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
     public List<RecordedBinding> getRecordedBindings() {
         return recordedBindings;
     }
+    
+    public Map<String, RecordedConsumer> getRecordedConsumers() {
+        return consumers;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryLogic.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryLogic.java
@@ -22,8 +22,6 @@ import com.rabbitmq.utility.Utility;
 import java.util.function.BiPredicate;
 import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryHandlerBuilder.builder;
 
-import ch.qos.logback.core.Context;
-
 /**
  * Useful ready-to-use conditions and operations for {@link DefaultRetryHandler}.
  * They're composed and used with the {@link TopologyRecoveryRetryHandlerBuilder}.

--- a/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryLogic.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryLogic.java
@@ -22,6 +22,8 @@ import com.rabbitmq.utility.Utility;
 import java.util.function.BiPredicate;
 import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryHandlerBuilder.builder;
 
+import ch.qos.logback.core.Context;
+
 /**
  * Useful ready-to-use conditions and operations for {@link DefaultRetryHandler}.
  * They're composed and used with the {@link TopologyRecoveryRetryHandlerBuilder}.
@@ -77,27 +79,27 @@ public abstract class TopologyRecoveryRetryLogic {
      * Recover a binding.
      */
     public static final DefaultRetryHandler.RetryOperation<Void> RECOVER_BINDING = context -> {
+        context.binding().recover();
+        return null;
+    };
+    
+    /**
+     * Recover earlier bindings that share the same queue as this retry context
+     */
+    public static final DefaultRetryHandler.RetryOperation<Void> RECOVER_PREVIOUS_QUEUE_BINDINGS = context -> {
         if (context.entity() instanceof RecordedQueueBinding) {
-            // recover all bindings for the queue.
-            // need to do this incase some bindings have already been recovered successfully before this binding failed
+            // recover all bindings for the same queue that were recovered before this current binding
+            // need to do this incase some bindings had already been recovered successfully before the queue was deleted & this binding failed
             String queue = context.binding().getDestination();
             for (RecordedBinding recordedBinding : Utility.copy(context.connection().getRecordedBindings())) {
-                if (recordedBinding instanceof RecordedQueueBinding && queue.equals(recordedBinding.getDestination())) {
+                if (recordedBinding == context.entity()) {
+                    // we have gotten to the binding in this context. Since this is an ordered list we can now break
+                    // as we know we have recovered all the earlier bindings that may have existed on this queue
+                    break;
+                } else if (recordedBinding instanceof RecordedQueueBinding && queue.equals(recordedBinding.getDestination())) {
                     recordedBinding.recover();
                 }
             }
-        } else if (context.entity() instanceof RecordedExchangeBinding) {
-            // recover all bindings for the exchange
-            // need to do this incase some bindings have already been recovered successfully before this binding failed
-            String exchange = context.binding().getDestination();
-            for (RecordedBinding recordedBinding : Utility.copy(context.connection().getRecordedBindings())) {
-                if (recordedBinding instanceof RecordedExchangeBinding && exchange.equals(recordedBinding.getDestination())) {
-                    recordedBinding.recover();
-                }
-            }
-        } else {
-            // should't be possible to get here, but just in case recover just this binding
-            context.binding().recover();
         }
         return null;
     };
@@ -148,7 +150,8 @@ public abstract class TopologyRecoveryRetryLogic {
     public static final TopologyRecoveryRetryHandlerBuilder RETRY_ON_QUEUE_NOT_FOUND_RETRY_HANDLER = builder()
         .bindingRecoveryRetryCondition(CHANNEL_CLOSED_NOT_FOUND)
         .consumerRecoveryRetryCondition(CHANNEL_CLOSED_NOT_FOUND)
-        .bindingRecoveryRetryOperation(RECOVER_CHANNEL.andThen(RECOVER_BINDING_QUEUE).andThen(RECOVER_BINDING))
+        .bindingRecoveryRetryOperation(RECOVER_CHANNEL.andThen(RECOVER_BINDING_QUEUE).andThen(RECOVER_BINDING)
+            .andThen(RECOVER_PREVIOUS_QUEUE_BINDINGS))
         .consumerRecoveryRetryOperation(RECOVER_CHANNEL.andThen(RECOVER_CONSUMER_QUEUE.andThen(RECOVER_CONSUMER)
             .andThen(RECOVER_CONSUMER_QUEUE_BINDINGS)));
 }

--- a/src/test/java/com/rabbitmq/client/test/functional/TopologyRecoveryRetry.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/TopologyRecoveryRetry.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class TopologyRecoveryRetry extends BrokerTestCase {
 
-    private Consumer<Integer> backoffConsumer;
+    private volatile Consumer<Integer> backoffConsumer;
     
     @After
     public void cleanup() {
@@ -105,12 +105,14 @@ public class TopologyRecoveryRetry extends BrokerTestCase {
         // it should fail once more because queue is gone, and then succeed
         final CountDownLatch backoffLatch = new CountDownLatch(1);
         backoffConsumer = attempt -> {
-            binding2.destination(queue);
-            try {
-                Host.rabbitmqctl("delete_queue " + queue);
-                Thread.sleep(2000);
-            } catch (Exception e) {
-                e.printStackTrace();
+            if (attempt == 1) {
+                binding2.destination(queue);
+                try {
+                    Host.rabbitmqctl("delete_queue " + queue);
+                    Thread.sleep(2000);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
             backoffLatch.countDown();
         };
@@ -166,12 +168,14 @@ public class TopologyRecoveryRetry extends BrokerTestCase {
         // it should fail once more because queue is gone, and then succeed
         final CountDownLatch backoffLatch = new CountDownLatch(1);
         backoffConsumer = attempt -> {
-            consumer.setQueue(queue);
-            try {
-                Host.rabbitmqctl("delete_queue " + queue);
-                Thread.sleep(2000);
-            } catch (Exception e) {
-                e.printStackTrace();
+            if (attempt == 1) {
+                consumer.setQueue(queue);
+                try {
+                    Host.rabbitmqctl("delete_queue " + queue);
+                    Thread.sleep(2000);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
             backoffLatch.countDown();
         };

--- a/src/test/java/com/rabbitmq/client/test/functional/TopologyRecoveryRetry.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/TopologyRecoveryRetry.java
@@ -17,11 +17,24 @@ package com.rabbitmq.client.test.functional;
 
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.Recoverable;
+import com.rabbitmq.client.RecoveryListener;
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
+import com.rabbitmq.client.impl.recovery.RecordedBinding;
+import com.rabbitmq.client.impl.recovery.RecordedConsumer;
 import com.rabbitmq.client.test.BrokerTestCase;
 import com.rabbitmq.client.test.TestUtils;
+import com.rabbitmq.tools.Host;
+import org.junit.After;
 import org.junit.Test;
-
+import java.io.IOException;
 import java.util.HashMap;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryLogic.RETRY_ON_QUEUE_NOT_FOUND_RETRY_HANDLER;
 import static com.rabbitmq.client.test.TestUtils.closeAllConnectionsAndWaitForRecovery;
@@ -32,6 +45,13 @@ import static org.junit.Assert.assertTrue;
  */
 public class TopologyRecoveryRetry extends BrokerTestCase {
 
+    private Consumer<Integer> backoffConsumer;
+    
+    @After
+    public void cleanup() {
+        backoffConsumer = null;
+    }
+    
     @Test
     public void topologyRecoveryRetry() throws Exception {
         int nbQueues = 200;
@@ -40,6 +60,7 @@ public class TopologyRecoveryRetry extends BrokerTestCase {
             String queue = prefix + i;
             channel.queueDeclare(queue, false, false, true, new HashMap<>());
             channel.queueBind(queue, "amq.direct", queue);
+            channel.queueBind(queue, "amq.direct", queue + "2");
             channel.basicConsume(queue, true, new DefaultConsumer(channel));
         }
 
@@ -47,11 +68,137 @@ public class TopologyRecoveryRetry extends BrokerTestCase {
 
         assertTrue(channel.isOpen());
     }
+    
+    @Test
+    public void topologyRecoveryBindingFailure() throws Exception {
+        final String queue = "topology-recovery-retry-binding-failure" + System.currentTimeMillis();
+        channel.queueDeclare(queue, false, false, true, new HashMap<>());
+        channel.queueBind(queue, "amq.topic", "topic1");
+        channel.queueBind(queue, "amq.topic", "topic2");
+        final CountDownLatch messagesReceivedLatch = new CountDownLatch(2);
+        channel.basicConsume(queue, true, new DefaultConsumer(channel) {
+            @Override
+            public void handleDelivery(String consumerTag, Envelope envelope, BasicProperties properties, byte[] body) throws IOException {
+                System.out.println("Got message=" + new String(body));
+                messagesReceivedLatch.countDown();
+            }
+        });
+        final CountDownLatch recoveryLatch = new CountDownLatch(1);
+        ((AutorecoveringConnection)connection).addRecoveryListener(new RecoveryListener() {
+            @Override
+            public void handleRecoveryStarted(Recoverable recoverable) {
+                // no-op
+            }
+            @Override
+            public void handleRecovery(Recoverable recoverable) {
+                recoveryLatch.countDown();
+            }
+        });
+        
+        // we want recovery to fail when recovering the 2nd binding
+        // give the 2nd recorded binding a bad queue name so it fails
+        final RecordedBinding binding2 = ((AutorecoveringConnection)connection).getRecordedBindings().get(1);
+        binding2.destination(UUID.randomUUID().toString());
+        
+        // use the backoffConsumer to know that it has failed
+        // then delete the real queue & fix the recorded binding
+        // it should fail once more because queue is gone, and then succeed
+        final CountDownLatch backoffLatch = new CountDownLatch(1);
+        backoffConsumer = attempt -> {
+            binding2.destination(queue);
+            try {
+                Host.rabbitmqctl("delete_queue " + queue);
+                Thread.sleep(2000);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            backoffLatch.countDown();
+        };
+        
+        // close connection
+        Host.closeAllConnections();
+        
+        // assert backoff was called
+        assertTrue(backoffLatch.await(90, TimeUnit.SECONDS));
+        // wait for full recovery
+        assertTrue(recoveryLatch.await(90, TimeUnit.SECONDS));
+        
+        // publish messages to verify both bindings were recovered
+        basicPublishVolatile("test1".getBytes(), "amq.topic", "topic1");
+        basicPublishVolatile("test2".getBytes(), "amq.topic", "topic2");
+        
+        assertTrue(messagesReceivedLatch.await(10, TimeUnit.SECONDS));
+    }
+    
+    @Test
+    public void topologyRecoveryConsumerFailure() throws Exception {
+        final String queue = "topology-recovery-retry-consumer-failure" + System.currentTimeMillis();
+        channel.queueDeclare(queue, false, false, true, new HashMap<>());
+        channel.queueBind(queue, "amq.topic", "topic1");
+        channel.queueBind(queue, "amq.topic", "topic2");
+        final CountDownLatch messagesReceivedLatch = new CountDownLatch(2);
+        channel.basicConsume(queue, true, new DefaultConsumer(channel) {
+            @Override
+            public void handleDelivery(String consumerTag, Envelope envelope, BasicProperties properties, byte[] body) throws IOException {
+                System.out.println("Got message=" + new String(body));
+                messagesReceivedLatch.countDown();
+            }
+        });
+        final CountDownLatch recoveryLatch = new CountDownLatch(1);
+        ((AutorecoveringConnection)connection).addRecoveryListener(new RecoveryListener() {
+            @Override
+            public void handleRecoveryStarted(Recoverable recoverable) {
+                // no-op
+            }
+            @Override
+            public void handleRecovery(Recoverable recoverable) {
+                recoveryLatch.countDown();
+            }
+        });
+        
+        // we want recovery to fail when recovering the consumer
+        // give the recorded consumer a bad queue name so it fails
+        final RecordedConsumer consumer = ((AutorecoveringConnection)connection).getRecordedConsumers().values().iterator().next();
+        consumer.setQueue(UUID.randomUUID().toString());
+        
+        // use the backoffConsumer to know that it has failed
+        // then delete the real queue & fix the recorded consumer
+        // it should fail once more because queue is gone, and then succeed
+        final CountDownLatch backoffLatch = new CountDownLatch(1);
+        backoffConsumer = attempt -> {
+            consumer.setQueue(queue);
+            try {
+                Host.rabbitmqctl("delete_queue " + queue);
+                Thread.sleep(2000);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            backoffLatch.countDown();
+        };
+        
+        // close connection
+        Host.closeAllConnections();
+        
+        // assert backoff was called
+        assertTrue(backoffLatch.await(90, TimeUnit.SECONDS));
+        // wait for full recovery
+        assertTrue(recoveryLatch.await(90, TimeUnit.SECONDS));
+        
+        // publish messages to verify both bindings & consumer were recovered
+        basicPublishVolatile("test1".getBytes(), "amq.topic", "topic1");
+        basicPublishVolatile("test2".getBytes(), "amq.topic", "topic2");
+        
+        assertTrue(messagesReceivedLatch.await(10, TimeUnit.SECONDS));
+    }
 
     @Override
     protected ConnectionFactory newConnectionFactory() {
         ConnectionFactory connectionFactory = TestUtils.connectionFactory();
-        connectionFactory.setTopologyRecoveryRetryHandler(RETRY_ON_QUEUE_NOT_FOUND_RETRY_HANDLER.build());
+        connectionFactory.setTopologyRecoveryRetryHandler(RETRY_ON_QUEUE_NOT_FOUND_RETRY_HANDLER.backoffPolicy(attempt -> {
+            if (backoffConsumer != null) {
+                backoffConsumer.accept(attempt);
+            }
+        }).build());
         connectionFactory.setNetworkRecoveryInterval(1000);
         return connectionFactory;
     }


### PR DESCRIPTION
## Proposed Changes
When a binding recovery fails and retry logic kicks in, the code should recreate all of the bindings on the destination and not just the binding that failed.

For a queue with a large amount of bindings, its possible that some of the first binding recoveries succeeded, but then the queue got deleted and a later binding failed. In that scenario, we need to make sure all the earlier bindings that were already recovered are created as well.

Background: We hit this scenario on a cluster that had a large amount of queues and bindings. The queue in question had an expiry policy set on it that caused the queue to get deleted before all the binding recoveries had finished. The retry logic did its job and recreated the queue and the failed bindings. But we were silently missing the 1st set of bindings that had originally passed. We made a change to the policy to increase the expiry time so this scenario shouldn't happen again. But I thought it best to implement this fix as well.

## Types of Changes


- [ x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x ] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I believe these tests should work... However, I am on windows and had issues getting the Host.rabbitmqctl() pieces to work. So when running locally i commented those pieces out and manually dropped the connections and queues and the tests were passing that way.