### PR TITLE
Revert "Bump maven-bundle-plugin from 5.1.4 to 5.1.5"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <maven.failsafe.plugin.version>2.22.2</maven.failsafe.plugin.version>
     <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
     <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
-    <maven.bundle.plugin.version>5.1.5</maven.bundle.plugin.version>
+    <maven.bundle.plugin.version>5.1.4</maven.bundle.plugin.version>
     <maven.packagecloud.wagon.version>0.0.6</maven.packagecloud.wagon.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     <checksum.maven.plugin.version>1.11</checksum.maven.plugin.version>


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-java-client#767.

`./mvnw package` fails with this PR for a reason I could not quickly determine.