### PR TITLE
cleanup ReturnListener in close()

### DIFF
--- a/src/main/java/com/rabbitmq/client/RpcClient.java
+++ b/src/main/java/com/rabbitmq/client/RpcClient.java
@@ -93,6 +93,7 @@ public class RpcClient implements AutoCloseable {
      * @since 5.9.0
      */
     private final Supplier<String> _correlationIdSupplier;
+    private final ReturnListener _returnListener;
 
     private String lastCorrelationId = "0";
 
@@ -123,7 +124,7 @@ public class RpcClient implements AutoCloseable {
 
         _consumer = setupConsumer();
         if (_useMandatory) {
-            this._channel.addReturnListener(returnMessage -> {
+            this._returnListener = this._channel.addReturnListener(returnMessage -> {
                 synchronized (_continuationMap) {
                     String replyId = returnMessage.getProperties().getCorrelationId();
                     BlockingCell<Object> blocker = _continuationMap.remove(replyId);
@@ -136,6 +137,8 @@ public class RpcClient implements AutoCloseable {
                     }
                 }
             });
+        } else {
+            this._returnListener = null;
         }
     }
 
@@ -157,6 +160,7 @@ public class RpcClient implements AutoCloseable {
     public void close() throws IOException {
         if (this.closed.compareAndSet(false, true)) {
             _channel.basicCancel(_consumer.getConsumerTag());
+            _channel.removeReturnListener(this._returnListener);
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

Remove the `ReturnListener` in `RpcClient#close()` that is added in the constructor.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #1168)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

 None.
