### PR TITLE
Recovery related improvements

### DIFF
--- a/src/main/java/com/rabbitmq/client/TopologyRecoveryException.java
+++ b/src/main/java/com/rabbitmq/client/TopologyRecoveryException.java
@@ -15,6 +15,8 @@
 
 package com.rabbitmq.client;
 
+import com.rabbitmq.client.impl.recovery.RecordedEntity;
+
 /**
  * Indicates an exception thrown during topology recovery.
  *
@@ -22,7 +24,19 @@ package com.rabbitmq.client;
  * @since 3.3.0
  */
 public class TopologyRecoveryException extends Exception {
+    
+    private final RecordedEntity recordedEntity;
+    
     public TopologyRecoveryException(String message, Throwable cause) {
+        this(message, cause, null);
+    }
+    
+    public TopologyRecoveryException(String message, Throwable cause, final RecordedEntity recordedEntity) {
         super(message, cause);
+        this.recordedEntity = recordedEntity;
+    }
+    
+    public RecordedEntity getRecordedEntity() {
+        return recordedEntity;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
@@ -900,7 +900,11 @@ public class AutorecoveringChannel implements RecoverableChannel {
         this.connection.recordConsumer(result, consumer);
     }
 
-    private void deleteRecordedConsumer(String consumerTag) {
+    /**
+     * Delete the recorded consumer from this channel and accompanying connection
+     * @param consumerTag consumer tag to delete
+     */
+    public void deleteRecordedConsumer(String consumerTag) {
         this.consumerTags.remove(consumerTag);
         RecordedConsumer c = this.connection.deleteRecordedConsumer(consumerTag);
         if (c != null) {

--- a/src/main/java/com/rabbitmq/client/impl/recovery/DefaultRetryHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/DefaultRetryHandler.java
@@ -40,19 +40,19 @@ public class DefaultRetryHandler implements RetryHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRetryHandler.class);
 
-    private final BiPredicate<? super RecordedQueue, Exception> queueRecoveryRetryCondition;
-    private final BiPredicate<? super RecordedExchange, Exception> exchangeRecoveryRetryCondition;
-    private final BiPredicate<? super RecordedBinding, Exception> bindingRecoveryRetryCondition;
-    private final BiPredicate<? super RecordedConsumer, Exception> consumerRecoveryRetryCondition;
+    protected final BiPredicate<? super RecordedQueue, Exception> queueRecoveryRetryCondition;
+    protected final BiPredicate<? super RecordedExchange, Exception> exchangeRecoveryRetryCondition;
+    protected final BiPredicate<? super RecordedBinding, Exception> bindingRecoveryRetryCondition;
+    protected final BiPredicate<? super RecordedConsumer, Exception> consumerRecoveryRetryCondition;
 
-    private final RetryOperation<?> queueRecoveryRetryOperation;
-    private final RetryOperation<?> exchangeRecoveryRetryOperation;
-    private final RetryOperation<?> bindingRecoveryRetryOperation;
-    private final RetryOperation<?> consumerRecoveryRetryOperation;
+    protected final RetryOperation<?> queueRecoveryRetryOperation;
+    protected final RetryOperation<?> exchangeRecoveryRetryOperation;
+    protected final RetryOperation<?> bindingRecoveryRetryOperation;
+    protected final RetryOperation<?> consumerRecoveryRetryOperation;
 
-    private final int retryAttempts;
+    protected final int retryAttempts;
 
-    private final BackoffPolicy backoffPolicy;
+    protected final BackoffPolicy backoffPolicy;
 
     public DefaultRetryHandler(BiPredicate<? super RecordedQueue, Exception> queueRecoveryRetryCondition,
         BiPredicate<? super RecordedExchange, Exception> exchangeRecoveryRetryCondition,

--- a/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryHandlerBuilder.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryHandlerBuilder.java
@@ -30,19 +30,19 @@ import java.util.function.BiPredicate;
  */
 public class TopologyRecoveryRetryHandlerBuilder {
 
-    private BiPredicate<? super RecordedQueue, Exception> queueRecoveryRetryCondition = (q, e) -> false;
-    private BiPredicate<? super RecordedExchange, Exception> exchangeRecoveryRetryCondition = (ex, e) -> false;
-    private BiPredicate<? super RecordedBinding, Exception> bindingRecoveryRetryCondition = (b, e) -> false;
-    private BiPredicate<? super RecordedConsumer, Exception> consumerRecoveryRetryCondition = (c, e) -> false;
+    protected BiPredicate<? super RecordedQueue, Exception> queueRecoveryRetryCondition = (q, e) -> false;
+    protected BiPredicate<? super RecordedExchange, Exception> exchangeRecoveryRetryCondition = (ex, e) -> false;
+    protected BiPredicate<? super RecordedBinding, Exception> bindingRecoveryRetryCondition = (b, e) -> false;
+    protected BiPredicate<? super RecordedConsumer, Exception> consumerRecoveryRetryCondition = (c, e) -> false;
 
-    private DefaultRetryHandler.RetryOperation<?> queueRecoveryRetryOperation = context -> null;
-    private DefaultRetryHandler.RetryOperation<?> exchangeRecoveryRetryOperation = context -> null;
-    private DefaultRetryHandler.RetryOperation<?> bindingRecoveryRetryOperation = context -> null;
-    private DefaultRetryHandler.RetryOperation<?> consumerRecoveryRetryOperation = context -> null;
+    protected DefaultRetryHandler.RetryOperation<?> queueRecoveryRetryOperation = context -> null;
+    protected DefaultRetryHandler.RetryOperation<?> exchangeRecoveryRetryOperation = context -> null;
+    protected DefaultRetryHandler.RetryOperation<?> bindingRecoveryRetryOperation = context -> null;
+    protected DefaultRetryHandler.RetryOperation<?> consumerRecoveryRetryOperation = context -> null;
 
-    private int retryAttempts = 2;
+    protected int retryAttempts = 2;
 
-    private BackoffPolicy backoffPolicy = nbAttempts -> {
+    protected BackoffPolicy backoffPolicy = nbAttempts -> {
     };
 
     public static TopologyRecoveryRetryHandlerBuilder builder() {


### PR DESCRIPTION
## Proposed Changes

Quality of life improvements to topology recovery to make it easier for consumers to extend the existing recovery retry logic or build their own.

This adds the RecordedEntity to the TopologyRecoveryException and then exposes a method on AutorecoveringConnection to recover a channel and any recorded entities that are tied to that channel. The thought being that I can capture all of the recorded entities and the associated channels that failed via ExceptionHandler.handleTopologyRecoveryException(). And then after the amqp-client's auto-recovery is complete, build my own logic to retry recovery on each channel again via AutorecoveringConnection.recoverChannelAndTopology().

The existing topology recovery retry design works pretty well, but has some holes with how we are using it.
For example:
1) successfully recover multiple auto-delete exchanges for a channel
2) successfully recover multiple auto-delete queues on same channel (that are bound to the exchanges in step 1)
3) fail to recover a later queue, binding, or consumer on same channel

In this scenario, the TopologyRecoveryRetryLogic recovers the queue/binding/consumer that failed, but isn't handling any upstream exchanges and exchange bindings on the queue in question that were deleted when the auto-delete queue was.

I considered trying address this scenario in the existing TopologyRecoveryRetryLogic patterns, but it feels safer and cleaner to take a different approach where I just always recover all entities tied to the failed channel.


The new AutorecoveringConnection.recoverChannelAndTopology() method is also useful for scenarios where a channel is closed that may not be tied to a connection failure.


Background of what drove these changes:
During RabbitMQ cluster restarts or upgrade in TAS, we have been struggling with high counts of errors such as:

```
channel error; protocol method: #method<channel.close>(reply-code=404, reply-text=NOT_FOUND - queue '<queue>' in vhost '<vhost>' process is stopped by supervisor, class-id=50, method-id=10)
```
during recovery of auto-delete queues (and their bindings/consumers). (We have a support ticket currently open with Pivotal for this). We are using the existing recovery retry logic to help address, but sometimes it will fail 5+ times (with multiple second sleeps in between) before finally succeeding.

Longer term, we plan on evaluating no longer using auto-delete queues, and instead preferring manual deletion and an expiry policy to cleanup abandoned ones.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
