### PR TITLE
Move resolved address shuffling to AddressResolver

### DIFF
--- a/src/main/java/com/rabbitmq/client/AddressResolver.java
+++ b/src/main/java/com/rabbitmq/client/AddressResolver.java
@@ -16,6 +16,8 @@
 package com.rabbitmq.client;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -30,4 +32,9 @@ public interface AddressResolver {
      */
     List<Address> getAddresses() throws IOException;
 
+    default List<Address> maybeShuffle(List<Address> input) {
+        List<Address> list = new ArrayList<Address>(input);
+        Collections.shuffle(list);
+        return list;
+    }
 }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareAMQConnectionFactory.java
@@ -55,7 +55,8 @@ public class RecoveryAwareAMQConnectionFactory {
     // package protected API, made public for testing only
     public RecoveryAwareAMQConnection newConnection() throws IOException, TimeoutException {
         Exception lastException = null;
-        List<Address> shuffled = shuffle(addressResolver.getAddresses());
+        List<Address> resolved = addressResolver.getAddresses();
+        List<Address> shuffled = addressResolver.maybeShuffle(resolved);
 
         for (Address addr : shuffled) {
             try {


### PR DESCRIPTION
so that it can be overridden by implementations, e.g. to perform
no shuffling at all.

References #690.
