### PR TITLE
Added option to maintain AddressResolver address order for AutoRecove…

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -126,6 +126,7 @@ public class ConnectionFactory implements Cloneable {
     private boolean automaticRecovery               = true;
     private boolean topologyRecovery                = true;
     private ExecutorService topologyRecoveryExecutor;
+    private boolean maintainAddressOrder;
     
     // long is used to make sure the users can use both ints
     // and longs safely. It is unlikely that anybody'd need
@@ -197,6 +198,8 @@ public class ConnectionFactory implements Cloneable {
     private TrafficListener trafficListener = TrafficListener.NO_OP;
 
     private CredentialsRefreshService credentialsRefreshService;
+
+
 
     /** @return the default host to use for connections */
     public String getHost() {
@@ -1263,6 +1266,7 @@ public class ConnectionFactory implements Cloneable {
         result.setTopologyRecoveryRetryHandler(topologyRecoveryRetryHandler);
         result.setTrafficListener(trafficListener);
         result.setCredentialsRefreshService(credentialsRefreshService);
+        result.setMaintainAddressOrder(maintainAddressOrder);
         return result;
     }
 
@@ -1652,5 +1656,18 @@ public class ConnectionFactory implements Cloneable {
      */
     public void setTrafficListener(TrafficListener trafficListener) {
         this.trafficListener = trafficListener;
+    }
+
+    /**
+     * Set to true in order to maintain the order of Addresses when setting automaticRecovery=true
+     * Default is false and automatic shuffling.
+     * @param maintainAddressOrder
+     */
+    public void setMaintainAddressOrder(boolean maintainAddressOrder) {
+        this.maintainAddressOrder = maintainAddressOrder;
+    }
+
+    public boolean shouldMaintainAddressOrder() {
+        return this.maintainAddressOrder;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -49,6 +49,7 @@ public class ConnectionParams {
     private ExecutorService topologyRecoveryExecutor;
     private int channelRpcTimeout;
     private boolean channelShouldCheckRpcResponseType;
+    private boolean maintainAddressOrder;
     private ErrorOnWriteListener errorOnWriteListener;
     private int workPoolTimeout = -1;
     private TopologyRecoveryFilter topologyRecoveryFilter;
@@ -286,5 +287,13 @@ public class ConnectionParams {
 
     public CredentialsRefreshService getCredentialsRefreshService() {
         return credentialsRefreshService;
+    }
+
+    public boolean shouldMaintainAddressOrder() {
+        return maintainAddressOrder;
+    }
+
+    public void setMaintainAddressOrder(boolean maintainAddressOrder) {
+        this.maintainAddressOrder = maintainAddressOrder;
     }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnectionFactory.java
@@ -55,7 +55,8 @@ public class RecoveryAwareAMQConnectionFactory {
     // package protected API, made public for testing only
     public RecoveryAwareAMQConnection newConnection() throws IOException, TimeoutException {
         Exception lastException = null;
-        List<Address> shuffled = shuffle(addressResolver.getAddresses());
+        List<Address> originalOrder = addressResolver.getAddresses();
+        List<Address> shuffled = params.shouldMaintainAddressOrder() ? originalOrder : shuffle(originalOrder);
 
         for (Address addr : shuffled) {
             try {


### PR DESCRIPTION
Allows the option to maintain the address order from the address resolver when using an auto recoverable connection.  The default behavior is unchanged. This pull request is for the issue https://github.com/rabbitmq/rabbitmq-java-client/issues/689