### PR TITLE
Report publish failures for the closed channel as well

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -710,7 +710,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
                 .build(), props, body);
         try {
             transmit(command);
-        } catch (IOException e) {
+        } catch (IOException | AlreadyClosedException e) {
             metricsCollector.basicPublishFailure(this, e);
             throw e;
         }
@@ -1493,7 +1493,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
 
 
         rpc(m, k);
-        
+
         try {
             if(_rpcTimeout == NO_RPC_TIMEOUT) {
                 k.getReply(); // discard result


### PR DESCRIPTION
## Proposed Changes

Currently if a channel was closed then when a publish fails to that channel it will not be reported to the metrics, avoiding the usual alert rules set up for the `failed publishes` counter.

Recently it has been the case for us where publishes started failing following changes in user/permissions setup in our CloudAMQP instance; while looking at how we could alert ourselves if this ever happens again we noticed that our `failed publishes` metric didn't budge, even though a lot of publishes have in fact failed. (this wasn't the problem because at the time we didn't have an alert set up for this metric anyway but going forward we would love to be able to have it)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
