### PR TITLE
Handle basic query parameters in connection URI

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -348,6 +348,11 @@ public class ConnectionFactory implements Cloneable {
 
             setVirtualHost(uriDecode(uri.getPath().substring(1)));
         }
+        
+        String rawQuery = uri.getRawQuery();
+        if (rawQuery != null && rawQuery.length() > 0) {
+            setQuery(rawQuery);
+        }
     }
 
     /**
@@ -374,6 +379,65 @@ public class ConnectionFactory implements Cloneable {
         }
         catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Convenience method for setting some fields from query parameters
+     * Will handle only a subset of the query parameters supported by the
+     * official erlang client
+     * https://www.rabbitmq.com/uri-query-parameters.html
+     * @param rawQuery is the string containing the raw query parameters part from a URI
+     */
+    private void setQuery(String rawQuery) {
+        Map<String, String> parameters = new HashMap<>();
+        
+        // parsing the query parameters
+        try {
+            for (String param : rawQuery.split("&")) {
+                String[] pair = param.split("=");
+                String key = URLDecoder.decode(pair[0], "US-ASCII");
+                String value = null;
+                if (pair.length > 1) {
+                    value = URLDecoder.decode(pair[1], "US-ASCII");
+                }
+                parameters.put(key, value);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot parse the query parameters", e);
+        }
+
+        // heartbeat
+        String heartbeat = parameters.get("heartbeat");
+        if (heartbeat != null) {
+            try {
+                int heartbeatInt = Integer.parseInt(heartbeat);
+                setRequestedHeartbeat(heartbeatInt);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Requested heartbeat must an integer");
+            }
+        }
+        
+        // connection_timeout
+        String connectionTimeout = parameters.get("connection_timeout");
+        if (connectionTimeout != null) {
+            try {
+                int connectionTimeoutInt = Integer.parseInt(connectionTimeout);
+                setConnectionTimeout(connectionTimeoutInt);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("TCP connection timeout must an integer");
+            }
+        }
+        
+        // channel_max
+        String channelMax = parameters.get("channel_max");
+        if (channelMax != null) {
+            try {
+                int channelMaxInt = Integer.parseInt(channelMax);
+                setRequestedChannelMax(channelMaxInt);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Requested channel max must an integer");
+            }
         }
     }
 

--- a/src/test/java/com/rabbitmq/client/test/AmqpUriTest.java
+++ b/src/test/java/com/rabbitmq/client/test/AmqpUriTest.java
@@ -32,35 +32,63 @@ public class AmqpUriTest extends BrokerTestCase
     {
         /* From the spec (subset of the tests) */
         parseSuccess("amqp://user:pass@host:10000/vhost",
-                     "user", "pass", "host", 10000, "vhost");
+                     "user", "pass", "host", 10000, "vhost", false);
         parseSuccess("aMQps://user%61:%61pass@host:10000/v%2fhost",
-                     "usera", "apass", "host", 10000, "v/host");
-        parseSuccess("amqp://host", "guest", "guest", "host", 5672, "/");
+                     "usera", "apass", "host", 10000, "v/host", true);
+        parseSuccess("amqp://host", "guest", "guest", "host", 5672, "/", false);
         parseSuccess("amqp:///vhost",
-                     "guest", "guest", "localhost", 5672, "vhost");
-        parseSuccess("amqp://host/", "guest", "guest", "host", 5672, "");
-        parseSuccess("amqp://host/%2f", "guest", "guest", "host", 5672, "/");
-        parseSuccess("amqp://[::1]", "guest", "guest", "[::1]", 5672, "/");
+                     "guest", "guest", "localhost", 5672, "vhost", false);
+        parseSuccess("amqp://host/", "guest", "guest", "host", 5672, "", false);
+        parseSuccess("amqp://host/%2f", "guest", "guest", "host", 5672, "/", false);
+        parseSuccess("amqp://[::1]", "guest", "guest", "[::1]", 5672, "/", false);
 
         /* Various other success cases */
-        parseSuccess("amqp://host:100", "guest", "guest", "host", 100, "/");
-        parseSuccess("amqp://[::1]:100", "guest", "guest", "[::1]", 100, "/");
+        parseSuccess("amqp://host:100", "guest", "guest", "host", 100, "/", false);
+        parseSuccess("amqp://[::1]:100", "guest", "guest", "[::1]", 100, "/", false);
 
         parseSuccess("amqp://host/blah",
-                     "guest", "guest", "host", 5672, "blah");
+                     "guest", "guest", "host", 5672, "blah", false);
         parseSuccess("amqp://host:100/blah",
-                     "guest", "guest", "host", 100, "blah");
+                     "guest", "guest", "host", 100, "blah", false);
         parseSuccess("amqp://[::1]/blah",
-                     "guest", "guest", "[::1]", 5672, "blah");
+                     "guest", "guest", "[::1]", 5672, "blah", false);
         parseSuccess("amqp://[::1]:100/blah",
-                     "guest", "guest", "[::1]", 100, "blah");
+                     "guest", "guest", "[::1]", 100, "blah", false);
 
         parseSuccess("amqp://user:pass@host",
-                     "user", "pass", "host", 5672, "/");
+                     "user", "pass", "host", 5672, "/", false);
         parseSuccess("amqp://user:pass@[::1]",
-                     "user", "pass", "[::1]", 5672, "/");
+                     "user", "pass", "[::1]", 5672, "/", false);
         parseSuccess("amqp://user:pass@[::1]:100",
-                     "user", "pass", "[::1]", 100, "/");
+                     "user", "pass", "[::1]", 100, "/", false);
+
+        /* using query parameters */
+        parseSuccess("amqp://user:pass@host:10000/vhost?",
+                     "user", "pass", "host", 10000, "vhost", false);
+        parseSuccess("amqp://user:pass@host:10000/vhost?&",
+                     "user", "pass", "host", 10000, "vhost", false);
+        parseSuccess("amqp://user:pass@host:10000/vhost?unknown_parameter",
+                     "user", "pass", "host", 10000, "vhost", false);
+        parseSuccess("amqp://user:pass@host:10000/vhost?unknown_parameter=value",
+                     "user", "pass", "host", 10000, "vhost", false);
+        parseSuccess("amqp://user:pass@host:10000/vhost?unknown%2fparameter=value",
+                     "user", "pass", "host", 10000, "vhost", false);
+
+        parseSuccess("amqp://user:pass@host:10000/vhost?heartbeat=342",
+                     "user", "pass", "host", 10000, "vhost", false,
+                     342, null, null);
+        parseSuccess("amqp://user:pass@host:10000/vhost?connection_timeout=442",
+                     "user", "pass", "host", 10000, "vhost", false,
+                     null, 442, null);
+        parseSuccess("amqp://user:pass@host:10000/vhost?channel_max=542",
+                     "user", "pass", "host", 10000, "vhost", false,
+                     null, null, 542);
+        parseSuccess("amqp://user:pass@host:10000/vhost?heartbeat=342&connection_timeout=442&channel_max=542",
+                     "user", "pass", "host", 10000, "vhost", false,
+                     342, 442, 542);
+        parseSuccess("amqp://user:pass@host:10000/vhost?heartbeat=342&connection_timeout=442&channel_max=542&a=b",
+                     "user", "pass", "host", 10000, "vhost", false,
+                     342, 442, 542);
 
         /* Various failure cases */
         parseFail("https://www.rabbitmq.com");
@@ -71,10 +99,26 @@ public class AmqpUriTest extends BrokerTestCase
         parseFail("amqp://foo%1");
         parseFail("amqp://foo%1x");
         parseFail("amqp://foo%xy");
+
+        parseFail("amqp://user:pass@host:10000/vhost?heartbeat=not_an_integer");
+        parseFail("amqp://user:pass@host:10000/vhost?heartbeat=-1");
+        parseFail("amqp://user:pass@host:10000/vhost?connection_timeout=not_an_integer");
+        parseFail("amqp://user:pass@host:10000/vhost?connection_timeout=-1");
+        parseFail("amqp://user:pass@host:10000/vhost?channel_max=not_an_integer");
+        parseFail("amqp://user:pass@host:10000/vhost?channel_max=-1");
+        parseFail("amqp://user:pass@host:10000/vhost?heartbeat=342?connection_timeout=442");
     }
 
     private void parseSuccess(String uri, String user, String password,
-                              String host, int port, String vhost)
+                              String host, int port, String vhost, boolean secured)
+        throws URISyntaxException, NoSuchAlgorithmException, KeyManagementException
+    {
+        parseSuccess(uri, user, password, host, port, vhost, secured, null, null, null);
+    }
+
+    private void parseSuccess(String uri, String user, String password,
+                              String host, int port, String vhost, boolean secured,
+                              Integer heartbeat, Integer connectionTimeout, Integer channelMax)
         throws URISyntaxException, NoSuchAlgorithmException, KeyManagementException
     {
         ConnectionFactory cf = TestUtils.connectionFactory();
@@ -85,6 +129,17 @@ public class AmqpUriTest extends BrokerTestCase
         assertEquals(host, cf.getHost());
         assertEquals(port, cf.getPort());
         assertEquals(vhost, cf.getVirtualHost());
+        assertEquals(secured, cf.isSSL());
+        
+        if(heartbeat != null) {
+            assertEquals(heartbeat.intValue(), cf.getRequestedHeartbeat());
+        }
+        if(connectionTimeout != null) {
+            assertEquals(connectionTimeout.intValue(), cf.getConnectionTimeout());
+        }
+        if(channelMax != null) {
+            assertEquals(channelMax.intValue(), cf.getRequestedChannelMax());
+        }
     }
 
     private void parseFail(String uri) {


### PR DESCRIPTION
## Proposed Changes

The current connection method `setUri()` does not handle query parameters at all, unlike the official Erlang client.
This pull request adds basic query parameters capabilities.
However, due to SSL handling differences between the Erlang client and the Java client, all SSL parameters are not used.
Only the following parameters are used:

- heartbeat : Heartbeat timeout value in seconds (an integer) to negotiate with the server.
- connection_timeout : Time in milliseconds (an integer) to wait while establishing a TCP connection to the server before giving up.
- channel_max : Maximum number of channels to permit on this connection.

(taken from https://www.rabbitmq.com/uri-query-parameters.html)

It is easily extendable for other future query parameters.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
