### PR TITLE
fix typo in ForgivingExceptionHandler.java

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/ForgivingExceptionHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/ForgivingExceptionHandler.java
@@ -33,7 +33,7 @@ import java.net.ConnectException;
 public class ForgivingExceptionHandler implements ExceptionHandler {
     @Override
     public void handleUnexpectedConnectionDriverException(Connection conn, Throwable exception) {
-        log("An unexpected connection driver error occured", exception);
+        log("An unexpected connection driver error occurred", exception);
     }
 
     @Override


### PR DESCRIPTION
fix a minor typo

## Proposed Changes

there is a minor typo in ForgivingExceptionHandler.java which is a bit irritating to read in application logs.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ x] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ x] I have read the `CONTRIBUTING.md` document
- [ x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
