### PR TITLE
Remove the exclusion of the setup-test-cluster profile

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -181,7 +181,7 @@ make deps
 
 [source,shell]
 ----
-./mvnw clean package -Dmaven.test.skip -P '!setup-test-cluster'
+./mvnw clean package -Dmaven.test.skip
 ----
 
 === Launching Tests with the Broker Running in a Docker Container
@@ -197,7 +197,7 @@ Launch "essential" tests (takes about 10 minutes):
 
 [source,shell]
 ----
-./mvnw verify -P '!setup-test-cluster' \
+./mvnw verify \
     -Drabbitmqctl.bin=DOCKER:rabbitmq \
     -Dit.test=ClientTestSuite,FunctionalTestSuite,ServerTestSuite
 ----
@@ -206,7 +206,7 @@ Launch a single test:
 
 [source,shell]
 ----
-./mvnw verify -P '!setup-test-cluster' \
+./mvnw verify \
     -Drabbitmqctl.bin=DOCKER:rabbitmq \
     -Dit.test=DeadLetterExchange
 ----
@@ -218,7 +218,7 @@ system property must point to the `rabbitmqctl` program:
 
 [source,shell]
 ----
-./mvnw verify -P '!setup-test-cluster' \
+./mvnw verify \
        -Dtest-broker.A.nodename=rabbit@$(hostname) \
        -Drabbitmqctl.bin=/path/to/rabbitmqctl \
        -Dit.test=ClientTestSuite,FunctionalTestSuite,ServerTestSuite
@@ -228,7 +228,7 @@ To launch a single test:
 
 [source,shell]
 ----
-./mvnw verify -P '!setup-test-cluster' \
+./mvnw verify \
        -Dtest-broker.A.nodename=rabbit@$(hostname) \
        -Drabbitmqctl.bin=/path/to/rabbitmqctl \
        -Dit.test=DeadLetterExchange

--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -34,7 +34,7 @@ make deps
 To run a subset of the test suite (do not forget to start a local RabbitMQ node):
 
 ```
-./mvnw verify -P '!setup-test-cluster' \
+./mvnw verify \
        -Dtest-broker.A.nodename=rabbit@$(hostname) \
        -Drabbitmqctl.bin=/path/to/rabbitmqctl \
        -Dit.test=ClientTestSuite,FunctionalTestSuite,ServerTestSuite
@@ -47,7 +47,7 @@ The previous command launches tests against the blocking IO connector.
 To run the tests against the NIO connector, add `-P use-nio` to the command line:
 
 ```
-./mvnw verify -P '!setup-test-cluster',use-nio \
+./mvnw verify -P use-nio \
        -Dtest-broker.A.nodename=rabbit@$(hostname) \
        -Drabbitmqctl.bin=/path/to/rabbitmqctl \
        -Dit.test=ClientTestSuite,FunctionalTestSuite,ServerTestSuite
@@ -64,7 +64,7 @@ top-level directory of the source tree:
 * To run the client unit tests:
 
 ```
-./mvnw verify -P '!setup-test-cluster',use-nio \
+./mvnw verify -P use-nio \
        -Dtest-broker.A.nodename=rabbit@$(hostname) \
        -Drabbitmqctl.bin=/path/to/rabbitmqctl \
        -Dit.test=ClientTestSuite
@@ -73,7 +73,7 @@ top-level directory of the source tree:
 * To run the functional tests:
 
 ```
-./mvnw verify -P '!setup-test-cluster',use-nio \
+./mvnw verify -P use-nio \
        -Dtest-broker.A.nodename=rabbit@$(hostname) \
        -Drabbitmqctl.bin=/path/to/rabbitmqctl \
        -Dit.test=FunctionalTestSuite
@@ -82,7 +82,7 @@ top-level directory of the source tree:
 * To run a single test:
 
 ```
-./mvnw verify -P '!setup-test-cluster',use-nio \
+./mvnw verify -P use-nio \
        -Dtest-broker.A.nodename=rabbit@$(hostname) \
        -Drabbitmqctl.bin=/path/to/rabbitmqctl \
        -Dit.test=DeadLetterExchange
@@ -101,7 +101,7 @@ docker run -it --rm --name rabbitmq -p 5672:5672 rabbitmq:3.8
 Launch the tests:
 
 ```
-./mvnw verify -P '!setup-test-cluster' \
+./mvnw verify \
     -Drabbitmqctl.bin=DOCKER:rabbitmq \
     -Dit.test=ClientTestSuite,FunctionalTestSuite,ServerTestSuite
 ```

--- a/generate-observation-documentation.sh
+++ b/generate-observation-documentation.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-./mvnw -q -P '!setup-test-cluster' test-compile exec:java \
+./mvnw -q test-compile exec:java \
   -Dexec.mainClass=io.micrometer.docs.DocsGeneratorCommand \
   -Dexec.classpathScope="test" \
   -Dexec.args='src/main/java/com/rabbitmq/client/observation/micrometer .* target/micrometer-observation-docs'


### PR DESCRIPTION
## Proposed Changes

setup-test-cluster profile is deleted in previous commit.
It is not used anymore, thus I removed that profile from docs.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories