### PR TITLE
feat(Channel): Remove checked exception from interface Channel.abort(...) as it should silently discard any exceptions

### DIFF
--- a/src/main/java/com/rabbitmq/client/Channel.java
+++ b/src/main/java/com/rabbitmq/client/Channel.java
@@ -89,7 +89,7 @@ public interface Channel extends ShutdownNotifier, AutoCloseable {
      * Forces the channel to close and waits for the close operation to complete.
      * Any encountered exceptions in the close operation are silently discarded.
      */
-    void abort() throws IOException;
+    void abort();
 
     /**
      * Abort this channel.
@@ -97,7 +97,7 @@ public interface Channel extends ShutdownNotifier, AutoCloseable {
      * Forces the channel to close and waits for the close operation to complete.
      * Any encountered exceptions in the close operation are silently discarded.
      */
-    void abort(int closeCode, String closeMessage) throws IOException;
+    void abort(int closeCode, String closeMessage);
 
     /**
      * Add a {@link ReturnListener}.

--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -545,7 +545,6 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     /** Public API - {@inheritDoc} */
     @Override
     public void abort()
-        throws IOException
     {
         abort(AMQP.REPLY_SUCCESS, "OK");
     }
@@ -553,14 +552,11 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
     /** Public API - {@inheritDoc} */
     @Override
     public void abort(int closeCode, String closeMessage)
-        throws IOException
     {
         try {
           close(closeCode, closeMessage, true, null, true);
-        } catch (IOException _e) {
-        /* ignored */
-        } catch (TimeoutException _e) {
-          /* ignored */
+        } catch (IOException | TimeoutException _e) {
+            // abort() shall silently discard any exceptions
         }
     }
 

--- a/src/test/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannelTest.java
+++ b/src/test/java/com/rabbitmq/client/impl/recovery/AutorecoveringChannelTest.java
@@ -1,0 +1,48 @@
+package com.rabbitmq.client.impl.recovery;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public final class AutorecoveringChannelTest {
+
+    private AutorecoveringChannel channel;
+
+    @Mock
+    private AutorecoveringConnection autorecoveringConnection;
+
+    @Mock
+    private RecoveryAwareChannelN recoveryAwareChannelN;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        this.channel = new AutorecoveringChannel(autorecoveringConnection, recoveryAwareChannelN);
+    }
+
+    @Test
+    void abort() {
+        this.channel.abort();
+        verify(recoveryAwareChannelN, times(1)).abort();
+    }
+
+    @Test
+    void abortWithDetails() {
+        int closeCode = 1;
+        String closeMessage = "reason";
+        this.channel.abort(closeCode, closeMessage);
+        verify(recoveryAwareChannelN, times(1)).abort(closeCode, closeMessage);
+    }
+
+    @Test
+    void abortWithDetailsCloseMessageNull() {
+        int closeCode = 1;
+        this.channel.abort(closeCode, null);
+        verify(recoveryAwareChannelN, times(1)).abort(closeCode, "");
+    }
+
+}


### PR DESCRIPTION
## Proposed Changes
As proposed in #434, I eliminated the "throws" clause from the Channel.abort(...) interface in order to align with the desired behaviour, which is also document above the method definitions: 
_Any encountered exceptions in the close operation are silently discarded._

At the current time, consumers calling the abort(...) method will have to manually check for IOException by using a try-catch-block, which is obsolete and just unnecessarily blows up code.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

As already mentioned inside #434: 
_This is a breaking change though (code catching the IOException won't compile anymore), so it must go into 6.0._

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

It seems as there are no existing tests for class `AutorecoveringChannel`. This might be something that could be improved in the future. I just added some initial tests for the abort methods.
