### PR TITLE
Adjust abbreviation of Apache License 2.0 to AL 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <licenses>
     <license>
-      <name>ASL 2.0</name>
+      <name>AL 2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
       <distribution>repo</distribution>
     </license>


### PR DESCRIPTION
The Apache License, 2.0 should be abbreviated as AL 2.0 instead of ASL 2.0. (https://www.apache.org/licenses/LICENSE-2.0)

Only the version 1.1 was known as Apache Software License 1.1, however, AL 2.0 can also be used for non-software. To avoid any confusion (e.g. in downstream licence checks), the abbreviation should be kept consistent.