### PR TITLE
Distinguish nack metrics by requeue flag

### DIFF
--- a/src/main/java/com/rabbitmq/client/MetricsCollector.java
+++ b/src/main/java/com/rabbitmq/client/MetricsCollector.java
@@ -58,9 +58,9 @@ public interface MetricsCollector {
 
     void basicAck(Channel channel, long deliveryTag, boolean multiple);
 
-    void basicNack(Channel channel, long deliveryTag);
+    void basicNack(Channel channel, long deliveryTag, boolean requeue);
 
-    void basicReject(Channel channel, long deliveryTag);
+    void basicReject(Channel channel, long deliveryTag, boolean requeue);
 
     void basicConsume(Channel channel, String consumerTag, boolean autoAck);
 

--- a/src/main/java/com/rabbitmq/client/NoOpMetricsCollector.java
+++ b/src/main/java/com/rabbitmq/client/NoOpMetricsCollector.java
@@ -46,12 +46,12 @@ public class NoOpMetricsCollector implements MetricsCollector {
     }
 
     @Override
-    public void basicNack(Channel channel, long deliveryTag) {
+    public void basicNack(Channel channel, long deliveryTag, boolean requeue) {
 
     }
 
     @Override
-    public void basicReject(Channel channel, long deliveryTag) {
+    public void basicReject(Channel channel, long deliveryTag, boolean requeue) {
 
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/ChannelN.java
@@ -1213,7 +1213,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
         throws IOException
     {
         transmit(new Basic.Nack(deliveryTag, multiple, requeue));
-        metricsCollector.basicNack(this, deliveryTag);
+        metricsCollector.basicNack(this, deliveryTag, requeue);
     }
 
     /** Public API - {@inheritDoc} */
@@ -1222,7 +1222,7 @@ public class ChannelN extends AMQChannel implements com.rabbitmq.client.Channel 
         throws IOException
     {
         transmit(new Basic.Reject(deliveryTag, requeue));
-        metricsCollector.basicReject(this, deliveryTag);
+        metricsCollector.basicReject(this, deliveryTag, requeue);
     }
 
     /** Public API - {@inheritDoc} */

--- a/src/main/java/com/rabbitmq/client/impl/MicrometerMetricsCollector.java
+++ b/src/main/java/com/rabbitmq/client/impl/MicrometerMetricsCollector.java
@@ -63,6 +63,8 @@ public class MicrometerMetricsCollector extends AbstractMetricsCollector {
 
     private final Counter rejectedMessages;
 
+    private final Counter requeuedPublishedMessages;
+
     public MicrometerMetricsCollector(MeterRegistry registry) {
         this(registry, "rabbitmq");
     }
@@ -90,6 +92,7 @@ public class MicrometerMetricsCollector extends AbstractMetricsCollector {
         this.ackedPublishedMessages = (Counter) metricsCreator.apply(ACKED_PUBLISHED_MESSAGES);
         this.nackedPublishedMessages = (Counter) metricsCreator.apply(NACKED_PUBLISHED_MESSAGES);
         this.unroutedPublishedMessages = (Counter) metricsCreator.apply(UNROUTED_PUBLISHED_MESSAGES);
+        this.requeuedPublishedMessages = (Counter) metricsCreator.apply(REQUEUED_PUBLISHED_MESSAGES);
     }
 
     @Override
@@ -133,7 +136,10 @@ public class MicrometerMetricsCollector extends AbstractMetricsCollector {
     }
 
     @Override
-    protected void markRejectedMessage() {
+    protected void markRejectedMessage(boolean requeue) {
+        if (requeue) {
+            requeuedPublishedMessages.increment();
+        }
         rejectedMessages.increment();
     }
 
@@ -251,6 +257,12 @@ public class MicrometerMetricsCollector extends AbstractMetricsCollector {
             @Override
             Object create(MeterRegistry registry, String prefix, Iterable<Tag> tags) {
                 return registry.counter(prefix + ".unrouted_published", tags);
+            }
+        },
+        REQUEUED_PUBLISHED_MESSAGES {
+            @Override
+            Object create(MeterRegistry registry, String prefix, Iterable<Tag> tags) {
+                return registry.counter(prefix + ".requeued_published", tags);
             }
         };
 

--- a/src/main/java/com/rabbitmq/client/impl/StandardMetricsCollector.java
+++ b/src/main/java/com/rabbitmq/client/impl/StandardMetricsCollector.java
@@ -45,6 +45,7 @@ public class StandardMetricsCollector extends AbstractMetricsCollector {
     private final Meter publishAcknowledgedMessages;
     private final Meter publishNacknowledgedMessages;
     private final Meter publishUnroutedMessages;
+    private final Meter requeuedPublishedMessages;
 
 
     public StandardMetricsCollector(MetricRegistry registry, String metricsPrefix) {
@@ -59,6 +60,7 @@ public class StandardMetricsCollector extends AbstractMetricsCollector {
         this.consumedMessages = registry.meter(metricsPrefix+".consumed");
         this.acknowledgedMessages = registry.meter(metricsPrefix+".acknowledged");
         this.rejectedMessages = registry.meter(metricsPrefix+".rejected");
+        this.requeuedPublishedMessages = registry.meter(metricsPrefix+".requeued_published");
     }
 
     public StandardMetricsCollector() {
@@ -110,7 +112,7 @@ public class StandardMetricsCollector extends AbstractMetricsCollector {
     }
 
     @Override
-    protected void markRejectedMessage() {
+    protected void markRejectedMessage(boolean requeue) {
         rejectedMessages.mark();
     }
 

--- a/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareChannelN.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/RecoveryAwareChannelN.java
@@ -126,7 +126,7 @@ public class RecoveryAwareChannelN extends ChannelN {
             return;
         }
         transmit(new Basic.Nack(realTag, multiple, requeue));
-        metricsCollector.basicNack(this, deliveryTag);
+        metricsCollector.basicNack(this, deliveryTag, requeue);
     }
 
     @Override
@@ -137,7 +137,7 @@ public class RecoveryAwareChannelN extends ChannelN {
         long realTag = deliveryTag - activeDeliveryTagOffset;
         if (realTag > 0) {
             transmit(new Basic.Reject(realTag, requeue));
-            metricsCollector.basicReject(this, deliveryTag);
+            metricsCollector.basicReject(this, deliveryTag, requeue);
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

- Enhanced the MetricsCollector to distinguish metrics for NACK with requeue option
- Related issue: #1442 

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

