### PR TITLE
Initialize frame handler's connection reference before sending header

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -321,6 +321,10 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
         // initiator) is to wait for a connection.start method to
         // arrive.
         _channel0.enqueueRpc(connStartBlocker);
+        // Must happen before the header is sent: sending it can make the broker reply
+        // immediately, and the I/O thread that reads that reply needs the connection
+        // reference to already be in place, or it hits a null reference.
+        this._frameHandler.initialize(this);
         try {
             // The following two lines are akin to AMQChannel's
             // transmit() method for this pseudo-RPC.
@@ -330,8 +334,6 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
             _frameHandler.close();
             throw ioe;
         }
-
-        this._frameHandler.initialize(this);
 
         AMQP.Connection.Start connStart;
         AMQP.Connection.Tune connTune = null;


### PR DESCRIPTION
_frameHandler.sendHeader() can trigger an immediate reply from the broker, which the I/O thread processes as soon as it arrives. If that happens before _frameHandler.initialize(this) has run, the I/O thread dereferences a still-null AMQConnection reference (e.g. in AmqpHandler.channelRead for the Netty transport) and the connection fails with a NullPointerException wrapped as an IOException. This mostly surfaces under CI-style thread scheduling on fast/local round-trips, where the reply can outrace initialize().