### PR TITLE
make RpcClient implement java.io.Closeable

### DIFF
--- a/src/main/java/com/rabbitmq/client/RpcClient.java
+++ b/src/main/java/com/rabbitmq/client/RpcClient.java
@@ -18,6 +18,7 @@ package com.rabbitmq.client;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
@@ -44,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * It simply provides a mechanism for sending a message to an exchange with a given routing key,
  * and waiting for a response.
 */
-public class RpcClient {
+public class RpcClient implements Closeable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RpcClient.class);
 
@@ -151,10 +152,13 @@ public class RpcClient {
      * Public API - cancels the consumer, thus deleting the temporary queue, and marks the RpcClient as closed.
      * @throws IOException if an error is encountered
      */
+    @Override
     public void close() throws IOException {
         if (_consumer != null) {
-            _channel.basicCancel(_consumer.getConsumerTag());
+            final String consumerTag = _consumer.getConsumerTag();
+            // set it null before calling basicCancel to make this method idempotent in case of IOException
             _consumer = null;
+            _channel.basicCancel(consumerTag);
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

Resolve Issue #1032  by making `RpcClient` implement `java.io.Closeable`. The `close` method was rewritten to be idempotent in accordance with the Spec of `Closeable`. Now `RpcClient` can be used in a try-with-resources block and IDEs will (hopefully) remind developers if they forget to call the close method.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq) @pivotal-cla This is an Obvious Fix
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories