### PR TITLE
topology : fix connection factory property evaluation

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactoryConfigurator.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactoryConfigurator.java
@@ -210,7 +210,7 @@ public class ConnectionFactoryConfigurator {
         }
         String topologyRecovery = lookUp(TOPOLOGY_RECOVERY_ENABLED, properties, prefix);
         if (topologyRecovery != null) {
-            cf.setTopologyRecoveryEnabled(Boolean.getBoolean(topologyRecovery));
+            cf.setTopologyRecoveryEnabled(Boolean.valueOf(topologyRecovery));
         }
         String networkRecoveryInterval = lookUp(CONNECTION_RECOVERY_INTERVAL, properties, prefix);
         if (networkRecoveryInterval != null) {


### PR DESCRIPTION
## Proposed Changes

You can't set topology recovery using the CF configurator unless you do a trick like `-Dtrue=true` in JVM args

This PR is following https://github.com/quarkiverse/quarkus-rabbitmq-client/issues/85 because of the root commit at https://github.com/rabbitmq/rabbitmq-java-client/commit/e9b642f7e34499b67928d00c4b868d5e9228e34f#diff-3ee7482ebddb8471bf938e29cb3b8d0704c94e0cf94fe6a67593149b99f38c69R190

Because `getBoolean("true")` evaluates for a System property called "true". oops

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue [#see quarkus](https://github.com/quarkiverse/quarkus-rabbitmq-client/issues/85))
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

Following readme `./mvnw clean package -P '!setup-test-cluster'` does not run the tests. So I don't know if a test suite will run.

## Further Comments

I followed https://github.com/quarkiverse/quarkus-rabbitmq-client/issues/85#issuecomment-1030608534 to fix the root cause

I check breaking change above and signed Pivotal CLA because if someone made it work via this true=true property trick well it won't work anymore as the real property name is expected.


