### PR TITLE
fix vHost not set to default when trailing slash in URI

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -389,7 +389,12 @@ public class ConnectionFactory implements Cloneable {
         throw new IllegalArgumentException("Multiple segments in " + "path of AMQP URI: " + path);
       }
 
-      setVirtualHost(uriDecode(uri.getPath().substring(1)));
+      String pathDecoded = uriDecode(uri.getPath().substring(1));
+      if (pathDecoded.isEmpty()) {
+        setVirtualHost(virtualHost);
+      } else {
+        setVirtualHost(pathDecoded);
+      }
     }
 
     String rawQuery = uri.getRawQuery();


### PR DESCRIPTION
## Proposed Changes

This Pull Request addresses a [bug](https://github.com/rabbitmq/rabbitmq-java-client/discussions/1977) when using URI to create a connection to RabbitMq Server and that URI has a trailing slash indicating virtual host `/`, `setUri()` from `ConnectionFactory` fails to parse that and sets virtual host to empty string.
So this Pull request adds the check when the URI has a trailing slash only it sets the virtual host to the default value else it sets the provided value. (example URI `amqp://guest:guest@localhost:5672/`)

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #1977)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories