### PR TITLE
Re-enable DNS round robin

### DIFF
--- a/src/main/java/com/rabbitmq/client/Address.java
+++ b/src/main/java/com/rabbitmq/client/Address.java
@@ -16,6 +16,7 @@
 
 package com.rabbitmq.client;
 
+import java.net.InetSocketAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,6 +163,13 @@ public class Address {
     }
 
     /**
+     * Construct an InetSocketAddress for this address with a specific port
+     */
+    public InetSocketAddress toInetSocketAddress(int port) {
+        return new InetSocketAddress(getHost(), port);
+    }
+
+    /**
      * Array-based factory method: takes an array of formatted address strings as construction parameter
      * @param addresses array of strings of form "host[:port],..."
      * @return a list of {@link Address} values
@@ -191,5 +199,4 @@ public class Address {
     @Override public String toString() {
         return _port == -1 ? _host : _host + ":" + _port;
     }
-
 }

--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -1339,7 +1339,11 @@ public class ConnectionFactory implements Cloneable {
     }
 
     protected AddressResolver createAddressResolver(List<Address> addresses) {
-        return new ListAddressResolver(addresses);
+        if (addresses.size() > 1) {
+            return new ListAddressResolver(addresses);
+        } else {
+            return new DnsRecordIpAddressResolver(addresses.get(0), isSSL());
+        }
     }
 
     @Override public ConnectionFactory clone(){

--- a/src/main/java/com/rabbitmq/client/DnsRecordIpAddressResolver.java
+++ b/src/main/java/com/rabbitmq/client/DnsRecordIpAddressResolver.java
@@ -72,9 +72,9 @@ public class DnsRecordIpAddressResolver implements AddressResolver {
 
         InetAddress[] inetAddresses = resolveIpAddresses(hostName);
 
-        List<Address> addresses = new ArrayList<Address>();
+        List<Address> addresses = new ArrayList<>();
         for (InetAddress inetAddress : inetAddresses) {
-            addresses.add(new Address(inetAddress.getHostAddress(), portNumber));
+            addresses.add(new ResolvedInetAddress(inetAddress, portNumber));
         }
         return addresses;
     }

--- a/src/main/java/com/rabbitmq/client/ResolvedInetAddress.java
+++ b/src/main/java/com/rabbitmq/client/ResolvedInetAddress.java
@@ -1,0 +1,23 @@
+package com.rabbitmq.client;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+public class ResolvedInetAddress extends Address {
+    private final InetAddress inetAddress;
+
+    public ResolvedInetAddress(InetAddress inetAddress, int port) {
+        super(inetAddress.getHostAddress(), port);
+        this.inetAddress = inetAddress;
+    }
+
+    public ResolvedInetAddress(InetAddress inetAddress) {
+        super(inetAddress.getHostAddress());
+        this.inetAddress = inetAddress;
+    }
+
+    @Override
+    public InetSocketAddress toInetSocketAddress(int port) {
+        return new InetSocketAddress(inetAddress, port);
+    }
+}

--- a/src/main/java/com/rabbitmq/client/impl/SocketFrameHandlerFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/SocketFrameHandlerFactory.java
@@ -17,6 +17,7 @@ package com.rabbitmq.client.impl;
 
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.ResolvedInetAddress;
 import com.rabbitmq.client.SocketConfigurator;
 import com.rabbitmq.client.SslContextFactory;
 
@@ -51,14 +52,13 @@ public class SocketFrameHandlerFactory extends AbstractFrameHandlerFactory {
     }
 
     public FrameHandler create(Address addr, String connectionName) throws IOException {
-        String hostName = addr.getHost();
         int portNumber = ConnectionFactory.portOrDefault(addr.getPort(), ssl);
         Socket socket = null;
         try {
             socket = createSocket(connectionName);
             configurator.configure(socket);
-            socket.connect(new InetSocketAddress(hostName, portNumber),
-                    connectionTimeout);
+
+            socket.connect(addr.toInetSocketAddress(portNumber), connectionTimeout);
             return create(socket);
         } catch (IOException ioe) {
             quietTrySocketClose(socket);

--- a/src/main/java/com/rabbitmq/client/impl/nio/SocketChannelFrameHandlerFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/nio/SocketChannelFrameHandlerFactory.java
@@ -85,7 +85,7 @@ public class SocketChannelFrameHandlerFactory extends AbstractFrameHandlerFactor
                 }
             }
 
-            SocketAddress address = new InetSocketAddress(addr.getHost(), portNumber);
+            SocketAddress address = addr.toInetSocketAddress(portNumber);
             // No Sonar: the channel is closed in case of error and it cannot
             // be closed here because it's part of the state of the connection
             // to be returned.


### PR DESCRIPTION
## Proposed Changes

This change reenables DNS round robin (https://github.com/rabbitmq/rabbitmq-java-client/issues/138) which was disabled because it was deemed incompatible with TLS hostname verification (https://github.com/rabbitmq/rabbitmq-java-client/issues/394).

To make DNS round robin work with hostname verification, this change subclasses `Address` to hold an `InetAddress`. The `InetAddressSocket` is then constructed from the `InetAddress` instead of the raw address.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ x ] I have read the `CONTRIBUTING.md` document
- [ x ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ x ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
