### PR TITLE
Defer main loop start until after the header is sent

### DIFF
--- a/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
+++ b/src/main/java/com/rabbitmq/client/impl/AMQConnection.java
@@ -334,6 +334,12 @@ public class AMQConnection extends ShutdownNotifierComponent implements Connecti
             _frameHandler.close();
             throw ioe;
         }
+        // Only start reading frames once the header has actually gone out: for
+        // frame handlers with their own dedicated I/O thread (e.g. blocking IO),
+        // starting it any earlier would race with sendHeader() over who drives
+        // the TLS handshake, and the loser gets a confusing generic SocketException
+        // instead of the real SSLHandshakeException.
+        this._frameHandler.startProcessing();
 
         AMQP.Connection.Start connStart;
         AMQP.Connection.Tune connTune = null;

--- a/src/main/java/com/rabbitmq/client/impl/FrameHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/FrameHandler.java
@@ -55,14 +55,22 @@ public interface FrameHandler extends NetworkConnection {
 
     void initialize(AMQConnection connection);
 
-    default void finishConnectionNegotiation() {
+    /**
+     * Start processing incoming frames, once the connection header has been sent.
+     * Frame handlers that already read asynchronously (e.g. Netty, NIO) can ignore this,
+     * as reading may already be under way by the time {@link #initialize(AMQConnection)} runs.
+     * Frame handlers with their own dedicated reader thread should wait for this call before
+     * starting it, so that thread does not race {@link #sendHeader()} over the TLS handshake.
+     */
+    void startProcessing();
 
-    }
+    /**
+     * Callback to signal the end of the negotiation phase.
+     */
+    void finishConnectionNegotiation();
 
     /** Cap inbound frame payloads, applied once frame_max is negotiated. */
-    default void setFrameMax(int frameMax) {
-
-    }
+    void setFrameMax(int frameMax);
 
     /**
      * Read a {@link Frame} from the underlying data connection.

--- a/src/main/java/com/rabbitmq/client/impl/NettyFrameHandlerFactory.java
+++ b/src/main/java/com/rabbitmq/client/impl/NettyFrameHandlerFactory.java
@@ -333,6 +333,11 @@ public final class NettyFrameHandlerFactory extends AbstractFrameHandlerFactory 
     }
 
     @Override
+    public void startProcessing() {
+      // no op
+    }
+
+    @Override
     public void finishConnectionNegotiation() {
       maybeRemoveHandler(HANDLER_PROTOCOL_VERSION_MISMATCH);
     }

--- a/src/main/java/com/rabbitmq/client/impl/SocketFrameHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/SocketFrameHandler.java
@@ -61,6 +61,8 @@ public class SocketFrameHandler implements FrameHandler {
     private volatile int framePayloadLimit;
     private final IntSupplier payloadLimitSupplier;
 
+    private volatile AMQConnection connection;
+
     /** Time to linger before closing the socket forcefully. */
     public static final int SOCKET_CLOSING_TIMEOUT = 1;
 
@@ -193,7 +195,17 @@ public class SocketFrameHandler implements FrameHandler {
 
     @Override
     public void initialize(AMQConnection connection) {
-        connection.startMainLoop();
+        this.connection = connection;
+    }
+
+    @Override
+    public void startProcessing() {
+        this.connection.startMainLoop();
+    }
+
+    @Override
+    public void finishConnectionNegotiation() {
+      // no op
     }
 
     @Override

--- a/src/main/java/com/rabbitmq/client/impl/nio/SocketChannelFrameHandler.java
+++ b/src/main/java/com/rabbitmq/client/impl/nio/SocketChannelFrameHandler.java
@@ -84,6 +84,16 @@ public class SocketChannelFrameHandler implements FrameHandler {
     }
 
     @Override
+    public void startProcessing() {
+        // no op
+    }
+
+    @Override
+    public void finishConnectionNegotiation() {
+        // no op
+    }
+
+    @Override
     public void setFrameMax(int frameMax) {
         this.state.setFrameMax(frameMax);
     }

--- a/src/test/java/com/rabbitmq/client/test/AMQConnectionTest.java
+++ b/src/test/java/com/rabbitmq/client/test/AMQConnectionTest.java
@@ -231,13 +231,28 @@ public class AMQConnectionTest {
             return null; // simulate a socket timeout
         }
 
-        public void sendHeader() throws IOException {
+        public void sendHeader() {
             _numHeadersSent++;
         }
 
         @Override
         public void initialize(AMQConnection connection) {
             connection.startMainLoop();
+        }
+
+        @Override
+        public void startProcessing() {
+
+        }
+
+        @Override
+        public void finishConnectionNegotiation() {
+
+        }
+
+        @Override
+        public void setFrameMax(int frameMax) {
+
         }
 
         public void setTimeout(int timeoutMs) throws SocketException {

--- a/src/test/java/com/rabbitmq/client/test/BrokenFramesTest.java
+++ b/src/test/java/com/rabbitmq/client/test/BrokenFramesTest.java
@@ -226,6 +226,21 @@ public class BrokenFramesTest {
             connection.startMainLoop();
         }
 
+        @Override
+        public void startProcessing() {
+
+        }
+
+        @Override
+        public void finishConnectionNegotiation() {
+
+        }
+
+        @Override
+        public void setFrameMax(int frameMax) {
+
+        }
+
         public void setTimeout(int timeoutMs) {
             // no need to implement this: don't bother changing the timeout
         }


### PR DESCRIPTION
A previous commit moved _frameHandler.initialize(this) before sendHeader() in AMQConnection.start() to fix a race where the I/O thread could dereference a still-null connection reference on a fast broker reply. For SocketFrameHandler, though, initialize() also starts the MainLoop thread, which begins blocking-reading the socket right away.

That reader thread now runs concurrently with the header write. For TLS sockets the handshake is lazy and triggered by whichever operation touches the socket first, read or write. When the peer certificate is rejected, the thread that loses the race can see a generic SocketException ("Connection or outbound has closed") instead of the real SSLHandshakeException, since the other thread already tore down the connection. This showed up as a flaky SslContextFactoryTest failure on CI.

Split the two concerns: FrameHandler.initialize() still runs before sendHeader(), so the connection reference is set in time for an early reply, but a new FrameHandler.startProcessing() hook - called only after sendHeader() succeeds - is now responsible for actually starting a dedicated reader thread. SocketFrameHandler moves its connection.startMainLoop() call there. Netty and NIO ignore the new hook, since they already read asynchronously and aren't affected by this race.

References #2018