### PR TITLE
Fix handshake with NIO on TLS 1.3

### DIFF
--- a/src/test/java/com/rabbitmq/client/test/BrokerTestCase.java
+++ b/src/test/java/com/rabbitmq/client/test/BrokerTestCase.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -28,9 +28,7 @@ import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
@@ -348,7 +346,4 @@ public class BrokerTestCase {
         return "exchange" + UUID.randomUUID().toString();
     }
 
-    protected SSLContext getSSLContext() throws NoSuchAlgorithmException {
-        return TestUtils.getSSLContext();
-    }
 }

--- a/src/test/java/com/rabbitmq/client/test/ssl/BadVerifiedConnection.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/BadVerifiedConnection.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -15,20 +15,13 @@
 
 package com.rabbitmq.client.test.ssl;
 
-import com.rabbitmq.client.test.TestUtils;
 import org.junit.Test;
 
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.security.*;
-import java.security.cert.CertificateException;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -39,44 +32,10 @@ public class BadVerifiedConnection extends UnverifiedConnection {
     public void openConnection()
             throws IOException, TimeoutException {
         try {
-            String keystorePath = System.getProperty("test-keystore.empty");
-            assertNotNull(keystorePath);
-            String keystorePasswd = System.getProperty("test-keystore.password");
-            assertNotNull(keystorePasswd);
-            char [] keystorePassword = keystorePasswd.toCharArray();
-
-            KeyStore tks = KeyStore.getInstance("JKS");
-            tks.load(new FileInputStream(keystorePath), keystorePassword);
-
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
-            tmf.init(tks);
-
-            String p12Path = System.getProperty("test-client-cert.path");
-            assertNotNull(p12Path);
-            String p12Passwd = System.getProperty("test-client-cert.password");
-            assertNotNull(p12Passwd);
-            KeyStore ks = KeyStore.getInstance("PKCS12");
-            char [] p12Password = p12Passwd.toCharArray();
-            ks.load(new FileInputStream(p12Path), p12Password);
-
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-            kmf.init(ks, p12Password);
-            
-            SSLContext c = getSSLContext();
-            c.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
-
-            connectionFactory = TestUtils.connectionFactory();
+            SSLContext c = TlsTestUtils.badVerifiedSslContext();
             connectionFactory.useSslProtocol(c);
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IOException(ex.toString());
-        } catch (KeyManagementException ex) {
-            throw new IOException(ex.toString());
-        } catch (KeyStoreException ex) {
-            throw new IOException(ex.toString());
-        } catch (CertificateException ex) {
-            throw new IOException(ex.toString());
-        } catch (UnrecoverableKeyException ex) {
-            throw new IOException(ex.toString());
+        } catch (Exception ex) {
+            throw new IOException(ex);
         }
 
         try {

--- a/src/test/java/com/rabbitmq/client/test/ssl/HostnameVerification.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/HostnameVerification.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -24,17 +24,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.FileInputStream;
-import java.security.KeyStore;
 import java.util.function.Consumer;
 
-import static com.rabbitmq.client.test.TestUtils.getSSLContext;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -73,32 +67,7 @@ public class HostnameVerification {
 
     @BeforeClass
     public static void initCrypto() throws Exception {
-        String keystorePath = System.getProperty("test-keystore.ca");
-        assertNotNull(keystorePath);
-        String keystorePasswd = System.getProperty("test-keystore.password");
-        assertNotNull(keystorePasswd);
-        char[] keystorePassword = keystorePasswd.toCharArray();
-
-        KeyStore tks = KeyStore.getInstance("JKS");
-        tks.load(new FileInputStream(keystorePath), keystorePassword);
-
-        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
-        tmf.init(tks);
-
-        String p12Path = System.getProperty("test-client-cert.path");
-        assertNotNull(p12Path);
-        String p12Passwd = System.getProperty("test-client-cert.password");
-        assertNotNull(p12Passwd);
-
-        KeyStore ks = KeyStore.getInstance("PKCS12");
-        char[] p12Password = p12Passwd.toCharArray();
-        ks.load(new FileInputStream(p12Path), p12Password);
-
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-        kmf.init(ks, p12Password);
-
-        sslContext = getSSLContext();
-        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        sslContext = TlsTestUtils.verifiedSslContext();
     }
 
     @Test(expected = SSLHandshakeException.class)

--- a/src/test/java/com/rabbitmq/client/test/ssl/TlsConnectionLogging.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/TlsConnectionLogging.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2019-2021 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -65,7 +65,7 @@ public class TlsConnectionLogging {
 
     @Test
     public void certificateInfoAreProperlyExtracted() throws Exception {
-        SSLContext sslContext = TestUtils.getSSLContext();
+        SSLContext sslContext = TlsTestUtils.getSSLContext();
         sslContext.init(null, new TrustManager[]{new AlwaysTrustTrustManager()}, null);
         ConnectionFactory connectionFactory = TestUtils.connectionFactory();
         connectionFactory.useSslProtocol(sslContext);

--- a/src/test/java/com/rabbitmq/client/test/ssl/TlsTestUtils.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/TlsTestUtils.java
@@ -1,0 +1,115 @@
+// Copyright (c) 2021 VMware, Inc. or its affiliates.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.client.test.ssl;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+class TlsTestUtils {
+
+  private TlsTestUtils() {}
+
+  static SSLContext badVerifiedSslContext() throws Exception {
+    return verifiedSslContext(() -> getSSLContext(), emptyKeystoreCa());
+  }
+
+  static SSLContext verifiedSslContext() throws Exception {
+    return verifiedSslContext(() -> getSSLContext(), keystoreCa());
+  }
+
+  static SSLContext verifiedSslContext(CallableSupplier<SSLContext> sslContextSupplier) throws Exception {
+    return verifiedSslContext(sslContextSupplier, keystoreCa());
+  }
+
+  static SSLContext verifiedSslContext(CallableSupplier<SSLContext> sslContextSupplier, String keystorePath) throws Exception {
+    // for local testing, run ./mvnw test-compile -Dtest-tls-certs.dir=/tmp/tls-gen/basic
+    // (generates the Java keystores)
+    assertNotNull(keystorePath);
+    String keystorePasswd = keystorePassword();
+    assertNotNull(keystorePasswd);
+    char [] keystorePassword = keystorePasswd.toCharArray();
+
+    KeyStore tks = KeyStore.getInstance("JKS");
+    tks.load(new FileInputStream(keystorePath), keystorePassword);
+
+    TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+    tmf.init(tks);
+
+    String p12Path = clientCertPath();
+    assertNotNull(p12Path);
+    String p12Passwd = clientCertPassword();
+    assertNotNull(p12Passwd);
+    KeyStore ks = KeyStore.getInstance("PKCS12");
+    char [] p12Password = p12Passwd.toCharArray();
+    ks.load(new FileInputStream(p12Path), p12Password);
+
+    KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+    kmf.init(ks, p12Password);
+
+    SSLContext c = sslContextSupplier.get();
+    c.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+    return c;
+  }
+
+  static String keystoreCa() {
+    return System.getProperty("test-keystore.ca", "./target/ca.keystore");
+  }
+
+  static String emptyKeystoreCa() {
+    return System.getProperty("test-keystore.empty", "./target/empty.keystore");
+  }
+
+  static String keystorePassword() {
+    return System.getProperty("test-keystore.password", "bunnies");
+  }
+
+  static String clientCertPath() {
+    return System.getProperty("test-client-cert.path", "/tmp/tls-gen/basic/client/keycert.p12");
+  }
+
+  static String clientCertPassword() {
+    return System.getProperty("test-client-cert.password", "");
+  }
+
+  public static SSLContext getSSLContext() throws NoSuchAlgorithmException {
+    SSLContext c;
+
+    // pick the first protocol available, preferring TLSv1.2, then TLSv1,
+    // falling back to SSLv3 if running on an ancient/crippled JDK
+    for (String proto : Arrays.asList("TLSv1.3", "TLSv1.2", "TLSv1", "SSLv3")) {
+      try {
+        c = SSLContext.getInstance(proto);
+        return c;
+      } catch (NoSuchAlgorithmException x) {
+        // keep trying
+      }
+    }
+    throw new NoSuchAlgorithmException();
+  }
+
+  @FunctionalInterface
+  interface CallableSupplier <T> {
+
+    T get() throws Exception;
+  }
+}

--- a/src/test/java/com/rabbitmq/client/test/ssl/UnverifiedConnection.java
+++ b/src/test/java/com/rabbitmq/client/test/ssl/UnverifiedConnection.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -21,8 +21,6 @@ import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.*;
@@ -37,10 +35,8 @@ public class UnverifiedConnection extends BrokerTestCase {
             throws IOException, TimeoutException {
         try {
             connectionFactory.useSslProtocol();
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IOException(ex.toString());
-        } catch (KeyManagementException ex) {
-            throw new IOException(ex.toString());
+        } catch (Exception ex) {
+            throw new IOException(ex);
         }
 
         int attempt = 0;

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="warn">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
The unwrapping does not work the same way between TLS 1.2 and 1.3.
This commit makes the unwrapping more reliable by getting
the number of bytes consumed in the unwrapping and then set the
position of the reading ByteBuffer accordingly to the number of bytes.
With TLS 1.3, the unwrapping seems to read the whole content of
the buffer and to extract only the first record, so the rewinding
is necessary.

The commit also adds some debug logging, adds tests on TLS 1.2 and 1.3,
and re-arranges the TLS test (add utility class).

Fixes #715