### PR TITLE
Add topology recovery started method to RecoveryListener

### DIFF
--- a/src/main/java/com/rabbitmq/client/RecoveryListener.java
+++ b/src/main/java/com/rabbitmq/client/RecoveryListener.java
@@ -39,6 +39,8 @@ public interface RecoveryListener {
     
     /**
      * Invoked before automatic topology recovery starts.
+     * This means that the connection and channel recovery has completed 
+     * and that exchange/queue/binding/consumer recovery is about to begin.
      * @param recoverable a {@link Recoverable} connection.
      */
     default void handleTopologyRecoveryStarted(Recoverable recoverable) {}

--- a/src/main/java/com/rabbitmq/client/RecoveryListener.java
+++ b/src/main/java/com/rabbitmq/client/RecoveryListener.java
@@ -36,4 +36,10 @@ public interface RecoveryListener {
      * @param recoverable a {@link Recoverable} connection.
      */
     void handleRecoveryStarted(Recoverable recoverable);
+    
+    /**
+     * Invoked before automatic topology recovery starts.
+     * @param recoverable a {@link Recoverable} connection.
+     */
+    default void handleTopologyRecoveryStarted(Recoverable recoverable) {}
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -561,6 +561,10 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
 
     private synchronized void beginAutomaticRecovery() throws InterruptedException {
         this.wait(this.params.getRecoveryDelayHandler().getDelay(0));
+        final long delay = this.params.getRecoveryDelayHandler().getDelay(0);
+        if (delay > 0)  {
+            this.wait(delay);
+        }
 
         this.notifyRecoveryListenersStarted();
 
@@ -576,6 +580,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
 	    // don't assign new delegate connection until channel recovery is complete
 	    this.delegate = newConn;
 	    if (this.params.isTopologyRecoveryEnabled()) {
+	        notifyTopologyRecoveryListenersStarted();
 	        recoverTopology(params.getTopologyRecoveryExecutor());
 	    }
 		this.notifyRecoveryListenersComplete();
@@ -647,6 +652,12 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
     private void notifyRecoveryListenersStarted() {
         for (RecoveryListener f : Utility.copy(this.recoveryListeners)) {
             f.handleRecoveryStarted(this);
+        }
+    }
+    
+    private void notifyTopologyRecoveryListenersStarted() {
+        for (RecoveryListener f : Utility.copy(this.recoveryListeners)) {
+            f.handleTopologyRecoveryStarted(this);
         }
     }
     

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -560,7 +560,6 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
     }
 
     private synchronized void beginAutomaticRecovery() throws InterruptedException {
-        this.wait(this.params.getRecoveryDelayHandler().getDelay(0));
         final long delay = this.params.getRecoveryDelayHandler().getDelay(0);
         if (delay > 0)  {
             this.wait(delay);

--- a/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
+++ b/src/test/java/com/rabbitmq/client/test/functional/ConnectionRecovery.java
@@ -170,7 +170,7 @@ public class ConnectionRecovery extends BrokerTestCase {
     // see https://github.com/rabbitmq/rabbitmq-java-client/issues/135
     @Test public void thatShutdownHooksOnConnectionFireBeforeRecoveryStarts() throws IOException, InterruptedException {
         final List<String> events = new CopyOnWriteArrayList<String>();
-        final CountDownLatch latch = new CountDownLatch(2); // one when started, another when complete
+        final CountDownLatch latch = new CountDownLatch(3); // one when started, another when complete
         connection.addShutdownListener(new ShutdownListener() {
             @Override
             public void shutdownCompleted(ShutdownSignalException cause) {
@@ -200,6 +200,10 @@ public class ConnectionRecovery extends BrokerTestCase {
             }
             @Override
             public void handleRecoveryStarted(Recoverable recoverable) {
+                latch.countDown();
+            }
+            @Override
+            public void handleTopologyRecoveryStarted(Recoverable recoverable) {
                 latch.countDown();
             }
         });


### PR DESCRIPTION
## Proposed Changes

This adds a default method to the RecoveryListener interface that notifies the listener when connection & channel recovery is complete and that topology recovery is now starting.

Once the connection & channels have been recovered, it is safe for an application to start publishing messages again. For connections that have a lot of queues/bindings/consumers to recover, it can be useful for applications to know this intermediary state and not have to wait for all of the subscription related entities to be fully recovered.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
