### PR TITLE
ConnectionFactory#setUri(String) throws IllegalArgumentException

### DIFF
--- a/src/main/java/com/rabbitmq/client/ConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactory.java
@@ -412,9 +412,15 @@ public class ConnectionFactory implements Cloneable {
    *
    * @param uriString is the AMQP URI containing the data
    */
-  public ConnectionFactory setUri(String uriString)
-      throws URISyntaxException, NoSuchAlgorithmException, KeyManagementException {
-    setUri(new URI(uriString));
+  public ConnectionFactory setUri(String uriString) throws NoSuchAlgorithmException, KeyManagementException {
+    URI uri;
+    try {
+      uri = new URI(uriString);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(
+          "Invalid AMQP URI syntax (" + e.getReason() + " at index " + e.getIndex() + ")");
+    }
+    setUri(uri);
     return this;
   }
 

--- a/src/main/java/com/rabbitmq/client/ConnectionFactoryConfigurator.java
+++ b/src/main/java/com/rabbitmq/client/ConnectionFactoryConfigurator.java
@@ -157,12 +157,6 @@ public class ConnectionFactoryConfigurator {
         if (uri != null) {
             try {
                 cf.setUri(uri);
-            } catch (URISyntaxException e) {
-                // the URI is invalid, so it cannot be reliably stripped of credentials;
-                // do not include it or chain the cause, as its message contains the raw input
-                throw new IllegalArgumentException(
-                        "Error while setting AMQP URI: invalid syntax ("
-                                + e.getReason() + " at index " + e.getIndex() + ")");
             } catch (NoSuchAlgorithmException | KeyManagementException e) {
                 throw new IllegalArgumentException("Error while setting AMQP URI: " + redactCredentials(uri), e);
             }


### PR DESCRIPTION
Instead of URISyntaxException. This is a breaking change, but URISyntaxException contains the input URI and a caller may end up logging it. We want to avoid this as URI can contain sensitive information.