### PR TITLE
consumer recovery retry needs to return the new consumer tag

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryLogic.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/TopologyRecoveryRetryLogic.java
@@ -165,10 +165,11 @@ public abstract class TopologyRecoveryRetryLogic {
                 } else if (consumer.getChannel() == channel) {
                     final RetryContext retryContext = new RetryContext(consumer, context.exception(), context.connection());
                     RECOVER_CONSUMER_QUEUE.call(retryContext);
-                    consumer.recover();
+                    context.connection().recoverConsumer(consumer.getConsumerTag(), consumer, false);
                     RECOVER_CONSUMER_QUEUE_BINDINGS.call(retryContext);
                 }
             }
+            return context.consumer().getConsumerTag();
         }
         return null;
     };


### PR DESCRIPTION
## Proposed Changes

The consumerRecoveryRetryOperation needs to make sure it is returning the new consumerTag so that it can get updated in AutorecoveringConnection.recoverConsumer(). This was previously not working as the last item in the chain (i.e. RECOVER_CONSUMER_QUEUE_BINDINGS) was always returning null. My previous PR that added RECOVER_PREVIOUS_CONSUMERS had the same issue. This should fix that.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
