### PR TITLE
Allow changing queue names during recovery

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -19,6 +19,7 @@ import com.rabbitmq.client.impl.*;
 import com.rabbitmq.client.impl.nio.NioParams;
 import com.rabbitmq.client.impl.nio.SocketChannelFrameHandlerFactory;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
+import com.rabbitmq.client.impl.recovery.RecoveredQueueNameSupplier;
 import com.rabbitmq.client.impl.recovery.RetryHandler;
 import com.rabbitmq.client.impl.recovery.TopologyRecoveryFilter;
 import org.slf4j.Logger;
@@ -190,6 +191,8 @@ public class ConnectionFactory implements Cloneable {
      * @since 5.4.0
      */
     private RetryHandler topologyRecoveryRetryHandler;
+    
+    private RecoveredQueueNameSupplier recoveredQueueNameSupplier;
 
     /**
      * Traffic listener notified of inbound and outbound {@link Command}s.
@@ -1267,6 +1270,7 @@ public class ConnectionFactory implements Cloneable {
         result.setTopologyRecoveryFilter(topologyRecoveryFilter);
         result.setConnectionRecoveryTriggeringCondition(connectionRecoveryTriggeringCondition);
         result.setTopologyRecoveryRetryHandler(topologyRecoveryRetryHandler);
+        result.setRecoveredQueueNameSupplier(recoveredQueueNameSupplier);
         result.setTrafficListener(trafficListener);
         result.setCredentialsRefreshService(credentialsRefreshService);
         return result;
@@ -1647,6 +1651,15 @@ public class ConnectionFactory implements Cloneable {
      */
     public void setTopologyRecoveryRetryHandler(RetryHandler topologyRecoveryRetryHandler) {
         this.topologyRecoveryRetryHandler = topologyRecoveryRetryHandler;
+    }
+    
+    /**
+     * Set the recovered queue name supplier. Default is use the same queue name when recovering queues.
+     * 
+     * @param recoveredQueueNameSupplier queue name supplier
+     */
+    public void setRecoveredQueueNameSupplier(RecoveredQueueNameSupplier recoveredQueueNameSupplier) {
+        this.recoveredQueueNameSupplier = recoveredQueueNameSupplier;
     }
 
     /**

--- a/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/client/impl/ConnectionParams.java
@@ -21,6 +21,7 @@ import com.rabbitmq.client.RecoveryDelayHandler.DefaultRecoveryDelayHandler;
 import com.rabbitmq.client.SaslConfig;
 import com.rabbitmq.client.ShutdownSignalException;
 import com.rabbitmq.client.TrafficListener;
+import com.rabbitmq.client.impl.recovery.RecoveredQueueNameSupplier;
 import com.rabbitmq.client.impl.recovery.RetryHandler;
 import com.rabbitmq.client.impl.recovery.TopologyRecoveryFilter;
 
@@ -54,7 +55,8 @@ public class ConnectionParams {
     private TopologyRecoveryFilter topologyRecoveryFilter;
     private Predicate<ShutdownSignalException> connectionRecoveryTriggeringCondition;
     private RetryHandler topologyRecoveryRetryHandler;
-
+    private RecoveredQueueNameSupplier recoveredQueueNameSupplier;
+    
     private ExceptionHandler exceptionHandler;
     private ThreadFactory threadFactory;
 
@@ -270,6 +272,14 @@ public class ConnectionParams {
 
     public RetryHandler getTopologyRecoveryRetryHandler() {
         return topologyRecoveryRetryHandler;
+    }
+    
+    public void setRecoveredQueueNameSupplier(RecoveredQueueNameSupplier recoveredQueueNameSupplier) {
+        this.recoveredQueueNameSupplier = recoveredQueueNameSupplier;
+    }
+
+    public RecoveredQueueNameSupplier getRecoveredQueueNameSupplier() {
+        return recoveredQueueNameSupplier;
     }
 
     public void setTrafficListener(TrafficListener trafficListener) {

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannel.java
@@ -355,7 +355,8 @@ public class AutorecoveringChannel implements RecoverableChannel {
             durable(durable).
             exclusive(exclusive).
             autoDelete(autoDelete).
-            arguments(arguments);
+            arguments(arguments).
+            recoveredQueueNameSupplier(connection.getRecoveredQueueNameSupplier());
         delegate.queueDeclareNoWait(queue, durable, exclusive, autoDelete, arguments);
         recordQueue(queue, meta);
 
@@ -848,7 +849,8 @@ public class AutorecoveringChannel implements RecoverableChannel {
                 durable(durable).
                 exclusive(exclusive).
                 autoDelete(autoDelete).
-                arguments(arguments);
+                arguments(arguments).
+                recoveredQueueNameSupplier(connection.getRecoveredQueueNameSupplier());
         if (queue.equals(RecordedQueue.EMPTY_STRING)) {
             q.serverNamed(true);
         }

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueue.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecordedQueue.java
@@ -23,6 +23,10 @@ import java.util.Map;
  */
 public class RecordedQueue extends RecordedNamedEntity {
     public static final String EMPTY_STRING = "";
+    
+    static final RecoveredQueueNameSupplier DEFAULT_QUEUE_NAME_SUPPLIER = q -> q.isServerNamed() ? EMPTY_STRING : q.name;
+    
+    private RecoveredQueueNameSupplier recoveredQueueNameSupplier = DEFAULT_QUEUE_NAME_SUPPLIER;
     private boolean durable;
     private boolean autoDelete;
     private Map<String, Object> arguments;
@@ -58,11 +62,7 @@ public class RecordedQueue extends RecordedNamedEntity {
     }
 
     public String getNameToUseForRecovery() {
-        if(isServerNamed()) {
-            return EMPTY_STRING;
-        } else {
-            return this.name;
-        }
+        return recoveredQueueNameSupplier.getNameToUseForRecovery(this);
     }
 
     public RecordedQueue durable(boolean value) {
@@ -77,6 +77,11 @@ public class RecordedQueue extends RecordedNamedEntity {
 
     public RecordedQueue arguments(Map<String, Object> value) {
         this.arguments = value;
+        return this;
+    }
+    
+    public RecordedQueue recoveredQueueNameSupplier(RecoveredQueueNameSupplier recoveredQueueNameSupplier) {
+        this.recoveredQueueNameSupplier = recoveredQueueNameSupplier;
         return this;
     }
     

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecoveredQueueNameSupplier.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecoveredQueueNameSupplier.java
@@ -1,0 +1,18 @@
+package com.rabbitmq.client.impl.recovery;
+
+/**
+ * Functional callback interface that can be used to rename a queue during topology recovery.
+ * Can use along with {@link QueueRecoveryListener} to know when such a queue has been recovered successfully.
+ * 
+ * @see QueueRecoveryListener
+ */
+@FunctionalInterface
+public interface RecoveredQueueNameSupplier {
+
+    /**
+     * Get the queue name to use when recovering this RecordedQueue entity
+     * @param recordedQueue the queue to be recovered
+     * @return new queue name
+     */
+    String getNameToUseForRecovery(final RecordedQueue recordedQueue);
+}


### PR DESCRIPTION
## Proposed Changes

Allow a consumer to register a callback to change the name of a queue during recovery. This is useful when dealing with transient and auto-delete queues that are susceptible to 404 NOT_FOUND client recovery errors and binding corruption issues during cluster node cycles/upgrades. When a client reconnects and redeclares the queue, we expose a timing issue due to the server trying to cleanup the queue at the same time the client is coming back to redeclare it.

The easy existing alternative is to use server named queues. However, with that consumers have no ability to provide a useful queue name that makes it easy to tell what application a queue belongs too from a monitoring/troubleshooting perspective.

This enhancement allows for applications to still name queues in meaningful ways, but to then support modifying that name during a recovery to avoid the timing issues described above.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

