### PR TITLE
AutorecoveringConnection: clean up bindings of deleted exchanges

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/recovery/AutorecoveringConnection.java
@@ -1095,8 +1095,12 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
 
     void deleteRecordedExchange(String exchange) {
         this.recordedExchanges.remove(exchange);
-        Set<RecordedBinding> xs = this.removeBindingsWithDestination(exchange);
-        for (RecordedBinding b : xs) {
+        Set<RecordedBinding> xs1 = this.removeBindingsWithDestination(exchange);
+        for (RecordedBinding b : xs1) {
+            this.maybeDeleteRecordedAutoDeleteExchange(b.getSource());
+        }
+        Set<RecordedBinding> xs2 = this.removeBindingsWithSource(exchange);
+        for (RecordedBinding b : xs2) {
             this.maybeDeleteRecordedAutoDeleteExchange(b.getSource());
         }
     }
@@ -1165,6 +1169,20 @@ public class AutorecoveringConnection implements RecoverableConnection, NetworkC
             for (Iterator<RecordedBinding> it = this.recordedBindings.iterator(); it.hasNext(); ) {
                 RecordedBinding b = it.next();
                 if(b.getDestination().equals(s)) {
+                    it.remove();
+                    result.add(b);
+                }
+            }
+        }
+        return result;
+    }
+
+    Set<RecordedBinding> removeBindingsWithSource(String s) {
+        final Set<RecordedBinding> result = new LinkedHashSet<>();
+        synchronized (this.recordedBindings) {
+            for (Iterator<RecordedBinding> it = this.recordedBindings.iterator(); it.hasNext(); ) {
+                RecordedBinding b = it.next();
+                if (b.getSource().equals(s)) {
                     it.remove();
                     result.add(b);
                 }


### PR DESCRIPTION
so that they (the bindings) do not reappear after
connection recovery.

Noticed while working on ruby-amqp/bunny#704.
