### PR TITLE
Remove dependency on java.sql.Timestamp

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/Frame.java
+++ b/src/main/java/com/rabbitmq/client/impl/Frame.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -22,7 +22,6 @@ import com.rabbitmq.client.MalformedFrameException;
 import java.io.*;
 import java.math.BigDecimal;
 import java.net.SocketTimeoutException;
-import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -268,7 +267,7 @@ public class Frame {
         else if(value instanceof BigDecimal) {
             acc += 5;
         }
-        else if(value instanceof Date || value instanceof Timestamp) {
+        else if(value instanceof Date) {
             acc += 8;
         }
         else if(value instanceof Map) {

--- a/src/test/java/com/rabbitmq/client/test/FrameTest.java
+++ b/src/test/java/com/rabbitmq/client/test/FrameTest.java
@@ -5,15 +5,11 @@ import com.rabbitmq.client.impl.Frame;
 import com.rabbitmq.client.impl.nio.ByteBufferOutputStream;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 
@@ -103,46 +99,6 @@ public class FrameTest {
         @Override
         public void close() throws IOException {
 
-        }
-    }
-
-    private static class AccumulatorReadableByteChannel implements ReadableByteChannel {
-
-        private List<Byte> bytesOfFrames = new LinkedList<Byte>();
-
-        @Override
-        public int read(ByteBuffer dst) throws IOException {
-            int remaining = dst.remaining();
-            int read = 0;
-            if(remaining > 0) {
-                Iterator<Byte> iterator = bytesOfFrames.iterator();
-                while(iterator.hasNext() && read < remaining) {
-                    dst.put(iterator.next());
-                    iterator.remove();
-                    read++;
-                }
-            }
-            return read;
-        }
-
-        @Override
-        public boolean isOpen() {
-            return false;
-        }
-
-        @Override
-        public void close() throws IOException {
-
-        }
-
-        void add(Frame frame) throws IOException {
-            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(frame.size());
-            DataOutputStream outputStream = new DataOutputStream(byteArrayOutputStream);
-            frame.writeTo(outputStream);
-            outputStream.flush();
-            for (byte b : byteArrayOutputStream.toByteArray()) {
-                bytesOfFrames.add(b);
-            }
         }
     }
 

--- a/src/test/java/com/rabbitmq/client/test/TableTest.java
+++ b/src/test/java/com/rabbitmq/client/test/TableTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -17,6 +17,7 @@
 package com.rabbitmq.client.test;
 
 import com.rabbitmq.client.impl.*;
+import java.sql.Timestamp;
 import org.junit.Test;
 
 import java.io.*;
@@ -59,10 +60,14 @@ public class TableTest
         return new Date((System.currentTimeMillis()/1000)*1000);
     }
 
+    private static Timestamp timestamp() {
+        return new Timestamp((System.currentTimeMillis()/1000)*1000);
+    }
+
     @Test public void loop()
         throws IOException
     {
-        Map<String, Object> table = new HashMap<String, Object>();
+        Map<String, Object> table = new HashMap<>();
         table.put("a", 1);
         assertEquals(table, unmarshal(marshal(table)));
 
@@ -77,5 +82,11 @@ public class TableTest
 
         table.put("e", -126);
         assertEquals(table, unmarshal(marshal(table)));
+
+        Timestamp timestamp = timestamp();
+        table.put("f", timestamp);
+        Map<String, Object> tableWithTimestampAsDate = new HashMap<>(table);
+        tableWithTimestampAsDate.put("f", new Date(timestamp.getTime()));
+        assertEquals(tableWithTimestampAsDate, unmarshal(marshal(table)));
     }
 }


### PR DESCRIPTION
Only one condition test refers to java.sql.Timestamp and it's unnecessary anyway because it also refers to java.util.Date (Timestamp inherits from Date). Only the Date API is then used to marshall and unmarshall values.

This avoids a dependency on the java.sql module, which some SDK does not seem to contain (e.g. JavaFX, reported by a user). This should also avoid needing this module in some Docker images (e.g. PerfTest, which pulls this module in its stripped JRE just for this reference apparently).

Mailing list thread: https://groups.google.com/g/rabbitmq-users/c/ORX91PwYhnw/m/xlMR9JTTAQAJ