### PR TITLE
Fix potential deadlock in AutorecoveringConnection

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -809,9 +809,9 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
             if (!oldName.equals(newName)) {
                 // make sure queues are re-added with
                 // their new names, if applicable. MK.
+		propagateQueueNameChangeToBindings(oldName, newName);
+                propagateQueueNameChangeToConsumers(oldName, newName);
                 synchronized (this.recordedQueues) {
-                    this.propagateQueueNameChangeToBindings(oldName, newName);
-                    this.propagateQueueNameChangeToConsumers(oldName, newName);
                     // bug26552:
                     // remove old name after we've updated the bindings and consumers,
                     deleteRecordedQueue(oldName);

--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -809,7 +809,7 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
             if (!oldName.equals(newName)) {
                 // make sure queues are re-added with
                 // their new names, if applicable. MK.
-		propagateQueueNameChangeToBindings(oldName, newName);
+                propagateQueueNameChangeToBindings(oldName, newName);
                 propagateQueueNameChangeToConsumers(oldName, newName);
                 synchronized (this.recordedQueues) {
                     // bug26552:


### PR DESCRIPTION
## Proposed Changes

Fixing a potential deadlock between the internalRecoverQueue and excludeQueueFromRecovery methods.

internalRecoverQueue obtains a locks in the following order:
1. recordedQueues
2. consumers-> via propagateQueueNameChangeToConsumers()

and excludeQueueFromRecovery does:
1. consumers
2. recordedQueues

To resolve, I am proposing removing propagateQueueNameChangeToBindings() and propagateQueueNameChangeToConsumers() outside of the sync block on recordedQueues since neither of those methods touches that Map

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
