### PR TITLE
Prevent pinned CarrierThreads on JDK-21 while using Virtual Threads

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQChannel.java
@@ -56,8 +56,8 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
      * so that clients can themselves use the channel to synchronize
      * on.
      */
-    protected final ReentrantLock _channelMutex = new ReentrantLock();
-    protected final Condition _channelMutexCondition = _channelMutex.newCondition();
+    protected final ReentrantLock _channelLock = new ReentrantLock();
+    protected final Condition _channelLockCondition = _channelLock.newCondition();
 
     /** The connection this channel is associated with. */
     private final AMQConnection _connection;
@@ -194,7 +194,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
             // so it must be a response to an earlier RPC.
 
             if (_checkRpcResponseType) {
-                _channelMutex.lock();
+                _channelLock.lock();
                 try {
                     // check if this reply command is intended for the current waiting request before calling nextOutstandingRpc()
                     if (_activeRpc != null && !_activeRpc.canHandleReply(command)) {
@@ -204,7 +204,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
                         return;
                     }
                 } finally {
-                    _channelMutex.unlock();
+                    _channelLock.unlock();
                 }
             }
             final RpcWrapper nextOutstandingRpc = nextOutstandingRpc();
@@ -226,12 +226,12 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     }
 
     private void doEnqueueRpc(Supplier<RpcWrapper> rpcWrapperSupplier) {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             boolean waitClearedInterruptStatus = false;
             while (_activeRpc != null) {
                 try {
-                    _channelMutexCondition.await();
+                    _channelLockCondition.await();
                 } catch (InterruptedException e) { //NOSONAR
                     waitClearedInterruptStatus = true;
                     // No Sonar: we re-interrupt the thread later
@@ -242,30 +242,30 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
             }
             _activeRpc = rpcWrapperSupplier.get();
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 
     public boolean isOutstandingRpc()
     {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             return (_activeRpc != null);
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 
     public RpcWrapper nextOutstandingRpc()
     {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             RpcWrapper result = _activeRpc;
             _activeRpc = null;
-            _channelMutexCondition.signalAll();
+            _channelLockCondition.signalAll();
             return result;
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 
@@ -359,48 +359,48 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     public void rpc(Method m, RpcContinuation k)
         throws IOException
     {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             ensureIsOpen();
             quiescingRpc(m, k);
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 
     public void quiescingRpc(Method m, RpcContinuation k)
         throws IOException
     {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             enqueueRpc(k);
             quiescingTransmit(m);
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 
     public void asyncRpc(Method m, CompletableFuture<Command> future)
         throws IOException
     {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             ensureIsOpen();
             quiescingAsyncRpc(m, future);
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 
     public void quiescingAsyncRpc(Method m, CompletableFuture<Command> future)
         throws IOException
     {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             enqueueAsyncRpc(m, future);
             quiescingTransmit(m);
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 
@@ -429,16 +429,16 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
                                       boolean ignoreClosed,
                                       boolean notifyRpc) {
         try {
-            _channelMutex.lock();
+            _channelLock.lock();
             try {
                 if (!setShutdownCauseIfOpen(signal)) {
                     if (!ignoreClosed)
                         throw new AlreadyClosedException(getCloseReason());
                 }
 
-                _channelMutexCondition.signalAll();
+                _channelLockCondition.signalAll();
             } finally {
-                _channelMutex.unlock();
+                _channelLock.unlock();
             }
         } finally {
             if (notifyRpc)
@@ -454,40 +454,40 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
     }
 
     public void transmit(Method m) throws IOException {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             transmit(new AMQCommand(m));
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 
     public void transmit(AMQCommand c) throws IOException {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             ensureIsOpen();
             quiescingTransmit(c);
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 
     public void quiescingTransmit(Method m) throws IOException {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             quiescingTransmit(new AMQCommand(m));
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 
     public void quiescingTransmit(AMQCommand c) throws IOException {
-        _channelMutex.lock();
+        _channelLock.lock();
         try {
             if (c.getMethod().hasContent()) {
                 while (_blockContent) {
                     try {
-                        _channelMutexCondition.await();
+                        _channelLockCondition.await();
                     } catch (InterruptedException ignored) {
                         Thread.currentThread().interrupt();
                     }
@@ -501,7 +501,7 @@ public abstract class AMQChannel extends ShutdownNotifierComponent {
             this._trafficListener.write(c);
             c.transmit(this);
         } finally {
-            _channelMutex.unlock();
+            _channelLock.unlock();
         }
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -361,10 +361,13 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
                 return true;
             } else if (method instanceof Channel.Flow) {
                 Channel.Flow channelFlow = (Channel.Flow) method;
-                synchronized (_channelMutex) {
+                _channelMutex.lock();
+                try {
                     _blockContent = !channelFlow.getActive();
                     transmit(new Channel.FlowOk(!_blockContent));
-                    _channelMutex.notifyAll();
+                    _channelMutexCondition.signalAll();
+                } finally {
+                    _channelMutex.unlock();
                 }
                 return true;
             } else if (method instanceof Basic.Ack) {
@@ -524,7 +527,8 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
                                                                      false,
                                                                      command.getMethod(),
                                                                      this);
-        synchronized (_channelMutex) {
+        _channelMutex.lock();
+        try {
             try {
                 processShutdownSignal(signal, true, false);
                 quiescingTransmit(new Channel.CloseOk());
@@ -532,6 +536,9 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
                 releaseChannel();
                 notifyOutstandingRpc(signal);
             }
+        }
+        finally {
+            _channelMutex.unlock();
         }
         notifyListeners();
     }
@@ -612,9 +619,12 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
         try {
             // Synchronize the block below to avoid race conditions in case
             // connection wants to send Connection-CloseOK
-            synchronized (_channelMutex) {
+            _channelMutex.lock();
+            try {
                 startProcessShutdownSignal(signal, !initiatedByApplication, true);
                 quiescingRpc(reason, k);
+            } finally {
+                _channelMutex.unlock();
             }
 
             // Now that we're in quiescing state, channel.close was sent and
@@ -1602,16 +1612,22 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
 
     @Override
     public void enqueueRpc(RpcContinuation k) {
-        synchronized (_channelMutex) {
+        _channelMutex.lock();
+        try {
             super.enqueueRpc(k);
             dispatcher.setUnlimited(true);
+        } finally {
+            _channelMutex.unlock();
         }
     }
 
     @Override
     protected void markRpcFinished() {
-        synchronized (_channelMutex) {
+        _channelMutex.lock();
+        try {
             dispatcher.setUnlimited(false);
+        } finally {
+            _channelMutex.unlock();
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

This PR replaces some of the `synchronized()` blocks with `ReentrantLock` equivalents to prevent pinned CarrierThreads when using JDK-21 Virtual Threads.

When creating a `Connection` using the `ConnectionFactory` a consumer application can configure the new connection to use a custom `ExecutorService` instance:

```java
// create connection factory
var factory = new ConnectionFactory();

// ...

// create executor service (using a new virtual thread / task)
var executorService = Executors.newVirtualThreadPerTaskExecutor();

// create connection
var connection = factory.newConnection(executorService, "my-connection")
```

RabbitMQ messages received by the application via `Channel.basicConsume(...)` will execute in a new Virtual Thread created by the provided `ExecutorService`.

Sending messages via `Channel.basicPublish()` from one of the Virtual Threads will Pin CarrierThreads preventing the re-use of the Carrier Thread to execute another Virtual Thread. See the following traces logged by using the `-Djdk.tracePinnedThreads=full` command line argument to the `java` command:

```
Thread[#36,ForkJoinPool-1-worker-1,5,CarrierThreads]
    java.base/java.lang.VirtualThread$VThreadContinuation.onPinned(VirtualThread.java:185)
    java.base/jdk.internal.vm.Continuation.onPinned0(Continuation.java:393)
    java.base/java.lang.VirtualThread.park(VirtualThread.java:592)
    java.base/java.lang.System$2.parkVirtualThread(System.java:2639)
    java.base/jdk.internal.misc.VirtualThreads.park(VirtualThreads.java:54)
    java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:219)
    java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:754)
    java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:990)
    java.base/java.util.concurrent.locks.ReentrantLock$Sync.lock(ReentrantLock.java:153)
    java.base/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:322)
    java.base/jdk.internal.misc.InternalLock.lock(InternalLock.java:74)
    java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:157)
    java.base/java.io.DataOutputStream.writeByte(DataOutputStream.java:161)
    com.rabbitmq.client.impl.Frame.writeTo(Frame.java:193)
    com.rabbitmq.client.impl.SocketFrameHandler.writeFrame(SocketFrameHandler.java:195) <== monitors:1
    com.rabbitmq.client.impl.AMQConnection.writeFrame(AMQConnection.java:634)
    com.rabbitmq.client.impl.AMQCommand.transmit(AMQCommand.java:133) <== monitors:1
    com.rabbitmq.client.impl.AMQChannel.quiescingTransmit(AMQChannel.java:458) <== monitors:1
    com.rabbitmq.client.impl.AMQChannel.transmit(AMQChannel.java:431) <== monitors:1
    com.rabbitmq.client.impl.ChannelN.basicPublish(ChannelN.java:713)
    com.rabbitmq.client.impl.recovery.AutorecoveringChannel.basicPublish(AutorecoveringChannel.java:217)
    ...
```

```
Thread[#50,ForkJoinPool-1-worker-2,5,CarrierThreads]
    java.base/java.lang.VirtualThread$VThreadContinuation.onPinned(VirtualThread.java:185)
    java.base/jdk.internal.vm.Continuation.onPinned0(Continuation.java:393)
    java.base/java.lang.VirtualThread.park(VirtualThread.java:592)
    java.base/java.lang.System$2.parkVirtualThread(System.java:2639)
    java.base/jdk.internal.misc.VirtualThreads.park(VirtualThreads.java:54)
    java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:219)
    java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:754)
    java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:990)
    java.base/java.util.concurrent.locks.ReentrantLock$Sync.lock(ReentrantLock.java:153)
    java.base/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:322)
    java.base/jdk.internal.misc.InternalLock.lock(InternalLock.java:74)
    java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:157)
    java.base/java.io.DataOutputStream.writeByte(DataOutputStream.java:161)
    com.rabbitmq.client.impl.Frame.writeTo(Frame.java:193)
    com.rabbitmq.client.impl.SocketFrameHandler.writeFrame(SocketFrameHandler.java:195) <== monitors:1
    com.rabbitmq.client.impl.AMQConnection.writeFrame(AMQConnection.java:634)
    com.rabbitmq.client.impl.AMQCommand.transmit(AMQCommand.java:133) <== monitors:1
    com.rabbitmq.client.impl.AMQChannel.quiescingTransmit(AMQChannel.java:458) <== monitors:1
    com.rabbitmq.client.impl.AMQChannel.transmit(AMQChannel.java:431) <== monitors:1
    com.rabbitmq.client.impl.ChannelN.basicPublish(ChannelN.java:713)
    com.rabbitmq.client.impl.recovery.AutorecoveringChannel.basicPublish(AutorecoveringChannel.java:217)
    ...
```

```
Thread[#36,ForkJoinPool-1-worker-1,5,CarrierThreads]
    java.base/java.lang.VirtualThread$VThreadContinuation.onPinned(VirtualThread.java:185)
    java.base/jdk.internal.vm.Continuation.onPinned0(Continuation.java:393)
    java.base/java.lang.VirtualThread.park(VirtualThread.java:592)
    java.base/java.lang.System$2.parkVirtualThread(System.java:2639)
    java.base/jdk.internal.misc.VirtualThreads.park(VirtualThreads.java:54)
    java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:219)
    java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:754)
    java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:990)
    java.base/java.util.concurrent.locks.ReentrantLock$Sync.lock(ReentrantLock.java:153)
    java.base/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:322)
    com.rabbitmq.client.impl.SocketFrameHandler.writeFrame(SocketFrameHandler.java:206)
    com.rabbitmq.client.impl.AMQConnection.writeFrame(AMQConnection.java:649)
    com.rabbitmq.client.impl.AMQCommand.transmit(AMQCommand.java:133) <== monitors:1
    com.rabbitmq.client.impl.AMQChannel.quiescingTransmit(AMQChannel.java:502)
    com.rabbitmq.client.impl.AMQChannel.transmit(AMQChannel.java:469)
    com.rabbitmq.client.impl.ChannelN.lambda$basicPublish$1(ChannelN.java:729)
    com.rabbitmq.client.observation.NoOpObservationCollector.publish(NoOpObservationCollector.java:32)
    com.rabbitmq.client.impl.ChannelN.basicPublish(ChannelN.java:731)
    com.rabbitmq.client.impl.recovery.AutorecoveringChannel.basicPublish(AutorecoveringChannel.java:217)
    ...
```

```
Thread[#66,ForkJoinPool-1-worker-4,5,CarrierThreads]
    java.base/java.lang.VirtualThread$VThreadContinuation.onPinned(VirtualThread.java:185)
    java.base/jdk.internal.vm.Continuation.onPinned0(Continuation.java:393)
    java.base/java.lang.VirtualThread.park(VirtualThread.java:592)
    java.base/java.lang.System$2.parkVirtualThread(System.java:2639)
    java.base/jdk.internal.misc.VirtualThreads.park(VirtualThreads.java:54)
    java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:219)
    java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:754)
    java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:990)
    java.base/java.util.concurrent.locks.ReentrantLock$Sync.lock(ReentrantLock.java:153)
    java.base/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:322)
    java.base/jdk.internal.misc.InternalLock.lock(InternalLock.java:74)
    java.base/java.io.BufferedOutputStream.write(BufferedOutputStream.java:157)
    java.base/java.io.DataOutputStream.writeByte(DataOutputStream.java:161)
    com.rabbitmq.client.impl.Frame.writeTo(Frame.java:193)
    com.rabbitmq.client.impl.SocketFrameHandler.writeFrame(SocketFrameHandler.java:208)
    com.rabbitmq.client.impl.AMQConnection.writeFrame(AMQConnection.java:649)
    com.rabbitmq.client.impl.AMQCommand.transmit(AMQCommand.java:133) <== monitors:1
    com.rabbitmq.client.impl.AMQChannel.quiescingTransmit(AMQChannel.java:502)
    com.rabbitmq.client.impl.AMQChannel.transmit(AMQChannel.java:469)
    com.rabbitmq.client.impl.ChannelN.lambda$basicPublish$1(ChannelN.java:729)
    com.rabbitmq.client.observation.NoOpObservationCollector.publish(NoOpObservationCollector.java:32)
    com.rabbitmq.client.impl.ChannelN.basicPublish(ChannelN.java:731)
    com.rabbitmq.client.impl.recovery.AutorecoveringChannel.basicPublish(AutorecoveringChannel.java:217)
    ...
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
