### PR TITLE
Fix unwrapping loop in case reading bytebuffer has exactly 1 handshake message

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/nio/SslEngineHelper.java
+++ b/src/main/java/com/rabbitmq/client/impl/nio/SslEngineHelper.java
@@ -110,6 +110,7 @@ public class SslEngineHelper {
         SSLEngineResult unwrapResult;
         do {
             int positionBeforeUnwrapping = cipherIn.position();
+            LOGGER.debug("Before unwrapping cipherIn is {}, with {} remaining byte(s)", cipherIn, cipherIn.remaining());
             unwrapResult = sslEngine.unwrap(cipherIn, plainIn);
             LOGGER.debug("SSL engine result is {} after unwrapping", unwrapResult);
             status = unwrapResult.getStatus();
@@ -118,14 +119,7 @@ public class SslEngineHelper {
                 plainIn.clear();
                 if (unwrapResult.getHandshakeStatus() == NEED_TASK) {
                     handshakeStatus = runDelegatedTasks(sslEngine);
-                    int newPosition = positionBeforeUnwrapping + unwrapResult.bytesConsumed();
-                    if (newPosition == cipherIn.limit()) {
-                        LOGGER.debug("Clearing cipherIn because all bytes have been read and unwrapped");
-                        cipherIn.clear();
-                    } else {
-                        LOGGER.debug("Setting cipherIn position to {} (limit is {})", newPosition, cipherIn.limit());
-                        cipherIn.position(positionBeforeUnwrapping + unwrapResult.bytesConsumed());
-                    }
+                    cipherIn.position(positionBeforeUnwrapping + unwrapResult.bytesConsumed());
                 } else {
                     handshakeStatus = unwrapResult.getHandshakeStatus();
                 }


### PR DESCRIPTION
Fixes #1280

## Proposed Changes

In the scenario where the reading ByteBuffer only has enough bytes to unwrap one handshake message, the flow may enter a loop due to the call to `ByteBuffer.clear()`. That method does not actually erase any data, instead, it sets the position back to 0, the limit to the capacity, and the mark is discarded. Since we are doing another unwrap attempt using the same reading ByteBuffer, the same handshake message will be read.

Updating the reading ByteBuffer position instead of trying to clear it will result in a `BUFFER_UNDERFLOW`, which will then trigger another read from the channel, as expected.

<details>
<summary>Logs</summary>

Debug logs from successful NIO handshake attempt using AWS NLB with TLSv1.2:

```
Starting TLS handshake
Initial handshake status is NEED_WRAP
Handshake status is NEED_WRAP
Wrapping...
Handshake status is NEED_WRAP before wrapping
SSL engine result is Status = OK HandshakeStatus = NEED_UNWRAP
bytesConsumed = 0 bytesProduced = 362 sequenceNumber = 0 after wrapping
Wrote 362 byte(s)
Handshake status is NEED_UNWRAP
Unwrapping...
Handshake status is NEED_UNWRAP before unwrapping
Cipher in position 0
Reading from channel
Read 100 byte(s) from channel
Before unwrapping cipherIn is java.nio.HeapByteBuffer[pos=0 lim=100 cap=16709], with 100 remaining byte(s)
SSL engine result is Status = OK HandshakeStatus = NEED_TASK
bytesConsumed = 100 bytesProduced = 0 after unwrapping
Running delegated task
Before unwrapping cipherIn is java.nio.HeapByteBuffer[pos=100 lim=100 cap=16709], with 0 remaining byte(s)
SSL engine result is Status = BUFFER_UNDERFLOW HandshakeStatus = NEED_UNWRAP
bytesConsumed = 0 bytesProduced = 0 after unwrapping
Buffer underflow
Reading from channel...
Done reading from channel...
Before unwrapping cipherIn is java.nio.HeapByteBuffer[pos=0 lim=5298 cap=16709], with 5298 remaining byte(s)
SSL engine result is Status = OK HandshakeStatus = NEED_TASK
bytesConsumed = 4984 bytesProduced = 0 after unwrapping
Running delegated task
Before unwrapping cipherIn is java.nio.HeapByteBuffer[pos=4984 lim=5298 cap=16709], with 314 remaining byte(s)
SSL engine result is Status = OK HandshakeStatus = NEED_TASK
bytesConsumed = 305 bytesProduced = 0 after unwrapping
Running delegated task
Before unwrapping cipherIn is java.nio.HeapByteBuffer[pos=5289 lim=5298 cap=16709], with 9 remaining byte(s)
SSL engine result is Status = OK HandshakeStatus = NEED_TASK
bytesConsumed = 9 bytesProduced = 0 after unwrapping
Running delegated task
Before unwrapping cipherIn is java.nio.HeapByteBuffer[pos=5298 lim=5298 cap=16709], with 0 remaining byte(s)
SSL engine result is Status = OK HandshakeStatus = NEED_WRAP
bytesConsumed = 0 bytesProduced = 0 after unwrapping
cipherIn position after unwrap 5298
Handshake status is NEED_WRAP
Wrapping...
Handshake status is NEED_WRAP before wrapping
SSL engine result is Status = OK HandshakeStatus = NEED_WRAP
bytesConsumed = 0 bytesProduced = 42 sequenceNumber = 1 after wrapping
Wrote 42 byte(s)
Handshake status is NEED_WRAP
Wrapping...
Handshake status is NEED_WRAP before wrapping
SSL engine result is Status = OK HandshakeStatus = NEED_WRAP
bytesConsumed = 0 bytesProduced = 6 sequenceNumber = 2 after wrapping
Wrote 6 byte(s)
Handshake status is NEED_WRAP
Wrapping...
Handshake status is NEED_WRAP before wrapping
SSL engine result is Status = OK HandshakeStatus = NEED_UNWRAP
bytesConsumed = 0 bytesProduced = 45 sequenceNumber = 0 after wrapping
Wrote 45 byte(s)
Handshake status is NEED_UNWRAP
Unwrapping...
Handshake status is NEED_UNWRAP before unwrapping
Cipher in position 5298
Not reading
Before unwrapping cipherIn is java.nio.HeapByteBuffer[pos=5298 lim=5298 cap=16709], with 0 remaining byte(s)
SSL engine result is Status = BUFFER_UNDERFLOW HandshakeStatus = NEED_UNWRAP
bytesConsumed = 0 bytesProduced = 0 after unwrapping
Buffer underflow
Reading from channel...
Done reading from channel...
Before unwrapping cipherIn is java.nio.HeapByteBuffer[pos=0 lim=51 cap=16709], with 51 remaining byte(s)
SSL engine result is Status = OK HandshakeStatus = NEED_UNWRAP
bytesConsumed = 6 bytesProduced = 0 after unwrapping
Before unwrapping cipherIn is java.nio.HeapByteBuffer[pos=6 lim=51 cap=16709], with 45 remaining byte(s)
SSL engine result is Status = OK HandshakeStatus = FINISHED
bytesConsumed = 45 bytesProduced = 0 after unwrapping
cipherIn position after unwrap 51
TLS handshake completed
```
</details>

## Types of Changes

- [X] Bugfix (non-breaking change which fixes issue #1280)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
